### PR TITLE
Use workid in material app

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -16,9 +16,9 @@ export default {
       defaultValue: "/work/:workid",
       control: { type: "text" }
     },
-    pid: {
-      name: "pid",
-      defaultValue: "870970-basis:52557240",
+    wid: {
+      name: "Work ID",
+      defaultValue: "work-of:870970-basis:52557240",
       control: { type: "text" }
     },
     materialHeaderAuthorByText: {

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { withText } from "../../core/utils/text";
-import { Pid } from "../../core/utils/types/ids";
+import { WorkId } from "../../core/utils/types/ids";
 import { withUrls } from "../../core/utils/url";
 import Material from "./material";
 
@@ -43,11 +43,11 @@ interface MaterialEntryUrlProps {
 export interface MaterialEntryProps
   extends MaterialEntryUrlProps,
     MaterialEntryTextProps {
-  pid: Pid;
+  wid: WorkId;
 }
 
-const MaterialEntry: React.FC<MaterialEntryProps> = ({ pid }) => {
-  return <Material pid={pid} />;
+const MaterialEntry: React.FC<MaterialEntryProps> = ({ wid }) => {
+  return <Material wid={wid} />;
 };
 
 export default withUrls(withText(MaterialEntry));

--- a/src/apps/material/material.graphql
+++ b/src/apps/material/material.graphql
@@ -1,5 +1,5 @@
-query getMaterial($pid: String!) {
-  work(pid: $pid) {
+query getMaterial($wid: String!) {
+  work(id: $wid) {
     ...WorkMedium
   }
 }

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -9,7 +9,7 @@ import {
   LibrariansReview,
   useGetMaterialQuery
 } from "../../core/dbc-gateway/generated/graphql";
-import { Pid } from "../../core/utils/types/ids";
+import { Pid, WorkId } from "../../core/utils/types/ids";
 import MaterialDescription from "../../components/material/MaterialDescription";
 import Disclosure from "../../components/material/disclosures/disclosure";
 import { MaterialReviews } from "../../components/material/MaterialReviews";
@@ -21,17 +21,18 @@ import { useText } from "../../core/utils/text";
 import {
   creatorsToString,
   filterCreators,
-  flattenCreators
+  flattenCreators,
+  getManifestationPid
 } from "../../core/utils/helpers/general";
 
 export interface MaterialProps {
-  pid: Pid;
+  wid: WorkId;
 }
 
-const Material: React.FC<MaterialProps> = ({ pid }) => {
+const Material: React.FC<MaterialProps> = ({ wid }) => {
   const t = useText();
   const { data, isLoading } = useGetMaterialQuery({
-    pid
+    wid
   });
 
   if (isLoading) {
@@ -52,6 +53,10 @@ const Material: React.FC<MaterialProps> = ({ pid }) => {
     workYear
   } = data.work;
 
+  // TODO: Temporary way to get a pid we can use for showing a cover for the material.
+  // It should be replaced with some dynamic feature
+  // that follows the current type of the material.
+  const pid = getManifestationPid(manifestations) as Pid;
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t
@@ -86,7 +91,7 @@ const Material: React.FC<MaterialProps> = ({ pid }) => {
 
   return (
     <main className="material-page">
-      <MaterialHeader pid={pid} work={data.work} />
+      <MaterialHeader wid={wid} work={data.work} />
       <MaterialDescription pid={pid} work={data.work} />
       <Disclosure
         mainIconPath={VariousIcon}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -3,7 +3,8 @@ import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
 import {
   creatorsToString,
   filterCreators,
-  flattenCreators
+  flattenCreators,
+  getManifestationPid
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { Pid, WorkId } from "../../core/utils/types/ids";
@@ -16,18 +17,17 @@ import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
 
 interface MaterialHeaderProps {
-  pid: Pid;
+  wid: WorkId;
   work: WorkMediumFragment;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
-  pid,
   work: {
     titles: { full: fullTitle },
     creators,
     manifestations,
     mainLanguages,
-    workId
+    workId: wid
   }
 }) => {
   const t = useText();
@@ -37,6 +37,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     t
   );
 
+  // TODO: Temporary way to get a pid we can use for showing a cover for the material.
+  // It should be replaced with some dynamic feature
+  // that follows the current type of the material.
+  const pid = getManifestationPid(manifestations) as Pid;
   const author = creatorsText || "[Creators are missing]";
 
   const containsDanish = mainLanguages.some((language) =>
@@ -55,11 +59,11 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <Cover pid={pid} size="xlarge" animate={false} />
       </div>
       <div className="material-header__content">
-        <ButtonFavourite id={workId as WorkId} />
+        <ButtonFavourite id={wid as WorkId} />
         <MaterialHeaderText title={String(title)} author={author} />
         <div className="material-header__availability-label">
           <AvailabiltityLabels
-            workId={workId as WorkId}
+            workId={wid as WorkId}
             manifestations={manifestations}
           />
         </div>

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -856,6 +856,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DidYouMean",
+        "description": null,
+        "fields": [
+          {
+            "name": "query",
+            "description": "An alternative query",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "score",
+            "description": "A probability score between 0-1 indicating how relevant the query is",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DigitalArticleService",
         "description": null,
         "fields": [
@@ -1381,6 +1424,150 @@
           {
             "name": "NOT_SPECIFIED",
             "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "HoldingsFilters",
+        "description": "Holdings Filters",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "branchId",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "department",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "HoldingsStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sublocation",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "HoldingsStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "OnLoan",
+            "description": "Holding is on loan",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OnShelf",
+            "description": "Holding is physically available at the branch",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -4845,6 +5032,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "holdingsFilters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "HoldingsFilters",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "q",
                 "description": null,
                 "type": {
@@ -5789,6 +5988,30 @@
         "name": "SearchResponse",
         "description": "The simple search response",
         "fields": [
+          {
+            "name": "didYouMean",
+            "description": "A list of alternative search queries",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DidYouMean",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "facets",
             "description": "Make sure only to fetch this when needed\nThis may take seconds to complete",

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -149,6 +149,14 @@ export type Dk5MainEntry = {
   display: Scalars["String"];
 };
 
+export type DidYouMean = {
+  __typename?: "DidYouMean";
+  /** An alternative query */
+  query: Scalars["String"];
+  /** A probability score between 0-1 indicating how relevant the query is */
+  score: Scalars["Float"];
+};
+
 export type DigitalArticleService = {
   __typename?: "DigitalArticleService";
   /** Issn which can be used to order article through Digital Article Service */
@@ -242,6 +250,22 @@ export enum FictionNonfictionCode {
   Fiction = "FICTION",
   Nonfiction = "NONFICTION",
   NotSpecified = "NOT_SPECIFIED"
+}
+
+/** Holdings Filters */
+export type HoldingsFilters = {
+  branchId?: InputMaybe<Array<Scalars["String"]>>;
+  department?: InputMaybe<Array<Scalars["String"]>>;
+  location?: InputMaybe<Array<Scalars["String"]>>;
+  status?: InputMaybe<Array<HoldingsStatus>>;
+  sublocation?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+export enum HoldingsStatus {
+  /** Holding is on loan */
+  OnLoan = "OnLoan",
+  /** Holding is physically available at the branch */
+  OnShelf = "OnShelf"
 }
 
 export type HostPublication = {
@@ -736,6 +760,7 @@ export type QueryRisArgs = {
 
 export type QuerySearchArgs = {
   filters?: InputMaybe<SearchFilters>;
+  holdingsFilters?: InputMaybe<HoldingsFilters>;
   q: SearchQuery;
 };
 
@@ -854,6 +879,8 @@ export type SearchQuery = {
 /** The simple search response */
 export type SearchResponse = {
   __typename?: "SearchResponse";
+  /** A list of alternative search queries */
+  didYouMean: Array<DidYouMean>;
   /**
    * Make sure only to fetch this when needed
    * This may take seconds to complete
@@ -1081,7 +1108,7 @@ export type GetMaterialManifestationQuery = {
 };
 
 export type GetMaterialQueryVariables = Exact<{
-  pid: Scalars["String"];
+  wid: Scalars["String"];
 }>;
 
 export type GetMaterialQuery = {
@@ -1804,8 +1831,8 @@ export const useGetMaterialManifestationQuery = <
     options
   );
 export const GetMaterialDocument = `
-    query getMaterial($pid: String!) {
-  work(pid: $pid) {
+    query getMaterial($wid: String!) {
+  work(id: $wid) {
     ...WorkMedium
   }
 }


### PR DESCRIPTION

#### Description

Since we have decided to use full work id when using the material app we need to change the inner workings, query etc.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
As it is now we use the newest manifestation pid as the pid for choosing cover etc. That will change when we have implemented using the type parameter