### PR TITLE
Improve accessibility for search header

### DIFF
--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -182,11 +182,7 @@ const SearchHeader: React.FC = () => {
   });
 
   return (
-    <form
-      className="header__menu-second"
-      action={t("searchHeaderUrlText")}
-      id="autosuggestForm"
-    >
+    <form className="header__menu-second" action={t("searchHeaderUrlText")}>
       {/* The downshift combobox uses prop spreading by design */}
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <div className="header__menu-search" {...getComboboxProps()}>

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -187,10 +187,9 @@ const SearchHeader: React.FC = () => {
       action={t("searchHeaderUrlText")}
       id="autosuggestForm"
     >
-      {/* eslint-disable react/jsx-props-no-spreading */}
-      {/* The downshift combobox works this way by design */}
+      {/* The downshift combobox uses prop spreading by design */}
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <div className="header__menu-search" {...getComboboxProps()}>
-        {/* eslint-enable react/jsx-props-no-spreading */}
         <SearchBar getInputProps={getInputProps} />
         <Autosuggest
           originalData={originalData}

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -182,15 +182,14 @@ const SearchHeader: React.FC = () => {
   });
 
   return (
-    <div className="header__menu-second">
+    <form
+      className="header__menu-second"
+      action={t("searchHeaderUrlText")}
+      id="autosuggestForm"
+    >
       {/* eslint-disable react/jsx-props-no-spreading */}
       {/* The downshift combobox works this way by design */}
-      <form
-        action={t("searchHeaderUrlText")}
-        className="header__menu-search"
-        id="autosuggestForm"
-        {...getComboboxProps()}
-      >
+      <div className="header__menu-search" {...getComboboxProps()}>
         {/* eslint-enable react/jsx-props-no-spreading */}
         <SearchBar getInputProps={getInputProps} />
         <Autosuggest
@@ -204,8 +203,8 @@ const SearchHeader: React.FC = () => {
           getItemProps={getItemProps}
           isOpen={isAutosuggestOpen}
         />
-      </form>
-    </div>
+      </div>
+    </form>
   );
 };
 

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -11,8 +11,8 @@ const SearchBar: React.FC<SearchBarProps> = ({ getInputProps }) => {
   const t = useText();
   return (
     <>
+      {/* The downshift combobox uses prop spreading by design */}
       {/* eslint-disable react/jsx-props-no-spreading */}
-      {/* The downshift combobox works this way by design */}
       <input
         name="q"
         className="header__menu-search-input text-body-medium-regular"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-176

#### Description

Accessibility checks at danskernesdigitalebibliotek/dpl-cms#118 shows a problem where an ARIA property is added to the form element where it is not valid.

The ARIA role comes from Downshift `getInputProps()`. This PR moves it from the `<form>` to a `<div/>`  which wraps the `<input/>` element. This is in accordance with [Downshift documentation and examples](https://www.downshift-js.com/use-combobox).

As far as I remember we have experienced problems with using a form as the outer element. My initial testing shows that this is not the case.

The PR also includes a bit of boyscouting in relation to the search header.

#### Screenshot of the result

https://user-images.githubusercontent.com/73966/182362468-53bf3374-5757-46a9-9575-63b738ce57c4.mp4

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
