### PR TITLE
Add functionality for handling app string props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -109,6 +109,16 @@
         // We need a simple way of passing args in stories via object spreading.
         "react/jsx-props-no-spreading": "off"
       }
+    },
+    {
+      "files": [
+        "*.entry.tsx"
+      ],
+      "rules": {
+        // Since we use High Order Functional Component in entries for text props
+        // and want to show the props being used we disable this rule.
+        "@typescript-eslint/no-unused-vars": "off"
+      }
     }
   ]
 }

--- a/architecture/adr-002-ui-text-handling.md
+++ b/architecture/adr-002-ui-text-handling.md
@@ -1,0 +1,38 @@
+# Architecture Decision Record: UI Text Handling
+
+## Context
+
+It has been decided that app context/settings should be passed from the
+server side rendered mount points via data props.
+One type of settings is text strings that is defined by
+the system/host rendering the mount points.
+Since we are going to have quite some levels of nested components
+it would be nice to have a way to extract the string
+without having to define them all the way down the tree.
+
+## Decision
+
+A solution has been made that extracts the props holding the strings
+and puts them in the Redux store under the index: `text` at the app entry level.
+That is done with the help of the `withText()` High Order Component.
+The solution of having the strings in redux
+enables us to fetch the strings at any point in the tree.
+A hook called: `useText()` makes it simple to request a certain string
+inside a given component.
+
+## Alternatives considered
+
+One major alternative would be not doing it and pass down the props.
+But that leaves us with text props all the way down the tree
+which we would like to avoid.
+Some translation libraries has been investigated
+but that would in most cases give us a lot of tools and complexity
+that is not needed in order to solve the relatively simple task.
+
+## Consequences
+
+Since we omit the text props down the tree
+it leaves us with fewer props and a cleaner component setup.
+Although some "magic" has been introduced
+with text prop matching and storage in redux,
+it is outweighed by the simplicity of the HOC wrapper and useText hook.

--- a/docs/ui_text_handling.md
+++ b/docs/ui_text_handling.md
@@ -1,0 +1,63 @@
+# UI Text Handling
+
+This document describes how to use the text functionality
+that is partly defined in src/core/utils/text.tsx and in src/core/text.slice.ts.
+
+## Main Purpose
+
+The main purpose of the functionality is to be able to access strings defined
+at app level inside of sub components
+without passing them all the way down via props.
+You can read more about the decision
+and considerations [here](../architecture/adr-002-ui-text-handling.md).
+
+## How to use it
+
+In order to use the system the component that has the text props
+needs to be wrapped with the `withText` high order function.
+The texts can hereafter be accessed by using the `useText` hook.
+
+### Example of using withText
+
+In this example we have a HelloWorld app with three text props attached:
+
+```tsx
+import React from "react";
+import { withText } from "../../core/utils/text";
+import HelloWorld from "./hello-world";
+
+export interface HelloWorldEntryProps {
+  titleText: string;
+  introductionText: string;
+  whatText: string;
+}
+
+const HelloWorldEntry: React.FC<HelloWorldEntryProps> = (
+  props: HelloWorldEntryProps
+) => <HelloWorld />;
+
+export default withText(HelloWorldEntry);
+```
+
+Now it is possible to access the strings like this:
+
+```tsx
+import * as React from "react";
+import { Hello } from "../../components/hello/hello";
+import { useText } from "../../core/utils/text";
+
+const HelloWorld: React.FC = () => {
+  const t = useText();
+  return (
+    <article>
+      <h2>{t("titleText")}</h2>
+      <p>{t("introductionText")}</p>
+      <p>
+        <Hello shouldBeEmphasized />
+      </p>
+    </article>
+  );
+};
+export default HelloWorld;
+
+```

