### PR TITLE
Material app e2e + it also fixes the pathname problem

### DIFF
--- a/cypress/fixtures/material/availability.json
+++ b/cypress/fixtures/material/availability.json
@@ -1,0 +1,8 @@
+[
+  {
+    "available": false,
+    "recordId": "52557240",
+    "reservable": true,
+    "reservations": 2
+  }
+]

--- a/cypress/fixtures/material/cover.json
+++ b/cypress/fixtures/material/cover.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "870970-basis:45234401",
+    "type": "pid",
+    "imageUrls": {
+      "original": {
+        "url": "https:res.cloudinary.com/dandigbib/image/upload/v1605727140/bogportalen.dk/9781848485532.jpg",
+        "format": "jpeg",
+        "size": "original"
+      },
+      "small": {
+        "url": "https:res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_small/v1605727140/bogportalen.dk/9781848485532.jpg",
+        "format": "jpeg",
+        "size": "small"
+      },
+      "medium": {
+        "url": "https:res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_medium/v1605727140/bogportalen.dk/9781848485532.jpg",
+        "format": "jpeg",
+
+        "size": "medium"
+      },
+      "large": {
+        "url": "https:res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1605727140/bogportalen.dk/9781848485532.jpg",
+        "format": "jpeg",
+        "size": "large"
+      }
+    }
+  }
+]

