### PR TITLE
Add material page description to the material app

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-0e94af224aedfa4d9282ad1984d37616dcc66ea7",
+    "@danskernesdigitalebibliotek/dpl-design-system": "1.4.0",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -12,28 +12,28 @@ export default {
       control: { type: "text" }
     },
     materialHeaderAuthorByText: {
-      name: "Af forfatter",
+      name: "By (author)",
       defaultValue: "Af ",
       control: { type: "text" }
     },
     periodikumSelectYearText: {
-      name: "År",
+      name: "Year",
       defaultValue: "År",
       control: { type: "text" }
     },
     periodikumSelectWeekText: {
-      name: "Uge",
+      name: "Week",
       defaultValue: "Uge",
       control: { type: "text" }
     },
     reserveBookText: {
-      name: "Reserve book",
+      name: "Reserve",
       defaultValue: "RESERVER BOG",
       control: { type: "text" }
     },
-    fineOnBookshelfText: {
-      name: "Fine on bookshelf",
-      defaultValue: "FINE PÅ HYLDEN",
+    findOnBookshelfText: {
+      name: "Find on bookshelf",
+      defaultValue: "FIND PÅ HYLDEN",
       control: { type: "text" }
     }
   }

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -35,6 +35,11 @@ export default {
       name: "Find on bookshelf",
       defaultValue: "FIND PÅ HYLDEN",
       control: { type: "text" }
+    },
+    descriptionHeadlineText: {
+      name: "Description headline",
+      defaultValue: "Beskrivelse",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { getParams } from "../../core/utils/helpers";
 import { withText } from "../../core/utils/text";
 import { Pid } from "../../core/utils/types/ids";
 import Material from "./material";
@@ -8,6 +7,7 @@ interface MaterialEntryTextProps {
   materialHeaderAuthorByText: string;
   periodikumSelectYearText: string;
   periodikumSelectWeekText: string;
+  descriptionHeadlineText: string;
 }
 
 export interface MaterialEntryProps extends MaterialEntryTextProps {

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -7,6 +7,8 @@ interface MaterialEntryTextProps {
   materialHeaderAuthorByText: string;
   periodikumSelectYearText: string;
   periodikumSelectWeekText: string;
+  reserveBookText: string;
+  findOnBookshelfText: string;
   descriptionHeadlineText: string;
 }
 

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -1,7 +1,12 @@
 import React from "react";
+import VariousIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Various.svg";
+import ReceiptIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Receipt.svg";
+import CreateIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Create.svg";
+import ExpandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
 import MaterialHeader from "../../components/material/MaterialHeader";
 import { useGetMaterialQuery } from "../../core/dbc-gateway/generated/graphql";
 import { Pid } from "../../core/utils/types/ids";
+import MaterialDescription from "../../components/material-description/MaterialDescription";
 
 export interface MaterialProps {
   pid: Pid;
@@ -22,9 +27,147 @@ const Material: React.FC<MaterialProps> = ({ pid }) => {
   }
 
   return (
-    <main>
+    <div className="material-page">
       <MaterialHeader pid={pid} work={data.work} />
-    </main>
+      <MaterialDescription pid={pid} />
+      <details className="disclosure text-body-large">
+        <summary className="disclosure__headline text-body-large">
+          <div className="disclosure__icon bg-identity-tint-120 m-24">
+            <img
+              className="disclosure__icon"
+              src={VariousIcon}
+              alt="various-icon"
+            />
+          </div>
+          Udgaver (2)
+          <img
+            className="disclosure__expand mr-24 noselect"
+            src={ExpandIcon}
+            alt="expand-icon"
+          />
+        </summary>
+        <div className="material-manifestation-item">
+          <div className="material-manifestation-item__availability">
+            <div className="pagefold-parent--xsmall availability-label text-label availability-label--unselected">
+              <div className="pagefold-triangle--xsmall--success pagefold-triangle--xsmall" />
+              <img
+                className="availability-label--check available"
+                src="icons/collection/Check.svg"
+                alt="check-icon"
+              />
+              <p className="text-label-semibold ml-24">BOG</p>
+              <div className="availability-label--divider ml-4" />
+              <p className="text-label-normal ml-4 mr-8">Hjemme</p>
+            </div>
+          </div>
+          <div className="material-manifestation-item__cover">
+            <div className="material-container">
+              <span className="material material--small bg-identity-tint-120">
+                <img src="images/book_cover_3.jpg" alt="I will be replaced" />
+              </span>
+            </div>
+          </div>
+          <div className="material-manifestation-item__text">
+            <h2 className="material-manifestation-item__text__title text-header-h4">
+              Title
+            </h2>
+            <p className="text-small-caption">Af Author (2022)</p>
+            <div className="material-manifestation-item__text__details">
+              <p className="link-tag text-small-caption">
+                Detaljer om materialet
+              </p>
+              <img src={ExpandIcon} alt="ExpandMore-icon" />
+            </div>
+          </div>
+          <div className="material-manifestation-item__reserve">
+            <button
+              type="button"
+              className="btn-primary btn-filled btn-small arrow__hover--right-small"
+            >
+              RESERVER
+            </button>
+            <span className="link-tag text-small-caption material-manifestation-item__reserve__find">
+              Find på hylden
+            </span>
+          </div>
+        </div>
+      </details>
+      <details className="disclosure text-body-large">
+        <summary className="disclosure__headline text-body-large">
+          <div className="disclosure__icon bg-identity-tint-120 m-24">
+            <img
+              className="disclosure__icon"
+              src={ReceiptIcon}
+              alt="receipt-icon"
+            />
+          </div>
+          Detaljer
+          <img
+            className="disclosure__expand mr-24 noselect"
+            src={ExpandIcon}
+            alt="expand-icon"
+          />
+        </summary>
+        <dl className="list-description pl-80 pb-48">
+          <div>
+            <dt>Type:</dt>
+            <dd>Bog</dd>
+          </div>
+          <div>
+            <dt>Sprog:</dt>
+            <dd>Dansk</dd>
+          </div>
+          <div>
+            <dt>Bidragsydere:</dt>
+            <dd>
+              <span className="link-tag">Karsten Sand Iversen</span>
+            </dd>
+          </div>
+          <div>
+            <dt>Originaltitel:</dt>
+            <dd>Ulysses (1922)</dd>
+          </div>
+          <div>
+            <dt>ISBN:</dt>
+            <dd>9788763814584</dd>
+          </div>
+          <div>
+            <dt>Udgave:</dt>
+            <dd>Udgave, 2. oplag (2015)</dd>
+          </div>
+          <div>
+            <dt>Omfang:</dt>
+            <dd>795 sider</dd>
+          </div>
+          <div>
+            <dt>Forlag:</dt>
+            <dd>Rosinante</dd>
+          </div>
+          <div>
+            <dt>Målgruppe:</dt>
+            <dd>Voksenmateriale</dd>
+          </div>
+        </dl>
+      </details>
+      <details className="disclosure text-body-large">
+        <summary className="disclosure__headline text-body-large">
+          <div className="disclosure__icon bg-identity-tint-120 m-24">
+            <img
+              className="disclosure__icon"
+              src={CreateIcon}
+              alt="create-icon"
+            />
+          </div>
+          Anmeldelser
+          <img
+            className="disclosure__expand mr-24 noselect"
+            src={ExpandIcon}
+            alt="expand-icon"
+          />
+        </summary>
+        Content
+      </details>
+    </div>
   );
 };
 

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -27,7 +27,7 @@ const Material: React.FC<MaterialProps> = ({ pid }) => {
   }
 
   return (
-    <div className="material-page">
+    <main className="material-page">
       <MaterialHeader pid={pid} work={data.work} />
       <MaterialDescription pid={pid} />
       <details className="disclosure text-body-large">
@@ -167,7 +167,7 @@ const Material: React.FC<MaterialProps> = ({ pid }) => {
         </summary>
         Content
       </details>
-    </div>
+    </main>
   );
 };
 

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -19,6 +19,7 @@ export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
         if (faustId) {
           return (
             <AvailabilityLabel
+              key={pid}
               link="/"
               faustIds={[faustId]}
               manifestText={materialTypes[0].specific}

--- a/src/components/cover/cover.tsx
+++ b/src/components/cover/cover.tsx
@@ -6,7 +6,7 @@ import { LinkNoStyle } from "../atoms/link-no-style";
 
 export type CoverProps = {
   animate: boolean;
-  size: "xsmall" | "small" | "medium" | "large" | "original";
+  size: "xsmall" | "small" | "medium" | "large" | "xlarge" | "original";
   tint?: "20" | "40" | "80" | "100" | "120";
   pid: Pid;
   description?: string;
@@ -21,7 +21,12 @@ export const Cover = ({
   tint,
   pid
 }: CoverProps) => {
-  const dataSize: CoverProps["size"] = size === "xsmall" ? "small" : size;
+  let dataSize: CoverProps["size"] = size;
+  if (dataSize === "xsmall") {
+    dataSize = "small";
+  } else if (dataSize === "xlarge") {
+    dataSize = "large";
+  }
   const { data } = useGetCoverCollection({
     type: "pid",
     identifiers: [pid],

--- a/src/components/material-description/MaterialDescription.tsx
+++ b/src/components/material-description/MaterialDescription.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { useGetManifestationQuery } from "../../core/dbc-gateway/generated/graphql";
+import { useText } from "../../core/utils/text";
+import { Pid } from "../../core/utils/types/ids";
+
+export interface MaterialDescriptionProps {
+  pid: Pid;
+}
+
+const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ pid }) => {
+  const { data, isLoading } = useGetManifestationQuery({ pid });
+  const t = useText();
+  return (
+    <section className="material-description">
+      <h2 className="text-header-h4 pb-16">{t("descriptionHeadlineText")}</h2>
+      <p className="text-body-large material-description__content">
+        {!isLoading && data?.manifestation?.physicalDescriptions[0].summary}
+      </p>
+      <div className="material-description__links mt-32">
+        <div className="text-small-caption horizontal-term-line">
+          <p className="text-label-bold">
+            Nr. 3 <span className="text-small-caption">i serien</span>
+          </p>
+          <span>
+            <a href="/" className="link-tag">
+              Vejen til Jerusalem
+            </a>
+          </span>
+        </div>
+        <div className="text-small-caption horizontal-term-line">
+          <p className="text-label-bold">I samme serie</p>
+          <span>
+            <a href="/" className="link-tag">
+              Tempelridderen
+            </a>
+          </span>
+          <span>
+            <a href="/" className="link-tag">
+              Riget ved vejens ende
+            </a>
+          </span>
+          <span>
+            <a href="/" className="link-tag">
+              Arven efter Arn
+            </a>
+          </span>
+        </div>
+        <div className="text-small-caption horizontal-term-line">
+          <p className="text-label-bold">Emneord</p>
+          <span>
+            <a href="/" className="link-tag">
+              Sverige
+            </a>
+          </span>
+          <span>
+            <a href="/" className="link-tag">
+              historie
+            </a>
+          </span>
+          <span>
+            <a href="/" className="link-tag">
+              klosterliv
+            </a>
+          </span>
+          <span>
+            <a href="/" className="link-tag">
+              korstogene
+            </a>
+          </span>
+          <span>
+            <a href="/" className="link-tag">
+              middelalderen
+            </a>
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MaterialDescription;

--- a/src/components/material-description/material-description.graphql
+++ b/src/components/material-description/material-description.graphql
@@ -1,0 +1,7 @@
+query getManifestation($pid: String!) {
+  manifestation(pid: $pid) {
+    physicalDescriptions {
+      summary
+    }
+  }
+}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -40,7 +40,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   return (
     <header className="material-header">
       <div className="material-header__cover">
-        <Cover pid={pid} size="large" animate={false} />
+        <Cover pid={pid} size="xlarge" animate={false} />
       </div>
       <div className="material-header__content">
         <ButtonFavourite materialId={pid} />
@@ -54,7 +54,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <div className="material-header__button">
           <ButtonLargeFilled label={t("reserveBookText")} disabled={false} />
           <ButtonLargeOutline
-            label={t("fineOnBookshelfText")}
+            label={t("findOnBookshelfText")}
             disabled={false}
           />
         </div>

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -1220,6 +1220,21 @@ export type SuggestionsFromQueryStringQuery = {
   };
 };
 
+export type GetManifestationQueryVariables = Exact<{
+  pid: Scalars["String"];
+}>;
+
+export type GetManifestationQuery = {
+  __typename?: "Query";
+  manifestation?: {
+    __typename?: "Manifestation";
+    physicalDescriptions: Array<{
+      __typename?: "PhysicalDescription";
+      summary: string;
+    }>;
+  } | null;
+};
+
 export type ManifestationsSimpleFragment = {
   __typename?: "Manifestations";
   all: Array<{
@@ -1518,5 +1533,29 @@ export const useSuggestionsFromQueryStringQuery = <
       SuggestionsFromQueryStringQuery,
       SuggestionsFromQueryStringQueryVariables
     >(SuggestionsFromQueryStringDocument, variables),
+    options
+  );
+export const GetManifestationDocument = `
+    query getManifestation($pid: String!) {
+  manifestation(pid: $pid) {
+    physicalDescriptions {
+      summary
+    }
+  }
+}
+    `;
+export const useGetManifestationQuery = <
+  TData = GetManifestationQuery,
+  TError = unknown
+>(
+  variables: GetManifestationQueryVariables,
+  options?: UseQueryOptions<GetManifestationQuery, TError, TData>
+) =>
+  useQuery<GetManifestationQuery, TError, TData>(
+    ["getManifestation", variables],
+    fetcher<GetManifestationQuery, GetManifestationQueryVariables>(
+      GetManifestationDocument,
+      variables
+    ),
     options
   );

--- a/src/core/utils/text.tsx
+++ b/src/core/utils/text.tsx
@@ -37,7 +37,7 @@ export const withText = <T,>(Component: React.ComponentType<T>) => {
           entries: textEntries
         })
       );
-    }, [props, propsWithoutText]);
+    }, [props]);
 
     // Since this is a High Order Functional Component
     // we do not know what props we are dealing with.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,10 +1739,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-0e94af224aedfa4d9282ad1984d37616dcc66ea7":
-  version "0.0.0-0e94af224aedfa4d9282ad1984d37616dcc66ea7"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-0e94af224aedfa4d9282ad1984d37616dcc66ea7/e5344329004022eea46a82195ff44050c624823dd101186c1da6d2cb73f34107#eec66ad445ce39c248fd73e05e6b48ef23382155"
-  integrity sha512-bQziVm/elpFpcsT6jZeZFkSx+coZl406LpYEn1XTqzidoJseexd+HK0bE5JxT3tWvkjSAsdrFdVua+k7kNwEmQ==
+"@danskernesdigitalebibliotek/dpl-design-system@1.4.0":
+  version "1.4.0"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/1.4.0/ed2424987865a89eeddc0d439d65b0b2c70b9b87aa6237e952ca3a9555436029#d79dbc7164ed9aa76015b5034d6e342cd5ecc790"
+  integrity sha512-zwPqzLZt8LQaZNKirsYS5ijAtPL/Rlkw7eEMBFIV+Z0S1izbiOeup3G7xgxM8VSirG2H10IXJ1oDls4PXODL9w==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-184

#### Description
This PR adds all of the currently available static HTML to the material app with updated styling from the dpl-design-system package, and then slices the description part of the app into its own sub-component that makes a data call to populate itself based on the currently viewed material (based on PID). 
It also adds material description headline as one of the app mount props. This way the headline text can be adjusted from the CMS interface when mounted in. 
Outside of the ticket scope, I also added the option to set xlarge option for Cover component to match our design system package, and the Figma design, as I was already working with the whole material app anyways.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/181754354-bc650cba-5bb6-491f-8922-87beedee067b.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
What do you think of the implementation?
