### PR TITLE
Add logic to display language in title

### DIFF
--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -42,9 +42,11 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     language?.isoCode.toLowerCase().includes("dan")
   );
 
-  const title = containsDanish
-    ? fullTitle
-    : `${fullTitle} (${mainLanguages[0].display})`;
+  const allLanguages = mainLanguages
+    .map((language) => language.display)
+    .join(", ");
+
+  const title = containsDanish ? fullTitle : `${fullTitle} (${allLanguages})`;
 
   return (
     <header className="material-header">

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -39,7 +39,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const author = creatorsText || "[Creators are missing]";
 
   const containsDanish = mainLanguages.some((language) =>
-    language.display.toLowerCase().includes("dansk")
+    language?.isoCode.toLowerCase().includes("dan")
   );
 
   const title = containsDanish

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -25,7 +25,8 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   work: {
     titles: { full: fullTitle },
     creators,
-    manifestations
+    manifestations,
+    mainLanguages
   }
 }) => {
   const t = useText();
@@ -37,6 +38,14 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
 
   const author = creatorsText || "[Creators are missing]";
 
+  const containsDanish = mainLanguages.some((language) =>
+    language.display.toLowerCase().includes("dansk")
+  );
+
+  const title = containsDanish
+    ? fullTitle
+    : `${fullTitle} (${mainLanguages[0].display})`;
+
   return (
     <header className="material-header">
       <div className="material-header__cover">
@@ -44,7 +53,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
       </div>
       <div className="material-header__content">
         <ButtonFavourite materialId={pid} />
-        <MaterialHeaderText title={String(fullTitle)} author={author} />
+        <MaterialHeaderText title={String(title)} author={author} />
         <div className="material-header__availability-label">
           <AvailabiltityLabels manifestations={manifestations} />
         </div>

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -90,6 +90,7 @@ fragment WorkMedium on Work {
   }
   mainLanguages {
     display
+    isoCode
   }
   subjects {
     all {

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -1092,7 +1092,11 @@ export type GetMaterialQuery = {
     workId: string;
     abstract?: Array<string> | null;
     materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
-    mainLanguages: Array<{ __typename?: "Language"; display: string }>;
+    mainLanguages: Array<{
+      __typename?: "Language";
+      display: string;
+      isoCode: string;
+    }>;
     subjects: {
       __typename?: "SubjectContainer";
       all: Array<
@@ -1454,7 +1458,11 @@ export type WorkMediumFragment = {
   workId: string;
   abstract?: Array<string> | null;
   materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
-  mainLanguages: Array<{ __typename?: "Language"; display: string }>;
+  mainLanguages: Array<{
+    __typename?: "Language";
+    display: string;
+    isoCode: string;
+  }>;
   subjects: {
     __typename?: "SubjectContainer";
     all: Array<
@@ -1640,6 +1648,7 @@ export const WorkMediumFragmentDoc = `
   }
   mainLanguages {
     display
+    isoCode
   }
   subjects {
     all {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-148

#### Description

This change checks if the language contains "dansk" and if not it will be displayed together with the title.

## Uddrag fra mindstekrav:

c. Title-full - og såfremt værket er en bog, som ikke er på dansk - sprog i parentes efter Title-full

#### Screenshot of the result

**This is a reverse example because there are only languages that contain "dansk"**
<img width="1622" alt="Skærmbillede 2022-08-09 kl  14 00 20" src="https://user-images.githubusercontent.com/49920322/183642051-ce9bff41-e5d2-43a7-a5dc-84dcbd3929c5.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

