### PR TITLE
Update cover handling in Storybook

### DIFF
--- a/src/components/cover/cover.dev.tsx
+++ b/src/components/cover/cover.dev.tsx
@@ -4,7 +4,7 @@ import { Cover } from "./cover";
 import { getCurrentLocation } from "../../core/utils/helpers/url";
 
 export default {
-  title: "Atoms / Cover",
+  title: "Components / Cover",
   component: Cover,
   argTypes: {
     size: {

--- a/src/components/cover/cover.dev.tsx
+++ b/src/components/cover/cover.dev.tsx
@@ -33,10 +33,10 @@ export default {
     }
   },
   args: {
+    pid: "870970-basis:45234401",
     size: "small",
     animate: true,
     tint: "120",
-    pid: "870970-basis:45234401",
     url: new URL("/", getCurrentLocation()),
     description: "description"
   }

--- a/src/components/cover/cover.dev.tsx
+++ b/src/components/cover/cover.dev.tsx
@@ -19,8 +19,8 @@ export default {
       name: "Use animation",
       control: { type: "boolean" }
     },
-    materialId: {
-      name: "Material ID",
+    pid: {
+      name: "PID",
       control: { type: "text" }
     },
     url: {


### PR DESCRIPTION
#### Description

Update handling of pids for covers in Storybook

- Change materialId argument to pid. It was changed to `pid` for the component in 69daa5e5b77a88549cefdc19f8714d5ff8747343 so the `pid` control would appear anyway. Now it is just a matter of configuring the control
- Move the pid argument to the top
- Make the cover component a component instead of an atom

See individual commits for more commentary

#### Screenshot of the result

Before:

![Atoms : Cover - Item ⋅ Storybook 2022-08-15 16-35-14](https://user-images.githubusercontent.com/73966/184656279-51349aae-4558-4b82-a387-51f26d87b104.png)

After:

![Components : Cover - Item ⋅ Storybook 2022-08-15 16-33-54](https://user-images.githubusercontent.com/73966/184656319-2b616ae1-4ea3-4be5-a3de-6de136308b70.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