--- a/src/apps/hello-world/hello-world.dev.tsx
+++ b/src/apps/hello-world/hello-world.dev.tsx
@@ -13,6 +13,10 @@ export default {
     introductionText: {
       defaultValue: "We warmly welcome everybody by saying:",
       control: { type: "text" }
+    },
+    whatText: {
+      defaultValue: "world",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof HelloWorld>;

--- a/src/apps/hello-world/hello-world.entry.tsx
+++ b/src/apps/hello-world/hello-world.entry.tsx
@@ -1,4 +1,5 @@
-import * as React from "react";
+import React from "react";
+import { withText } from "../../core/utils/text";
 import HelloWorld from "./hello-world";
 
 export interface HelloWorldEntryProps {
@@ -6,9 +7,8 @@ export interface HelloWorldEntryProps {
   introductionText: string;
 }
 
-const HelloWorldEntry: React.FC<HelloWorldEntryProps> = ({
-  titleText,
-  introductionText
-}) => <HelloWorld title={titleText} introduction={introductionText} />;
+const HelloWorldEntry: React.FC<HelloWorldEntryProps> = (
+  props: HelloWorldEntryProps
+) => <HelloWorld />;
 
-export default HelloWorldEntry;
+export default withText(HelloWorldEntry);

--- a/src/apps/hello-world/hello-world.entry.tsx
+++ b/src/apps/hello-world/hello-world.entry.tsx
@@ -5,6 +5,7 @@ import HelloWorld from "./hello-world";
 export interface HelloWorldEntryProps {
   titleText: string;
   introductionText: string;
+  whatText: string;
 }
 
 const HelloWorldEntry: React.FC<HelloWorldEntryProps> = (

--- a/src/apps/hello-world/hello-world.tsx
+++ b/src/apps/hello-world/hello-world.tsx
@@ -1,19 +1,17 @@
 import * as React from "react";
 import { Hello } from "../../components/hello/hello";
+import { useText } from "../../core/utils/text";
 
-interface HelloWorldProps {
-  title: string;
-  introduction: string;
-}
-
-const HelloWorld: React.FC<HelloWorldProps> = ({ title, introduction }) => (
-  <article>
-    <h2>{title}</h2>
-    <p>{introduction}</p>
-    <p>
-      <Hello what="world" shouldBeEmphasized />
-    </p>
-  </article>
-);
-
+const HelloWorld: React.FC = () => {
+  const t = useText();
+  return (
+    <article>
+      <h2>{t("titleText")}</h2>
+      <p>{t("introductionText")}</p>
+      <p>
+        <Hello what="world" shouldBeEmphasized />
+      </p>
+    </article>
+  );
+};
 export default HelloWorld;

--- a/src/apps/hello-world/hello-world.tsx
+++ b/src/apps/hello-world/hello-world.tsx
@@ -9,7 +9,7 @@ const HelloWorld: React.FC = () => {
       <h2>{t("titleText")}</h2>
       <p>{t("introductionText")}</p>
       <p>
-        <Hello what="world" shouldBeEmphasized />
+        <Hello shouldBeEmphasized />
       </p>
     </article>
   );

--- a/src/components/hello/hello.dev.tsx
+++ b/src/components/hello/hello.dev.tsx
@@ -1,32 +1,43 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Hello, HelloProps } from "./hello";
+import { Hello, HelloProps, TextProps } from "./hello";
+import { withText } from "../../core/utils/text";
+
+type Args = {
+  args: HelloProps | TextProps;
+};
+
+// Add withText HOC because the Hello component uses texts.
+const WrappedHello = withText(Hello);
 
 export default {
   title: "Components/Hello",
-  component: Hello,
+  component: WrappedHello,
   argTypes: {
-    what: {
-      defaultValue: "world"
+    whatText: {
+      defaultValue: "world",
+      control: { type: "text" }
     },
     shouldBeEmphasized: {
       defaultValue: true
     }
   }
-} as ComponentMeta<typeof Hello>;
+} as ComponentMeta<typeof WrappedHello>;
 
-const Template: ComponentStory<typeof Hello> = (args: HelloProps) => (
-  <Hello {...args} />
+const Template: ComponentStory<typeof WrappedHello> = (props: HelloProps) => (
+  <WrappedHello {...props} />
 );
 
 export const HelloWorld = Template.bind({});
 
+// Create a sub story showing what happens if the whatText prop is set to "human".
 export const HelloHuman = Template.bind({});
-HelloHuman.args = {
-  what: "human"
+(HelloWorld as Args).args = {
+  whatText: "human"
 };
 
+// Create a sub story showing what happens if the whatText prop is set to "animal".
 export const HelloAnimal = Template.bind({});
-HelloAnimal.args = {
-  what: "animal"
+(HelloWorld as Args).args = {
+  whatText: "animal"
 };

--- a/src/components/hello/hello.tsx
+++ b/src/components/hello/hello.tsx
@@ -1,14 +1,20 @@
 import * as React from "react";
+import { useText } from "../../core/utils/text";
 
+export type TextProps = { whatText: string };
 export interface HelloProps {
-  // This is an example of a list of known strings.
-  // By specifying the possibilities the code becomes more strict.
-  what: "world" | "human" | "animal";
   shouldBeEmphasized: boolean;
 }
 
-export const Hello: React.FC<HelloProps> = ({ shouldBeEmphasized, what }) => (
-  <>Hello {shouldBeEmphasized ? <strong>{what}</strong> : what}!</>
-);
+export const Hello: React.FC<HelloProps> = ({ shouldBeEmphasized }) => {
+  const t = useText();
+
+  return (
+    <>
+      Hello{" "}
+      {shouldBeEmphasized ? <strong>{t("whatText")}</strong> : t("whatText")}!
+    </>
+  );
+};
 
 export default Hello;

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,21 +1,33 @@
 import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import {
+  TypedUseSelectorHook,
+  useSelector as rawUseSelector
+} from "react-redux";
 import { persistReducer, persistStore } from "redux-persist";
 import storage from "redux-persist/lib/storage/session";
+import textReducer from "./text.slice";
 import userReducer from "./user.slice";
 
+// TODO: We have planned to get rid of redux-persist.
+// When the step has been made to remove it all the persist setup should go as well.
 const persistConfig = {
   key: "dpl-react",
-  storage
+  storage,
+  blacklist: ["text"]
 };
 
 export const store = configureStore({
   reducer: persistReducer(
     persistConfig,
     combineReducers({
-      user: userReducer
+      user: userReducer,
+      text: textReducer
     })
   ),
   devTools: process.env.NODE_ENV === "development"
 });
 
 export const persistor = persistStore(store);
+
+export type RootState = ReturnType<typeof store.getState>;
+export const useSelector: TypedUseSelectorHook<RootState> = rawUseSelector;

--- a/src/core/text.slice.ts
+++ b/src/core/text.slice.ts
@@ -10,12 +10,12 @@ export const textSlice = createSlice({
   name: "text",
   initialState,
   reducers: {
-    setTextEntry(state, action) {
-      state.data[action.payload.key] = action.payload.value;
+    setTextEntries(state, action) {
+      state.data = { ...state.data, ...action.payload.entries };
     }
   }
 });
 
-export const { setTextEntry } = textSlice.actions;
+export const { setTextEntries } = textSlice.actions;
 
 export default textSlice.reducer;

--- a/src/core/text.slice.ts
+++ b/src/core/text.slice.ts
@@ -1,0 +1,21 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState: {
+  data: { [key: string]: string } | Record<string, never>;
+} = {
+  data: {}
+};
+
+export const textSlice = createSlice({
+  name: "text",
+  initialState,
+  reducers: {
+    setTextEntry(state, action) {
+      state.data[action.payload.key] = action.payload.value;
+    }
+  }
+});
+
+export const { setTextEntry } = textSlice.actions;
+
+export default textSlice.reducer;

--- a/src/core/text.slice.ts
+++ b/src/core/text.slice.ts
@@ -10,12 +10,12 @@ export const textSlice = createSlice({
   name: "text",
   initialState,
   reducers: {
-    setTextEntries(state, action) {
+    addTextEntries(state, action) {
       state.data = { ...state.data, ...action.payload.entries };
     }
   }
 });
 
-export const { setTextEntries } = textSlice.actions;
+export const { addTextEntries } = textSlice.actions;
 
 export default textSlice.reducer;

--- a/src/core/utils/text.tsx
+++ b/src/core/utils/text.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { RootState, store, useSelector } from "../store";
-import { setTextEntries, setTextEntry } from "../text.slice";
+import { addTextEntries } from "../text.slice";
 
 export const useText = (): ((key: string) => string) => {
   const { data } = useSelector((state: RootState) => state.text);
@@ -33,7 +33,7 @@ export const withText = <T,>(Component: React.ComponentType<T>) => {
       }
       // Put found texts in redux store.
       store.dispatch(
-        setTextEntries({
+        addTextEntries({
           entries: textEntries
         })
       );

--- a/src/core/utils/text.tsx
+++ b/src/core/utils/text.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from "react";
+import { RootState, store, useSelector } from "../store";
+import { setTextEntry } from "../text.slice";
+
+export const useText = (): ((key: string) => string) => {
+  const { data } = useSelector((state: RootState) => state.text);
+
+  return (key: string) => data?.[key] ?? key;
+};
+
+export const withText = <T,>(Component: React.ComponentType<T>) => {
+  return (props: T) => {
+    useEffect(() => {
+      // We do this in order to prevent an eslint error later.
+      const values = { ...props };
+      // Match all props that ends with "Text" and put them in redux store.
+      (Object.keys(values) as Array<keyof T>).forEach((prop) => {
+        const pattern = /.*Text$/g;
+        if (String(prop).match(pattern)) {
+          store.dispatch(
+            setTextEntry({
+              key: prop,
+              value: values[prop]
+            })
+          );
+        }
+      });
+    }, [props]);
+
+    // Since this is a High Order Functional Component
+    // we do not know what props we are dealing with.
+    // That is a part of the design.
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <Component {...(props as T)} />;
+  };
+};
+
+export default {};


### PR DESCRIPTION
With this initiative we can access strings in nested components inside 
the apps without passing props.

#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-122

#### Description

A high order component wraps the entry component and puts all props that ends with `*Text` in the redux store.

When the strings are needed you implement the `useText()` hook that returns a function that you can use to fetch them

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

