### PR TITLE
Reference TypeScript instead of JavaScript in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ this:
 </details>
 
 As a minimum you will need the `runtime.js` and `bundle.js`. For styling
-of atoms and components you will need to import `components.css`.
+of components you will need to import `components.css`.
 
 Each application also has its own JavaScript artifact and it might have a CSS
 artifact as well. Such as `add-to-checklist.js` and `add-to-checklist.css`.
@@ -515,7 +515,7 @@ can reuse various levels of infrastructure provided by the project such as:
 
 1. [Integration with various webservices](src/core)
 2. [User authentication and token management](src/core)
-3. [Visual atoms or components](#cross-application-components)
+3. [Visual components](#cross-application-components)
 4. Visual representations of [existing applications](src/apps)
 5. [Styling using SCSS](#style-your-application)
 6. Test infrastructure

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export default MyNewApplicationEntry;
 <details>
   <summary>3. Create the mount</summary>
 
-```javascript
+```typescript
 // ./src/apps/my-new-application/my-new-application.mount.ts
 import addMount from "../../core/addMount";
 import MyNewApplication from "./my-new-application.entry";

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/danskernesdigitalebibliotek/dpl-react/branch/master/graph/badge.svg)](https://codecov.io/gh/danskernesdigitalebibliotek/dpl-react)
 
 A set of React components and applications providing self-service features for
-Danish public libraries.
+Danish public libraries implemented in TypeScript.
 
 <!-- markdownlint-disable -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -17,7 +17,7 @@ Danish public libraries.
     - [Access tokens](#access-tokens)
   - [Installation](#installation)
   - [Standard and style](#standard-and-style)
-    - [JavaScript + JSX](#javascript--jsx)
+    - [TypeScript + TSX](#typescript--tsx)
       - [Named functions Vs. Anonymous arrow functions](#named-functions-vs-anonymous-arrow-functions)
   - [Create a new application](#create-a-new-application)
     - [Application state-machine](#application-state-machine)
@@ -84,7 +84,7 @@ When storybook is started, you can access it at: [dpl-react.docker](http://dpl-r
 
 ### Standard and style
 
-#### JavaScript + JSX
+#### TypeScript + TSX
 
 For static code analysis we make use of the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)
 and for formatting we make use of [Prettier](https://github.com/prettier/prettier)

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ appropriate.
 
 ```scss
 // ./src/apps/my-new-application/my-new-application.scss
-.warm {
+.dpl-warm {
   color: maroon;
 }
 ```
@@ -294,7 +294,7 @@ interface MyNewApplicationProps {
 }
 
 const MyNewApplication: React.FC<MyNewApplicationProps> = ({ text }) => (
-  <h2 className="warm">{text}</h2>
+  <h2 className="dpl-warm">{text}</h2>
 );
 
 export default MyNewApplication;

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Danish public libraries implemented in TypeScript.
     - [Application state-machine](#application-state-machine)
   - [Style your application](#style-your-application)
   - [Cross application components](#cross-application-components)
-    - [Creating an atom](#creating-an-atom)
-    - [Creating a component](#creating-a-component)
   - [Editor example configuration](#editor-example-configuration)
 - [Usage](#usage)
   - [Naive app mount](#naive-app-mount)
@@ -134,24 +132,17 @@ stacktraces.
 <details>
   <summary>1. Create a new application component</summary>
 
-```javascript
-// ./src/apps/my-new-application/my-new-application.jsx
-import React from "react";
-import PropTypes from "prop-types";
+```typescript
+// ./src/apps/my-new-application/my-new-application.tsx
+import * as React from "react";
 
-export function MyNewApplication({ text }) {
-  return (
-      <h2>{text}</h2>
-  );
+interface MyNewApplicationProps {
+  text: string;
 }
 
-MyNewApplication.defaultProps = {
-  text: "The fastest man alive!"
-};
-
-MyNewApplication.propTypes = {
-  text: PropTypes.string
-};
+const MyNewApplication: React.FC<MyNewApplicationProps> = ({ text }) => (
+  <h2>{text}</h2>
+);
 
 export default MyNewApplication;
 ```
@@ -161,18 +152,20 @@ export default MyNewApplication;
 <details>
   <summary>2. Create the entry component</summary>
 
-```javascript
-// ./src/apps/my-new-application/my-new-application.entry.jsx
-import React from "react";
-import PropTypes from "prop-types";
-import MyNewApplication from "./my-new-application";
+```typescript
+// ./src/apps/my-new-application/my-new-application.entry.tsx
+import * as React from "react";
+
+interface MyNewApplicationEntryProps {
+  text: string;
+}
 
 // The props of an entry is all of the data attributes that were
 // set on the DOM element. See the section on "Naive app mount." for
 // an example.
-export function MyNewApplicationEntry(props) {
-  return <MyNewApplication text='Might be from a server?' />;
-}
+const MyNewApplicationEntry: React.FC<MyNewApplicationEntryProps> = ({
+ text
+}) => <h2>{text}</h2>;
 
 export default MyNewApplicationEntry;
 ```
@@ -183,7 +176,7 @@ export default MyNewApplicationEntry;
   <summary>3. Create the mount</summary>
 
 ```javascript
-// ./src/apps/my-new-application/my-new-application.mount.js
+// ./src/apps/my-new-application/my-new-application.mount.ts
 import addMount from "../../core/addMount";
 import MyNewApplication from "./my-new-application.entry";
 
@@ -195,24 +188,28 @@ addMount({ appName: "my-new-application", app: MyNewApplication });
 <details>
   <summary>4. Add a story for local development</summary>
 
-```javascript
-// ./src/apps/my-new-application/my-new-application.dev.jsx
+```typescript
+// ./src/apps/my-new-application/my-new-application.dev.tsx
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import MyNewApplicationEntry from "./my-new-application.entry";
-import MyNewApplication from "./my-new-application";
+import MyNewApplication, {
+  MyNewApplicationEntryProps
+} from "./my-new-application.entry";
 
-export default { title: "Apps|My new application" };
+export default {
+  title: "My new application",
+  component: MyNewApplication,
+  argTypes: {
+    text: {
+      defaultValue: "Text",
+      control: { type: "text" }
+    }
+  }
+} as ComponentMeta<typeof MyNewApplication>;
 
-export function Entry() {
-  // Testing the version that will be shipped.
-  return <MyNewApplicationEntry />;
-}
-
-export function WithoutData() {
-  // Play around with the application itself without server side data.
-  return <MyNewApplication />;
-}
-
+export const App: ComponentStory<typeof MyNewApplication> = (
+  args: MyNewApplicationEntryProps
+) => <MyNewApplication {...args} />;
 ```
 
 </details>
@@ -240,7 +237,7 @@ for you to tinker around.
 Most applications will have multiple internal states, so to aid consistency,
 it's recommended to:
 
-``` javascript
+``` typescript
   const [status, setStatus] = useState("<initial state>");
 ```
 
@@ -278,7 +275,7 @@ appropriate.
 
 ```scss
 // ./src/apps/my-new-application/my-new-application.scss
-.dpl-warm {
+.warm {
   color: maroon;
 }
 ```
@@ -288,24 +285,17 @@ appropriate.
 <details>
   <summary>2. Add the class to your application</summary>
 
-```javascript
-// ./src/apps/my-new-application/my-new-application.jsx
-import React from "react";
-import PropTypes from "prop-types";
+```typescript
+// ./src/apps/my-new-application/my-new-application.tsx
+import * as React from "react";
 
-export function MyNewApplication({ text }) {
-  return (
-      <h2 className='warm'>{text}</h2>
-  );
+interface MyNewApplicationProps {
+  text: string;
 }
 
-MyNewApplication.defaultProps = {
-  text: "The fastest man alive!"
-};
-
-MyNewApplication.propTypes = {
-  text: PropTypes.string
-};
+const MyNewApplication: React.FC<MyNewApplicationProps> = ({ text }) => (
+  <h2 className="warm">{text}</h2>
+);
 
 export default MyNewApplication;
 ```
@@ -315,25 +305,29 @@ export default MyNewApplication;
 <details>
   <summary>3. Import the scss into your story</summary>
 
-```javascript
-// ./src/apps/my-new-application/my-new-application.dev.jsx
+```typescript
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import MyNewApplicationEntry from "./my-new-application.entry";
-import MyNewApplication from "./my-new-application";
+import MyNewApplication, {
+  MyNewApplicationEntryProps
+} from "./my-new-application.entry";
 
-import './my-new-application.scss';
+import "./my-new-application.css";
 
-export default { title: "Apps|My new application" };
+export default {
+  title: "My new application",
+  component: MyNewApplication,
+  argTypes: {
+    text: {
+      defaultValue: "Text",
+      control: { type: "text" }
+    }
+  }
+} as ComponentMeta<typeof MyNewApplication>;
 
-export function Entry() {
-  // Testing the version that will be shipped.
-  return <MyNewApplicationEntry />;
-}
-
-export function WithoutData() {
-  // Play around with the application itself without server side data.
-  return <MyNewApplication />;
-}
+export const App: ComponentStory<typeof MyNewApplication> = (
+  args: MyNewApplicationEntryProps
+) => <MyNewApplication {...args} />;
 ```
 
 </details>
@@ -343,129 +337,10 @@ __Cowabunga!__ You now got styling in your application
 ### Cross application components
 
 If the component is simple enough to be a primitive you would use in multiple
-occasions it's called an 'atom'. Such as a button or a link. If it's more
-specific than that and to be used across apps we just call it a component. An
-example would be some type of media presented alongside a header and some text.
+occasions it's called n component.
 
-The process when creating an atom or a component is more or less similar, but
+The process when creating an component or an app is more or less similar, but
 some structural differences might be needed.
-
-#### Creating an atom
-
-<details>
-  <summary>1. Create the atom</summary>
-
-```javascript
-// ./src/components/atoms/my-new-atom/my-new-atom.jsx
-import React from "react";
-import PropTypes from 'prop-types';
-
-/**
- * A simple button.
- *
- * @export
- * @param {object} props
- * @returns {ReactNode}
- */
-export function MyNewAtom({ className, children }) {
-  return <button className={`btn ${className}`}>{children}</button>;
-}
-
-MyNewAtom.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node.isRequired
-}
-
-MyNewAtom.defaultProps = {
-  className: ""
-}
-
-export default MyNewAtom;
-```
-
-</details>
-
-<details>
-  <summary>2. Create styles for the atom</summary>
-
-```scss
-// ./src/components/atoms/my-new-atom/my-new-atom.scss
-.dpl-btn {
-    color: blue;
-}
-```
-
-</details>
-
-<details>
-  <summary>3. Import the atom's styles into the component stylesheet</summary>
-
-```scss
-// ./src/components/components.scss
-@import 'atoms/button/button.scss';
-@import 'atoms/my-new-atom/my-new-atom.scss';
-```
-
-</details>
-
-<details>
-  <summary>4. Create a story for your atom</summary>
-
-```javascript
-// ./src/components/atoms/my-new-atom/my-new-atom.dev.jsx
-import React from "react";
-import MyNewAtom from "./my-new-atom";
-
-export default { title: "Atoms|My new atom" };
-
-export function WithText() {
-  return <MyNewAtom>Cick me!</MyNewAtom>;
-}
-```
-
-</details>
-
-<details>
-  <summary>5. Import the atom into the applications or other components where
-you would want to use it</summary>
-
-```javascript
-// ./src/apps/my-new-application/my-new-application.jsx
-import React, {Fragment} from "react";
-import PropTypes from "prop-types";
-
-import MyNewAtom from "../../components/atom/my-new-atom/my-new-atom"
-
-export function MyNewApplication({ text }) {
-  return (
-      <Fragment>
-        <h2 className='warm'>{text}</h2>
-        <MyNewAtom className='additional-class' />
-      </Fragment>
-  );
-}
-
-MyNewApplication.defaultProps = {
-  text: "The fastest man alive!"
-};
-
-MyNewApplication.propTypes = {
-  text: PropTypes.string
-};
-
-export default MyNewApplication;
-```
-
-</details>
-
-__Finito!__ You now know how to share code across applications
-
-#### Creating a component
-
-Repeat all of the same steps as with an atom but place it in it's own directory
-inside `components`.
-
-Such as `./src/components/my-new-component/my-new-component.jsx`
 
 ### Editor example configuration
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ __Cowabunga!__ You now got styling in your application
 
 If the component is simple enough to be a primitive you would use in multiple
 occasions it's called an 'atom'. Such as a button or a link. If it's more
-specific that that and to be used across apps we just call it a component. An
+specific than that and to be used across apps we just call it a component. An
 example would be some type of media presented alongside a header and some text.
 
 The process when creating an atom or a component is more or less similar, but

--- a/README.md
+++ b/README.md
@@ -337,9 +337,9 @@ __Cowabunga!__ You now got styling in your application
 ### Cross application components
 
 If the component is simple enough to be a primitive you would use in multiple
-occasions it's called n component.
+occasions it's called a component.
 
-The process when creating an component or an app is more or less similar, but
+The process when creating a component or an app is more or less similar, but
 some structural differences might be needed.
 
 ### Editor example configuration

--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -5,7 +5,7 @@ components for the Danish Public Libraries CMS project. The guidelines should
 help achieve:
 
 * A stable, secure and high quality foundation for building and maintaining
-  client-side JavaScript components for library websites
+  client-side TypeScript components for library websites
 * Consistency across multiple developers participating in the project
 * The best possible conditions for sharing components between library websites
 * The best possible conditions for the individual library website to customize
@@ -19,8 +19,10 @@ indicates that the guidelines should be updated to ensure transparency.
 ## Coding standards
 
 The project follows the [Airbnb JavaScript Style Guide](https://airbnb.io/javascript/)
-and [Airbnb React/JSX Style Guide](https://airbnb.io/javascript/react/). This
-choice is based on multiple factors:
+and [Airbnb React/JSX Style Guide](https://airbnb.io/javascript/react/). They
+have been [extended to support TypeScript](https://github.com/iamturns/eslint-config-airbnb-typescript).
+
+This choice is based on multiple factors:
 
 1. Historically the community of developers working with the Danish Public
    Libraries [has ties to the Drupal project](https://github.com/ding2/ding2/).
@@ -52,7 +54,7 @@ be especially aware of.
     * Firefox
     * Samsung Browser
 
-### JavaScript
+### TypeScript
 
 #### Named functions vs. anonymous arrow functions
 

--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -27,7 +27,7 @@ choice is based on multiple factors:
    [Drupal has adopted the Airbnb JavaScript Style Guide](https://www.drupal.org/node/2873849)
    so this choice should ensure consistency between the two projects.
 2. Airbnb's standard is one of the best known and most used in the JavaScript
-   ccoding standard landscape.
+   coding standard landscape.
 3. Airbnb’s standard is both comprehensive and well documented.
 4. Airbnb’s standards cover both JavaScript in general React/JSX specifically.
    This avoids potential conflicts between multiple standards.

--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -120,29 +120,29 @@ Files provided by components must be placed in the following folders and have
 the extensions defined here.
 
 * Components (React applications)
-  * apps/[component-name]/[component-name].jsx
-    * Core JSX component.
+  * apps/[component-name]/[component-name].tsx
+    * Core TSX component.
   * components/[component-name]/[component-name].scss
     * Stylesheet for the component.
-  * apps/[component-name]/[component-name].entry.jsx
+  * apps/[component-name]/[component-name].entry.tsx
     * Main application entrypoint.
     * This will usually also be where state management is implemented.
     * This must _not_ include the default stylesheet.
-  * apps/[component-name]/[component-name].dev.jsx
+  * apps/[component-name]/[component-name].dev.tsx
     * Storybook entry for the component.
     * If the component has a stylesheet this must also be included here.
-  * apps/[component-name]/[component-name].mount.js
+  * apps/[component-name]/[component-name].mount.ts
     * Code for registering the application to be booted when a page is loaded on
       the host system.
-  * apps/[component-name]/[component-name].test.js
+  * apps/[component-name]/[component-name].test.ts
     * Test of the component implemented with [Cypress](https://www.cypress.io/)
 * Reusable elements (React components)
-  * components/[component-name]/[component-name].dev.jsx
-  * components/[component-name]/[component-name].jsx
+  * components/[component-name]/[component-name].dev.tsx
+  * components/[component-name]/[component-name].tsx
   * components/[component-name]/[component-name].scss
 * Reusable functions and classes
-  * core/[function].js
-  * core/[Class].js
+  * core/[function].ts
+  * core/[Class].ts
 
 ## Third party code
 

--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -11,7 +11,7 @@ help achieve:
 * The best possible conditions for the individual library website to customize
   configuration and appearance
 
-Contributions to the DDB React project will be reviewed by members of the Core
+Contributions to the DPL React project will be reviewed by members of the Core
 team. These guidelines should inform contributors about what to expect in such a
 review. If a review comment cannot be traced back to one of these guidelines it
 indicates that the guidelines should be updated to ensure transparency.
@@ -22,8 +22,8 @@ The project follows the [Airbnb JavaScript Style Guide](https://airbnb.io/javasc
 and [Airbnb React/JSX Style Guide](https://airbnb.io/javascript/react/). This
 choice is based on multiple factors:
 
-1. Historically the community of developers working with DDB
-   [has ties to the Drupal project](https://github.com/ding2/ding2/).
+1. Historically the community of developers working with the Danish Public
+   Libraries [has ties to the Drupal project](https://github.com/ding2/ding2/).
    [Drupal has adopted the Airbnb JavaScript Style Guide](https://www.drupal.org/node/2873849)
    so this choice should ensure consistency between the two projects.
 2. Airbnb's standard is one of the best known and most used in the JavaScript


### PR DESCRIPTION
#### Description

This should clarify the primary language of the project.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.