### PR TITLE
Feature/link from search header to search results app + material app

### DIFF
--- a/src/apps/search-header/search-header.dev.tsx
+++ b/src/apps/search-header/search-header.dev.tsx
@@ -1,17 +1,14 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import * as React from "react";
 import StoryHeader from "../../components/search-bar/story-header.dev.inc";
-import SearchHeaderEntry, { SearchHeaderProps } from "./search-header.entry";
+import SearchHeaderEntry, {
+  SearchHeaderEntryProps
+} from "./search-header.entry";
 
 export default {
   title: "Apps / Search Header",
   component: SearchHeaderEntry,
   argTypes: {
-    searchHeaderUrlText: {
-      name: "Search header base URL",
-      defaultValue: "https://bibliotek.dk/search",
-      control: { type: "text" }
-    },
     altText: {
       name: "Alt text for search button image",
       defaultValue: "søgeikon",
@@ -36,12 +33,22 @@ export default {
       name: "String suggestion spec - topic",
       defaultValue: "emne",
       control: { type: "text" }
+    },
+    searchUrl: {
+      name: "Base search url",
+      defaultValue: "/search",
+      control: { type: "text" }
+    },
+    materialUrl: {
+      name: "Base material page url",
+      defaultValue: "/work/:workid",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof SearchHeaderEntry>;
 
 export const Default: ComponentStory<typeof SearchHeaderEntry> = (
-  args: SearchHeaderProps
+  args: SearchHeaderEntryProps
 ) => (
   // We use the Header component as context to the search bar.
   // It is the Header that creates the Search bar's design -

--- a/src/apps/search-header/search-header.entry.tsx
+++ b/src/apps/search-header/search-header.entry.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { withText } from "../../core/utils/text";
+import { withUrls } from "../../core/utils/url";
 import SearchHeader from "./search-header";
 
-export interface SearchHeaderProps {
-  searchHeaderUrlText?: string;
+export interface SearchHeaderTextProps {
   altText?: string;
   inputPlaceholderText?: string;
   stringSuggestionAuthorText?: string;
@@ -12,14 +12,24 @@ export interface SearchHeaderProps {
   etAlText?: string;
 }
 
-const SearchHeaderEntry: React.FC<SearchHeaderProps> = ({
-  searchHeaderUrlText = "https://bibliotek.dk/search",
+export interface SearchHeaderUrlProps {
+  searchUrl: string;
+  materialUrl: string;
+}
+
+export interface SearchHeaderEntryProps
+  extends SearchHeaderTextProps,
+    SearchHeaderUrlProps {}
+
+const SearchHeaderEntry: React.FC<SearchHeaderEntryProps> = ({
   altText = "search icon",
   inputPlaceholderText = "Search here",
   stringSuggestionAuthorText = "author",
   stringSuggestionWorkText = "work",
   stringSuggestionTopicText = "topic",
   etAlText = "et al."
-}) => <SearchHeader />;
+}) => {
+  return <SearchHeader />;
+};
 
-export default withText(SearchHeaderEntry);
+export default withUrls(withText(SearchHeaderEntry));

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -33,7 +33,7 @@ const SearchHeader: React.FC = () => {
   } = useSuggestionsFromQueryStringQuery({ q });
   const { searchUrl, materialUrl } = useUrls();
 
-  // make sure to only assign the data once
+  // mMke sure to only assign the data once.
   useEffect(() => {
     if (data) {
       const arayOfResults = data.suggest.result;
@@ -60,7 +60,7 @@ const SearchHeader: React.FC = () => {
     orderedData = textData.concat(materialData);
   }
 
-  // autosuggest opening and closing based on input text length
+  // Autosuggest opening and closing based on input text length.
   useEffect(() => {
     if (q) {
       const minimalLengthQuery = 3;
@@ -103,20 +103,20 @@ const SearchHeader: React.FC = () => {
     setCurrentlySelectedItem(determineSuggestionTerm(selectedItem));
   }
 
-  // downshift prevents the default form submission event when the
-  // autosuggest is open - we have to simulate form sumbission
+  // Downshift prevents the default form submission event when the
+  // autosuggest is open - we have to simulate form sumbission.
   function manualRedirect(
     currentSelectedSuggestion: Suggestion,
     materialId?: WorkId
   ) {
     let redirectUrl: URL;
-    // work suggestion redirect
+    // Work suggestion redirect.
     if (materialId) {
       redirectUrl = constructMaterialUrl(materialUrl, materialId as WorkId);
       redirectTo(redirectUrl);
       return;
     }
-    // not a work suggestion redirect
+    // Not a work suggestion redirect.
     redirectUrl = constructSearchUrl(
       searchUrl,
       determineSuggestionTerm(currentSelectedSuggestion)
@@ -129,14 +129,14 @@ const SearchHeader: React.FC = () => {
   ) {
     const { type } = changes;
     let { highlightedIndex } = changes;
-    // don't do aything for mouse events
+    // Don't do aything for mouse events.
     if (
       type === useCombobox.stateChangeTypes.ItemMouseMove ||
       type === useCombobox.stateChangeTypes.MenuMouseLeave
     ) {
       return;
     }
-    // close autosuggest if there is no highlighted index
+    // Close autosuggest if there is no highlighted index.
     if (highlightedIndex && highlightedIndex < 0) {
       setIsAutosuggestOpen(false);
       return;
@@ -189,7 +189,7 @@ const SearchHeader: React.FC = () => {
     manualRedirect(selectedItem);
   }
 
-  // this is the main Downshift hook
+  // This is the main Downshift hook.
   const {
     getMenuProps,
     highlightedIndex,

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -170,15 +170,18 @@ const SearchHeader: React.FC = () => {
       return;
     }
     setQWithoutQuery(inputValue);
+    // Escape if there is no selected item defined.
     if (!selectedItem) {
       return;
     }
+    // Nothing happens if this is not a mouse click or enter click.
     if (
       type !== useCombobox.stateChangeTypes.ItemClick &&
       type !== useCombobox.stateChangeTypes.InputKeyDownEnter
     ) {
       return;
     }
+    // If this item is shown as one of work suggestions redirect to material page.
     if (
       selectedItem.work?.workId &&
       isDisplayedAsWorkSuggestion(selectedItem.work, materialData)
@@ -186,6 +189,7 @@ const SearchHeader: React.FC = () => {
       manualRedirect(selectedItem, selectedItem.work?.workId as WorkId);
       return;
     }
+    // Otherwise redirect to search result page.
     manualRedirect(selectedItem);
   }
 

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -103,27 +103,6 @@ const SearchHeader: React.FC = () => {
     setCurrentlySelectedItem(determineSuggestionTerm(selectedItem));
   }
 
-  // Downshift prevents the default form submission event when the
-  // autosuggest is open - we have to simulate form sumbission.
-  function manualRedirect(
-    currentSelectedSuggestion: Suggestion,
-    materialId?: WorkId
-  ) {
-    let redirectUrl: URL;
-    // Work suggestion redirect.
-    if (materialId) {
-      redirectUrl = constructMaterialUrl(materialUrl, materialId as WorkId);
-      redirectTo(redirectUrl);
-      return;
-    }
-    // Not a work suggestion redirect.
-    redirectUrl = constructSearchUrl(
-      searchUrl,
-      determineSuggestionTerm(currentSelectedSuggestion)
-    );
-    redirectTo(redirectUrl);
-  }
-
   function handleHighlightedIndexChange(
     changes: UseComboboxStateChange<Suggestion>
   ) {
@@ -186,11 +165,15 @@ const SearchHeader: React.FC = () => {
       selectedItem.work?.workId &&
       isDisplayedAsWorkSuggestion(selectedItem.work, materialData)
     ) {
-      manualRedirect(selectedItem, selectedItem.work?.workId as WorkId);
+      redirectTo(
+        constructMaterialUrl(materialUrl, selectedItem.work?.workId as WorkId)
+      );
       return;
     }
     // Otherwise redirect to search result page.
-    manualRedirect(selectedItem);
+    redirectTo(
+      constructSearchUrl(searchUrl, determineSuggestionTerm(selectedItem))
+    );
   }
 
   // This is the main Downshift hook.

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -33,7 +33,7 @@ const SearchHeader: React.FC = () => {
   } = useSuggestionsFromQueryStringQuery({ q });
   const { searchUrl, materialUrl } = useUrls();
 
-  // mMke sure to only assign the data once.
+  // Make sure to only assign the data once.
   useEffect(() => {
     if (data) {
       const arayOfResults = data.suggest.result;

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -81,9 +81,12 @@ const SearchHeader: React.FC = () => {
     return suggestion.term;
   }
 
-  function isDisplayedAsWorkSuggestion(selectedItem: Suggestion["work"]) {
-    for (let i = 0; i < materialData.length; i += 1) {
-      if (materialData[i].work?.workId === selectedItem?.workId) {
+  function isDisplayedAsWorkSuggestion(
+    selectedItem: Suggestion["work"],
+    currentMaterialData: Suggestion[]
+  ) {
+    for (let i = 0; i < currentMaterialData.length; i += 1) {
+      if (currentMaterialData[i].work?.workId === selectedItem?.workId) {
         return true;
       }
     }
@@ -178,7 +181,7 @@ const SearchHeader: React.FC = () => {
     }
     if (
       selectedItem.work?.workId &&
-      isDisplayedAsWorkSuggestion(selectedItem.work)
+      isDisplayedAsWorkSuggestion(selectedItem.work, materialData)
     ) {
       manualRedirect(selectedItem, selectedItem.work?.workId as WorkId);
       return;

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -145,13 +145,6 @@ const SearchHeader: React.FC = () => {
     const currentlyHighlightedObject = orderedData[arrayIndex];
     const currentItemValue = determinSuggestionTerm(currentlyHighlightedObject);
     if (
-      type === useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem
-    ) {
-      // not sure if we need this here
-      // manualRedirect(changes.selectedItem as Suggestion);
-      return;
-    }
-    if (
       type === useCombobox.stateChangeTypes.InputKeyDownArrowDown ||
       type === useCombobox.stateChangeTypes.InputKeyDownArrowUp
     ) {

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -8,20 +8,15 @@ import {
 import SearchBar from "../../components/search-bar/search-bar";
 import { Autosuggest } from "../../components/autosuggest/autosuggest";
 import { Suggestion } from "../../core/utils/types/autosuggest";
-import { useText } from "../../core/utils/text";
-import { itemToString } from "../../components/autosuggest-text/autosuggest-text";
-
-export interface SearchHeaderProps {
-  searchHeaderUrl?: string;
-  altText?: string;
-  inputPlaceholderText?: string;
-  stringSuggestionAuthorText?: string;
-  stringSuggestionWorkText?: string;
-  stringSuggestionTopicText?: string;
-}
+import { useUrls } from "../../core/utils/url";
+import {
+  constructMaterialUrl,
+  constructSearchUrl,
+  redirectTo
+} from "../../core/utils/helpers/url";
+import { WorkId } from "../../core/utils/types/ids";
 
 const SearchHeader: React.FC = () => {
-  const t = useText();
   const [q, setQ] = useState<string>("");
   const [qWithoutQuery, setQWithoutQuery] = useState<string>(q);
   const [suggestItems, setSuggestItems] = useState<any[]>([]);
@@ -36,6 +31,7 @@ const SearchHeader: React.FC = () => {
     isLoading: boolean;
     status: string;
   } = useSuggestionsFromQueryStringQuery({ q });
+  const { searchUrl, materialUrl } = useUrls();
 
   // make sure to only assign the data once
   useEffect(() => {
@@ -48,7 +44,6 @@ const SearchHeader: React.FC = () => {
   const textData: Suggestion[] = [];
   const materialData: Suggestion[] = [];
   let orderedData: SuggestionsFromQueryStringQuery["suggest"]["result"] = [];
-
   if (originalData) {
     originalData.forEach((item: Suggestion) => {
       if (
@@ -65,7 +60,7 @@ const SearchHeader: React.FC = () => {
     orderedData = textData.concat(materialData);
   }
 
-  // autosuggest dropdown opening and closing based on input text length
+  // autosuggest opening and closing based on input text length
   useEffect(() => {
     if (q) {
       const minimalLengthQuery = 3;
@@ -79,11 +74,20 @@ const SearchHeader: React.FC = () => {
     }
   }, [q]);
 
-  function determinSuggestionType(suggestion: Suggestion): string {
+  function determinSuggestionTerm(suggestion: Suggestion): string {
     if (suggestion.type === SuggestionType.Composit) {
       return suggestion.work?.titles.main[0] || "incomplete data";
     }
     return suggestion.term;
+  }
+
+  function isDisplayedAsWorkSuggestion(selectedItem: Suggestion["work"]) {
+    for (let i = 0; i < materialData.length; i += 1) {
+      if (materialData[i].work?.workId === selectedItem?.workId) {
+        return true;
+      }
+    }
+    return false;
   }
 
   function handleSelectedItemChange(
@@ -93,17 +97,28 @@ const SearchHeader: React.FC = () => {
     if (!selectedItem) {
       return;
     }
-    setCurrentlySelectedItem(determinSuggestionType(selectedItem));
+    setCurrentlySelectedItem(determinSuggestionTerm(selectedItem));
   }
 
-  // downshift prevents the default form submission event when the autosuggest
-  // is open - that's why in some cases we have to simulate form sumbission
-  function manualRedirect(inputValue: string) {
-    const baseUrl = t("searchHeaderUrlText");
-    const params = inputValue;
-    if (window.top) {
-      window.top.location.href = `${baseUrl}?q=${params}`;
+  // downshift prevents the default form submission event when the
+  // autosuggest is open - we have to simulate form sumbission
+  function manualRedirect(
+    currentSelectedSuggestion: Suggestion,
+    materialId?: WorkId
+  ) {
+    let redirectUrl: URL;
+    // work suggestion redirect
+    if (materialId) {
+      redirectUrl = constructMaterialUrl(materialUrl, materialId as WorkId);
+      redirectTo(redirectUrl);
+      return;
     }
+    // not a work suggestion redirect
+    redirectUrl = constructSearchUrl(
+      searchUrl,
+      determinSuggestionTerm(currentSelectedSuggestion)
+    );
+    redirectTo(redirectUrl);
   }
 
   function handleHighlightedIndexChange(
@@ -111,12 +126,14 @@ const SearchHeader: React.FC = () => {
   ) {
     const { type } = changes;
     let { highlightedIndex } = changes;
+    // don't do aything for mouse events
     if (
       type === useCombobox.stateChangeTypes.ItemMouseMove ||
       type === useCombobox.stateChangeTypes.MenuMouseLeave
     ) {
       return;
     }
+    // close autosuggest if there is no highlighted index
     if (highlightedIndex && highlightedIndex < 0) {
       setIsAutosuggestOpen(false);
       return;
@@ -126,11 +143,12 @@ const SearchHeader: React.FC = () => {
     }
     const arrayIndex: number = highlightedIndex;
     const currentlyHighlightedObject = orderedData[arrayIndex];
-    const currentItemValue = determinSuggestionType(currentlyHighlightedObject);
+    const currentItemValue = determinSuggestionTerm(currentlyHighlightedObject);
     if (
       type === useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem
     ) {
-      manualRedirect(currentItemValue);
+      // not sure if we need this here
+      // manualRedirect(changes.selectedItem as Suggestion);
       return;
     }
     if (
@@ -154,16 +172,25 @@ const SearchHeader: React.FC = () => {
       return;
     }
     setQWithoutQuery(inputValue);
-    if (
-      type === useCombobox.stateChangeTypes.ItemClick ||
-      type === useCombobox.stateChangeTypes.InputKeyDownEnter
-    ) {
-      if (!selectedItem) {
-        return;
-      }
-      manualRedirect(itemToString(selectedItem));
+    if (!selectedItem) {
+      return;
     }
+    if (
+      type !== useCombobox.stateChangeTypes.ItemClick &&
+      type !== useCombobox.stateChangeTypes.InputKeyDownEnter
+    ) {
+      return;
+    }
+    if (
+      selectedItem.work?.workId &&
+      isDisplayedAsWorkSuggestion(selectedItem.work)
+    ) {
+      manualRedirect(selectedItem, selectedItem.work?.workId as WorkId);
+      return;
+    }
+    manualRedirect(selectedItem);
   }
+
   // this is the main Downshift hook
   const {
     getMenuProps,
@@ -183,7 +210,10 @@ const SearchHeader: React.FC = () => {
   });
 
   return (
-    <form className="header__menu-second" action={t("searchHeaderUrlText")}>
+    <form
+      className="header__menu-second"
+      action={String(constructSearchUrl(searchUrl, qWithoutQuery))}
+    >
       {/* The downshift combobox uses prop spreading by design */}
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <div className="header__menu-search" {...getComboboxProps()}>

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -74,7 +74,7 @@ const SearchHeader: React.FC = () => {
     }
   }, [q]);
 
-  function determinSuggestionTerm(suggestion: Suggestion): string {
+  function determineSuggestionTerm(suggestion: Suggestion): string {
     if (suggestion.type === SuggestionType.Composit) {
       return suggestion.work?.titles.main[0] || "incomplete data";
     }
@@ -97,7 +97,7 @@ const SearchHeader: React.FC = () => {
     if (!selectedItem) {
       return;
     }
-    setCurrentlySelectedItem(determinSuggestionTerm(selectedItem));
+    setCurrentlySelectedItem(determineSuggestionTerm(selectedItem));
   }
 
   // downshift prevents the default form submission event when the
@@ -116,7 +116,7 @@ const SearchHeader: React.FC = () => {
     // not a work suggestion redirect
     redirectUrl = constructSearchUrl(
       searchUrl,
-      determinSuggestionTerm(currentSelectedSuggestion)
+      determineSuggestionTerm(currentSelectedSuggestion)
     );
     redirectTo(redirectUrl);
   }
@@ -143,7 +143,9 @@ const SearchHeader: React.FC = () => {
     }
     const arrayIndex: number = highlightedIndex;
     const currentlyHighlightedObject = orderedData[arrayIndex];
-    const currentItemValue = determinSuggestionTerm(currentlyHighlightedObject);
+    const currentItemValue = determineSuggestionTerm(
+      currentlyHighlightedObject
+    );
     if (
       type === useCombobox.stateChangeTypes.InputKeyDownArrowDown ||
       type === useCombobox.stateChangeTypes.InputKeyDownArrowUp

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -85,12 +85,10 @@ const SearchHeader: React.FC = () => {
     selectedItem: Suggestion["work"],
     currentMaterialData: Suggestion[]
   ) {
-    for (let i = 0; i < currentMaterialData.length; i += 1) {
-      if (currentMaterialData[i].work?.workId === selectedItem?.workId) {
-        return true;
-      }
-    }
-    return false;
+    const dataWithWorkId = currentMaterialData.filter(
+      (item) => item.work?.workId === selectedItem?.workId
+    );
+    return Boolean(dataWithWorkId.length);
   }
 
   function handleSelectedItemChange(

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -32,7 +32,7 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
           {/* The downshift combobox works this way by design (line 50) */}
           {/* incorrectIndex because in the whole of autosuggest dropdown it is
           not the correct index for the item. We first need to add the length of
-          items from autosuggest string suggestion to it for it to be accurate */}
+          items from autosuggest string suggestion to it for it to be accurate. */}
           {materialData.map((item, incorrectIndex) => {
             const index = incorrectIndex + textDataLength;
             const authors: string[] = [];

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -52,7 +52,6 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
                 {/* eslint-enable react/jsx-props-no-spreading */}
                 <div className="autosuggest__material__content">
                   <div className="autosuggest__cover">
-                    {/* TODO: once we have the material page and know what the urls look like, we need to pass materialUrl here */}
                     {item.work && (
                       <Cover
                         animate

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -15,7 +15,7 @@ import urlReducer from "./url.slice";
 const persistConfig = {
   key: "dpl-react",
   storage,
-  blacklist: ["text"]
+  blacklist: ["text", "url"]
 };
 
 export const store = configureStore({


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-185

#### Description
This PR makes sure that linking from the search header app to search result app/material app works when the apps are set into the CMS.  
The biggest challenge here was distinguishing between the different kinds of suggestion items. If it is one of the string suggestions - we redirect to the search result; if it is a material suggestion - we redirect to the material app page. 

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
