### PR TITLE
Changing "master" branch definitions in gh actions

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     branches:
-      - 'master' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'main' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Upload Code Coverage
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: GitHub pages
 on:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   github-pages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
         run: |
           ghr -replace -delete -n ${GITHUB_REF:10} -c $GITHUB_SHA ${GITHUB_REF:10} dist.zip
       - name: Update latest release
-        if: startsWith(github.ref, 'refs/heads/master')
+        if: startsWith(github.ref, 'refs/heads/main')
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
-          ghr -prerelease -replace -delete -n Latest -c master latest dist.zip
+          ghr -prerelease -replace -delete -n Latest -c main latest dist.zip


### PR DESCRIPTION
Because dpl-react is using "main" and it's standard to do so.