### PR TITLE
Add GH token to setup-node tasks

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.22.0'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.22.0'
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Get yarn cache
       id: yarn-cache

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,9 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '12.22.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@reload'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -26,7 +30,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install Dependencies
         run: yarn install
-
       - name: stylelint
         uses: reviewdog/action-stylelint@v1
         with:
@@ -57,9 +60,14 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '12.22.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@reload'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -89,9 +97,13 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '12.22.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@reload'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -138,9 +150,13 @@ jobs:
           # Required to fetch all commits and tags
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '12.22.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@reload'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Dependencies
         run: yarn install
       - name: Build artifacts
@@ -161,9 +177,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '12.22.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@reload'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Dependencies
         run: yarn install
       - name: Build documentation
@@ -177,6 +197,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '12.22.0'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@reload'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Dependencies
         run: yarn install
       - name: Install problem matcher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12.22.0'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+"@reload:registry" "https://npm.pkg.github.com"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
     "webpack-cli": "^3.3.10",
     "webpack-version-file-plugin": "^0.4.0"
   },
+  "//dependencies": {
+    "@reload/dpl-design-system": "Is being used for being able to see the dpl-design-system styling in Storybook and potentially use icons"
+  },
   "dependencies": {
     "@reach/alert": "^0.6.1",
     "@reach/dialog": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@reach/alert": "^0.6.1",
     "@reach/dialog": "^0.5.4",
     "@reduxjs/toolkit": "^1.4.0",
+    "@reload/dpl-design-system": "0.0.0-4da50aa9f3541c6c831ab7219f0111f3c767f190",
     "@storybook/addon-docs": "^6.4.19",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,6 +3386,11 @@
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
 
+"@reload/dpl-design-system@0.0.0-4da50aa9f3541c6c831ab7219f0111f3c767f190":
+  version "0.0.0-4da50aa9f3541c6c831ab7219f0111f3c767f190"
+  resolved "https://npm.pkg.github.com/download/@reload/dpl-design-system/0.0.0-4da50aa9f3541c6c831ab7219f0111f3c767f190/e7b981fcc9963712e7397e217089d27118eed7557510b11269a60ab7cc066909#a9d0db7bce9b4e23efe5014b137d552dc5c067d6"
+  integrity sha512-Oe9izFeGSjDfPgQrJPROoQbmT/1SDiEW042PrTY67lUHFiju0nLJ7NkdFCZbjQLMtyHH2updBWXr5Lsv8KBoIg==
+
 "@storybook/addon-controls@^6.4.19":
   version "6.4.19"
   resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.4.19.tgz#1ebf74f7b0843ea0eccd319f5295dfa48947a975"


### PR DESCRIPTION
#### What does this PR do?
Github has a policy that only allows read access to their npm registry by using a token.
Either PAT or GITHUB_TOKEN.
This PR uses `secrets.GITHUB_TOKEN` in order to get access.

#### Should this be tested by the reviewer and how?
Look at the commits.
And verify that GH actions pass.

#### What are the relevant tickets?
https://reload.atlassian.net/browse/DDFSOEG-113