### PR TITLE
Make search header linkable to search result and material app

### DIFF
--- a/src/apps/search-header/search-header.dev.tsx
+++ b/src/apps/search-header/search-header.dev.tsx
@@ -7,9 +7,9 @@ export default {
   title: "Apps / Search Header",
   component: SearchHeaderEntry,
   argTypes: {
-    searchHeaderUrlText: {
+    baseUrl: {
       name: "Search header base URL",
-      defaultValue: "https://bibliotek.dk/search",
+      defaultValue: "https://bibliotek.dk",
       control: { type: "text" }
     },
     altText: {

--- a/src/apps/search-header/search-header.entry.tsx
+++ b/src/apps/search-header/search-header.entry.tsx
@@ -3,7 +3,7 @@ import { withText } from "../../core/utils/text";
 import SearchHeader from "./search-header";
 
 export interface SearchHeaderProps {
-  searchHeaderUrlText?: string;
+  baseUrl: string;
   altText?: string;
   inputPlaceholderText?: string;
   stringSuggestionAuthorText?: string;
@@ -13,13 +13,7 @@ export interface SearchHeaderProps {
 }
 
 const SearchHeaderEntry: React.FC<SearchHeaderProps> = ({
-  searchHeaderUrlText = "https://bibliotek.dk/search",
-  altText = "search icon",
-  inputPlaceholderText = "Search here",
-  stringSuggestionAuthorText = "author",
-  stringSuggestionWorkText = "work",
-  stringSuggestionTopicText = "topic",
-  etAlText = "et al."
-}) => <SearchHeader />;
+  baseUrl = "https://bibliotek.dk"
+}) => <SearchHeader baseUrl={baseUrl} />;
 
 export default withText(SearchHeaderEntry);

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -96,12 +96,17 @@ const SearchHeader: React.FC<SearchHeaderProps> = ({ baseUrl }) => {
 
   // downshift prevents the default form submission event when the autosuggest
   // is open - that's why in some cases we have to simulate form sumbission
-  function manualRedirect(inputValue: string) {
-    const baseUrl = t("searchHeaderUrlText");
-    const params = inputValue;
-    if (window.top) {
-      window.top.location.href = `${baseUrl}?q=${params}`;
+  function manualRedirect(itemValue: Suggestion) {
+    const inputValue = itemToString(itemValue);
+    if (!window.top) {
+      return;
     }
+    // if this item is one of the work suggestions, redirect to material page
+    if (materialData.includes(itemValue)) {
+      window.top.location.href = `${baseUrl}/work/${itemValue.work?.manifestations.first.pid}`;
+      return;
+    }
+    window.top.location.href = `${baseUrl}/search?q=${inputValue}`;
   }
 
   function handleHighlightedIndexChange(
@@ -128,7 +133,7 @@ const SearchHeader: React.FC<SearchHeaderProps> = ({ baseUrl }) => {
     if (
       type === useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem
     ) {
-      manualRedirect(currentItemValue);
+      manualRedirect(currentlyHighlightedObject);
       return;
     }
     if (
@@ -159,7 +164,7 @@ const SearchHeader: React.FC<SearchHeaderProps> = ({ baseUrl }) => {
       if (!selectedItem) {
         return;
       }
-      manualRedirect(itemToString(selectedItem));
+      manualRedirect(selectedItem);
     }
   }
   // this is the main Downshift hook

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -8,11 +8,10 @@ import {
 import SearchBar from "../../components/search-bar/search-bar";
 import { Autosuggest } from "../../components/autosuggest/autosuggest";
 import { Suggestion } from "../../core/utils/types/autosuggest";
-import { useText } from "../../core/utils/text";
 import { itemToString } from "../../components/autosuggest-text/autosuggest-text";
 
 export interface SearchHeaderProps {
-  searchHeaderUrl?: string;
+  baseUrl: string;
   altText?: string;
   inputPlaceholderText?: string;
   stringSuggestionAuthorText?: string;
@@ -20,8 +19,7 @@ export interface SearchHeaderProps {
   stringSuggestionTopicText?: string;
 }
 
-const SearchHeader: React.FC = () => {
-  const t = useText();
+const SearchHeader: React.FC<SearchHeaderProps> = ({ baseUrl }) => {
   const [q, setQ] = useState<string>("");
   const [qWithoutQuery, setQWithoutQuery] = useState<string>(q);
   const [suggestItems, setSuggestItems] = useState<any[]>([]);
@@ -183,7 +181,7 @@ const SearchHeader: React.FC = () => {
   });
 
   return (
-    <form className="header__menu-second" action={t("searchHeaderUrlText")}>
+    <form className="header__menu-second" action={`${baseUrl}/search`}>
       {/* The downshift combobox uses prop spreading by design */}
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <div className="header__menu-search" {...getComboboxProps()}>

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -31,7 +31,7 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
         <ul className="autosuggest__materials">
           {/* eslint-disable react/jsx-props-no-spreading */}
           {/* The downshift combobox works this way by design (line 50) */}
-          {/* incorrectIndex because in the whole of autosuggest dropdown it is 
+          {/* incorrectIndex because in the whole of autosuggest dropdown it is
           not the correct index for the item. We first need to add the length of
           items from autosuggest string suggestion to it for it to be accurate */}
           {materialData.map((item, incorrectIndex) => {
@@ -53,7 +53,6 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
                 {/* eslint-enable react/jsx-props-no-spreading */}
                 <div className="autosuggest__material__content">
                   <div className="autosuggest__cover">
-                    {/* TODO: once we have the material page and know what the urls look like, we need to pass materialUrl here */}
                     {item.work && (
                       <Cover
                         animate

--- a/src/components/search-bar/search-bar.dev.tsx
+++ b/src/components/search-bar/search-bar.dev.tsx
@@ -42,13 +42,13 @@ export const Default: ComponentStory<typeof SearchBar> = (
     }
   });
 
-  const searchHeaderUrl = "https://bibliotek.dk/search";
+  const baseUrl = "https://bibliotek.dk";
 
   return (
     <StoryHeader>
       <div className="header__menu-second">
         <form
-          action={searchHeaderUrl}
+          action={baseUrl}
           className="header__menu-search"
           {...getComboboxProps()}
         >


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-185

#### Description
This PR makes sure that linking from the search header app to search result app/material app works when the apps are set into the CMS.  
This needed to be distinguished based on the autosuggest item the user selected. If it is one of the string suggestions - we redirect to the search result; if it is a material suggestion - we redirect to the material app page. 

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
