### PR TITLE
Add fictionNonfiction / emnetal to Material description  

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -82,6 +82,11 @@ export default {
       defaultValue: "Udgaver",
       control: { type: "text" }
     },
+    fictionNonfictionText: {
+      name: "Fiction Nonfiction",
+      defaultValue: "Emnetal",
+      control: { type: "text" }
+    },
     detailsText: {
       name: "Details",
       defaultValue: "Detaljer",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -27,6 +27,7 @@ interface MaterialEntryTextProps {
   scopeText: string;
   publisherText: string;
   audienceText: string;
+  fictionNonfictionText: string;
 }
 
 export interface MaterialEntryProps extends MaterialEntryTextProps {

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -20,6 +20,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({
     (item) => item.titles.main[0]
   );
   const subjectsList = work.subjects.all.map((item) => item.display);
+  const { fictionNonfiction } = work;
 
   return (
     <section className="material-description">
@@ -53,6 +54,13 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({
           <HorizontalTermLine
             title={t("identifierText")}
             linkList={subjectsList}
+            searchUrl={searchUrl}
+          />
+        )}
+        {fictionNonfiction && (
+          <HorizontalTermLine
+            title={t("fictionNonfictionText")}
+            linkList={[fictionNonfiction.display]}
             searchUrl={searchUrl}
           />
         )}

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -96,5 +96,8 @@ fragment WorkMedium on Work {
       display
     }
   }
+  fictionNonfiction {
+    display
+  }
   workYear
 }

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -1102,6 +1102,10 @@ export type GetMaterialQuery = {
         | { __typename?: "TimePeriod"; display: string }
       >;
     };
+    fictionNonfiction?: {
+      __typename?: "FictionNonfiction";
+      display: string;
+    } | null;
     titles: {
       __typename?: "WorkTitles";
       full: Array<string>;
@@ -1460,6 +1464,10 @@ export type WorkMediumFragment = {
       | { __typename?: "TimePeriod"; display: string }
     >;
   };
+  fictionNonfiction?: {
+    __typename?: "FictionNonfiction";
+    display: string;
+  } | null;
   titles: {
     __typename?: "WorkTitles";
     full: Array<string>;
@@ -1637,6 +1645,9 @@ export const WorkMediumFragmentDoc = `
     all {
       display
     }
+  }
+  fictionNonfiction {
+    display
   }
   workYear
 }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-153

#### Description
This PR introduces "Emnetal" / fictionNonfiction.

It is displayed in the HorizontalTermLine in the same way as the rest of the data. 

#### Screenshot of the result
<img width="282" alt="Skærmbillede 2022-08-05 kl  14 23 22" src="https://user-images.githubusercontent.com/49920322/183076457-303c1034-c016-4202-b0ae-2f6d21d197ef.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

