### PR TITLE
Fix availability label stories and eslint settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Danish public libraries.
   - [Create a new application](#create-a-new-application)
     - [Application state-machine](#application-state-machine)
   - [Style your application](#style-your-application)
+  - [Style using the dpl design system library](#style-using-the-dpl-design-system-library)
   - [Cross application components](#cross-application-components)
     - [Creating an atom](#creating-an-atom)
     - [Creating a component](#creating-a-component)
@@ -339,6 +340,31 @@ export function WithoutData() {
 </details>
 
 __Cowabunga!__ You now got styling in your application
+
+### Style using the dpl design system library
+
+If you need to use styling created by this project's sister repository -
+[the design system](https://github.com/danskernesdigitalebibliotek/dpl-design-system)
+-you can run:
+
+```bash
+yarn add @danskernesdigitalebibliotek/dpl-design-system@latest
+```
+
+This command installs the latest released version of the package. Whenever a
+new version of the design system package is released, it is necessary
+to reinstall the package in this project using the same command to get the
+newest styling, because yarn adds a specific version number to the package name
+in package.json.
+
+If you need published but unreleased code from a specific branch, you can also
+use thebranch name, replacing all special characters with dashes (-). For
+example if you want the latest styling from a branch called
+"feature/availability-label", you would run:
+
+```bash
+yarn add @danskernesdigitalebibliotek/dpl-design-system@feature-availability-label
+```
 
 ### Cross application components
 

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "^0.0.0-3bd678a68e0854369f27016877773f6878a1cb61",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-372e102a9ded64f39067eb2a13f7485342418a23",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/availability-label/availability-label.dev.tsx
+++ b/src/components/availability-label/availability-label.dev.tsx
@@ -13,27 +13,27 @@ export default {
   component: AvailabilityLabel,
   argTypes: {
     manifestText: {
-      name: "Manifestation text"
+      name: "Manifestation text",
+      defaultValue: "Bog",
+      control: { type: "text" }
     },
-    defaultValue: "Bog",
-    control: { type: "text" }
-  },
-  availabilityText: {
-    name: "Availability text",
-    defaultValue: "Hjemme",
-    control: { type: "text" }
-  },
-  state: {
-    name: "State",
-    description:
-      "To change availaility, select from Storybook Availability Label components",
-    defaultValue: "available",
-    control: { type: null }
-  },
-  link: {
-    name: "Link",
-    defaultValue: "https://www.google.com",
-    control: { type: "text" }
+    availabilityText: {
+      name: "Availability text",
+      defaultValue: "Hjemme",
+      control: { type: "text" }
+    },
+    state: {
+      name: "State",
+      description:
+        "To change availaility, select from Storybook Availability Label components",
+      defaultValue: "available",
+      control: { type: null }
+    },
+    link: {
+      name: "Link",
+      defaultValue: "https://www.google.com",
+      control: { type: "text" }
+    }
   }
 } as ComponentMeta<typeof AvailabilityLabel>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,10 +1683,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@^0.0.0-3bd678a68e0854369f27016877773f6878a1cb61":
-  version "0.0.0-3bd678a68e0854369f27016877773f6878a1cb61"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-3bd678a68e0854369f27016877773f6878a1cb61/0f8d03d9c4a1df314f04932f4c8fdf80285539c790953163908aa5d1f3c22fe7#23fd86f6544c189e2bed1978a16d5231135d9cc1"
-  integrity sha512-A0MGgBf156/q+rFBrlrIKLX35McDDVpiqmcBRVfM4LXPZNSnondPaG1AQQVuIeHZDq5C8pVklMBj9eIDLH2ATA==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-372e102a9ded64f39067eb2a13f7485342418a23":
+  version "0.0.0-372e102a9ded64f39067eb2a13f7485342418a23"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-372e102a9ded64f39067eb2a13f7485342418a23/cdbbf0a88246da6856422d96a5d91cf590df55af3e1fde816940aeb3a6ab5be5#a0058cf8abf4ee1986eda02da6a7fbf40a3a9bee"
+  integrity sha512-Fqbtu4IoF9bX3ZyA31LY34d3Bk/GVL7R4GvzLjlevZx7LPjnTUrUDO3TJlanvoiFhoBjOR7+r8oqdMhjgNZ+zg==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
There was an error in indentation of argument types for the Availability label story, which prevented the default values to be read.