--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -1,0 +1,336 @@
+{
+  "data": {
+    "work": {
+      "workId": "work-of:870970-basis:52557240",
+      "titles": {
+        "full": ["Dummy Some Title: Full"],
+        "original": ["Dummy Some Title Origintal"]
+      },
+      "abstract": ["Dummy The abstract"],
+      "creators": [
+        { "display": "Dummy Jens Jensen", "__typename": "Person" },
+        { "display": "Dummy Some Corporation", "__typename": "Corporation" }
+      ],
+      "series": [
+        {
+          "title": "Dummy Some Series",
+          "isPopular": true,
+          "numberInSeries": { "display": "Dummy number one", "number": [1] },
+          "readThisFirst": true,
+          "readThisWhenever": false
+        },
+        {
+          "title": "Dummy Some Series",
+          "isPopular": false,
+          "numberInSeries": { "display": "Dummy number one", "number": [1] },
+          "readThisFirst": null,
+          "readThisWhenever": null
+        }
+      ],
+      "seriesMembers": [
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        },
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        },
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        },
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        },
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        },
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        },
+        {
+          "titles": {
+            "main": ["Dummy Some Title"],
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
+          }
+        }
+      ],
+      "manifestations": {
+        "all": [
+          {
+            "pid": "870970-basis:52557240",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          },
+          {
+            "pid": "870970-basis:52643503",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          },
+          {
+            "pid": "870970-basis:53200346",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          },
+          {
+            "pid": "870970-basis:53292968",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          },
+          {
+            "pid": "870970-basis:46615743",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          },
+          {
+            "pid": "870970-basis:52590302",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          },
+          {
+            "pid": "870970-basis:52643414",
+            "titles": {
+              "main": ["Dummy Some Title"],
+              "original": ["Dummy Some Title: Original"]
+            },
+            "publicationYear": { "display": "Dummy 1839" },
+            "materialTypes": [{ "specific": "Dummy bog" }],
+            "creators": [
+              { "display": "Dummy Jens Jensen", "__typename": "Person" },
+              {
+                "display": "Dummy Some Corporation",
+                "__typename": "Corporation"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dummy Årsskrift / Carlsbergfondet",
+              "creator": "Dummy Some Creator",
+              "publisher": "Dummy Some Publisher",
+              "year": { "year": 2006 }
+            },
+            "languages": { "main": [{ "display": "Dummy dansk" }] },
+            "identifiers": [{ "value": "Dummy 1234567891234" }],
+            "contributors": [{ "display": "Dummy Jens Jensen" }],
+            "edition": { "summary": "Dummy 3. i.e. 2 udgave, 2005" },
+            "audience": { "generalAudience": ["Dummy general audience"] },
+            "physicalDescriptions": [{ "numberOfPages": null }]
+          }
+        ]
+      },
+      "materialTypes": [{ "specific": "Dummy bog" }],
+      "mainLanguages": [{ "display": "Dummy dansk", "isoCode": "Dummy dan" }],
+      "subjects": {
+        "all": [
+          { "display": "Dummy Some fictional subject" },
+          { "display": "Dummy 1950-1980" },
+          { "display": "Dummy Jens Jensen" },
+          { "display": "Dummy Some Corporation" }
+        ]
+      },
+      "reviews": [
+        {
+          "__typename": "ExternalReview",
+          "author": "Lene Jensen",
+          "date": "2016-09-12",
+          "rating": null,
+          "urls": [
+            {
+              "origin": "litteratursiden.dk",
+              "url": "http:www.litteratursiden.dk/anmeldelser/syv-soestre-af-lucinda-riley"
+            }
+          ]
+        },
+        {
+          "__typename": "LibrariansReview",
+          "author": "Dorthe Marlene Jørgensen",
+          "date": "2016-08-23",
+          "sections": [
+            {
+              "code": "ABOUT",
+              "heading": "Kort om bogen",
+              "text": "Første bind i en stor serie, om kærlighed og tab, inspireret af stjernebilledet De Syv Søstre. For dem, der holder af kærlighedshistorier, primært kvinder"
+            },
+            {
+              "code": "DESCRIPTION",
+              "heading": "Beskrivelse",
+              "text": "Året er 2007 og Maia og hendes fem søstre er blevet kaldt hjem til deres barndomshjem, da deres elskede far, Pa Salt, er død. De er alle blevet adopteret, og deres far har efterladt en ledetråd til dem hver, der kan lede dem tilbage til deres ophav. Denne første bog i serien, handler om den ældste søster Maia, hvis ledetråd fører hende til Brasilien"
+            },
+            {
+              "code": "EVALUATION",
+              "heading": "Vurdering",
+              "text": "En rigtig flot roman, der er helt på niveau med forfatterens tidligere udgivelser. Der er tale om en stor serie på syv planlagte bøger. Sproget er let og historien fanger fra start"
+            },
+            {
+              "code": "OTHER",
+              "heading": "Andre bøger om samme emne",
+              "text": ""
+            }
+          ]
+        }
+      ],
+      "fictionNonfiction": { "display": "Dummy skønlitteratur" },
+      "workYear": "Dummy 1950"
+    }
+  }
+}

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -6,6 +6,16 @@ export default {
   title: "Apps / Material",
   component: MaterialEntry,
   argTypes: {
+    searchUrl: {
+      name: "Path to the search result page",
+      defaultValue: "/search",
+      control: { type: "text" }
+    },
+    materialUrl: {
+      name: "Path to the material page",
+      defaultValue: "/work/:workid",
+      control: { type: "text" }
+    },
     pid: {
       name: "pid",
       defaultValue: "870970-basis:52557240",
@@ -44,12 +54,6 @@ export default {
     descriptionHeadlineText: {
       name: "Description headline",
       defaultValue: "Beskrivelse",
-      control: { type: "text" }
-    },
-    searchUrl: {
-      name: "Base search url",
-      defaultValue:
-        "http://localhost/?path=/story/apps-search-result--search-result",
       control: { type: "text" }
     },
     identifierText: {

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -1,0 +1,69 @@
+describe("Material", () => {
+  it("Should render the material page as expected", () => {
+    cy.log("Does the Material have title?");
+    cy.contains("Dummy Some Title: Full");
+
+    cy.log("Check that cover has a src");
+    cy.get("img").should(
+      "have.attr",
+      "src",
+      "https:res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1605727140/bogportalen.dk/9781848485532.jpg"
+    );
+
+    cy.log("Does the material have favourite buttons?");
+    cy.get(".button-favourite").should(
+      "have.attr",
+      "aria-label",
+      "Add to favorites"
+    );
+
+    cy.log("Does the material have horizontal lines?");
+    cy.contains("Nr 1 i serien");
+    cy.contains("Dummy Some Series");
+
+    cy.log("Does the material have authors?");
+    cy.contains("Af Dummy Jens Jensen");
+
+    cy.log("Does a material have a availibility label");
+    cy.contains("Dummy bog");
+    cy.contains("unavailable");
+
+    cy.log("Open material details");
+    cy.get("details").click({ multiple: true });
+
+    cy.log("Does the material have a editions with a buttton to reserve");
+    cy.contains("reserver");
+  });
+
+  beforeEach(() => {
+    cy.visit("/iframe.html?args=&id=apps-material--material");
+
+    // Intercept graphql search query.
+    cy.fixture("material/fbi-api.json")
+      .then((result) => {
+        cy.intercept("POST", "**/opac/graphql**", result);
+      })
+      .as("Graphql search query");
+
+    // Intercept covers.
+    cy.fixture("material/cover.json")
+      .then((result) => {
+        cy.intercept("GET", "**/api/v2/covers?**", result);
+      })
+      .as("Cover service");
+
+    // Intercept availability's service.
+    cy.fixture("material/availability.json")
+      .then((result) => {
+        cy.intercept("GET", "**/availability/v3?recordid=**", result);
+      })
+      .as("Availability service");
+
+    // Intercept like button
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+  });
+});
+
+export {};

--- a/src/core/dbc-gateway/graphql-fetcher.ts
+++ b/src/core/dbc-gateway/graphql-fetcher.ts
@@ -9,9 +9,12 @@ export const fetcher = <TData, TVariables>(
     // First version is with a library token.
     const libraryToken = getToken(TOKEN_LIBRARY_KEY);
 
-    if (!libraryToken) {
-      throw new Error("Library token is missing!");
-    }
+    const headers = {
+      "Content-Type": "application/json"
+    };
+    const authHeaders = libraryToken
+      ? ({ Authorization: `Bearer ${libraryToken}` } as object)
+      : {};
 
     const res = await fetch(
       // For now the endpoint is hardcoded. (although it is unclear which agency id to use)
@@ -22,8 +25,8 @@ export const fetcher = <TData, TVariables>(
         method: "POST",
         ...{
           headers: {
-            Authorization: `Bearer ${libraryToken}`,
-            "Content-Type": "application/json"
+            ...headers,
+            ...authHeaders
           }
         },
         body: JSON.stringify({ query, variables })


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-188

#### Description

This PR sets up a cypress test that checks the material app and it also fixes the pathname problem.

- The test uses mockup data to check if data is rendered in the right places

**This commit fixes the pathname bug 9306dfbfab7a8bcb0ac40c718358aaffdd32d7c9** 

#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-08-16 kl  09 55 31" src="https://user-images.githubusercontent.com/49920322/184827787-d2e84187-1334-4ab1-9e0d-b6fdf5f9e3b1.png">



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

