### PR TITLE
Fix reloading covers for autosuggest - material suggestions

### DIFF
--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -31,7 +31,7 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
         <ul className="autosuggest__materials">
           {/* eslint-disable react/jsx-props-no-spreading */}
           {/* The downshift combobox works this way by design (line 50) */}
-          {/* incorrectIndex because in the whole of autosuggest dropdown it is 
+          {/* incorrectIndex because in the whole of autosuggest dropdown it is
           not the correct index for the item. We first need to add the length of
           items from autosuggest string suggestion to it for it to be accurate */}
           {materialData.map((item, incorrectIndex) => {
@@ -47,7 +47,7 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
                     ? "autosuggest__material--highlight"
                     : ""
                 }`}
-                key={generateItemId(item)}
+                key={item.work?.workId}
                 {...getItemProps({ item, index })}
               >
                 {/* eslint-enable react/jsx-props-no-spreading */}

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -1,7 +1,6 @@
 import { UseComboboxPropGetters } from "downshift";
 import React from "react";
 import { useText } from "../../core/utils/text";
-import { generateItemId } from "../autosuggest-text/autosuggest-text";
 import { Suggestion, Suggestions } from "../../core/utils/types/autosuggest";
 import { Cover } from "../cover/cover";
 import { creatorsToString } from "../../core/utils/helpers";


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-191

#### Description
Using autosuggest material item workId as key for mapped suggestion items makes sure that mapped element's keys stay the same between specific items across reloads. Thus the items won't be re-rendered when they the items stay the same - thus the cover pictures won't flash.

#### Screenshot of the result
https://user-images.githubusercontent.com/28546954/183887537-343c6ca4-791f-4830-a65e-125ab3e3d9d5.mov

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
