### PR TITLE
Linkability from material page to search results & material page

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-8f548e9376ece739167bb871359d5cc1b039f8d6",
+    "@danskernesdigitalebibliotek/dpl-design-system": "1.6.0",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/components/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { constructSearchUrl } from "../../core/utils/helpers/url";
-import { useUrls } from "../../core/utils/url";
 import { Link } from "../atoms/link";
 
 export interface HorizontalTermLineProps {
   title: string;
   subTitle?: string;
-  linkList: string[];
+  linkList: {
+    url: URL;
+    term: string;
+  }[];
 }
 
 const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
@@ -14,8 +15,6 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   subTitle,
   linkList
 }) => {
-  const { searchUrl } = useUrls();
-
   return (
     <div className="text-small-caption horizontal-term-line">
       <p className="text-label-bold">
@@ -25,13 +24,11 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
         )}
       </p>
 
-      {linkList.map((term) => {
-        const termUrl = constructSearchUrl(searchUrl, term);
-
+      {linkList.map((item) => {
         return (
-          <span key={term}>
-            <Link href={termUrl} className="link-tag">
-              {term}
+          <span key={item.term}>
+            <Link href={item.url} className="link-tag">
+              {item.term}
             </Link>
           </span>
         );

--- a/src/components/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/components/horizontal-term-line/HorizontalTermLine.tsx
@@ -25,10 +25,11 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
       </p>
 
       {linkList.map((item) => {
+        const { term, url } = item;
         return (
-          <span key={item.term}>
-            <Link href={item.url} className="link-tag">
-              {item.term}
+          <span key={term}>
+            <Link href={url} className="link-tag">
+              {term}
             </Link>
           </span>
         );

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
+import {
+  constructMaterialUrl,
+  constructSearchUrl
+} from "../../core/utils/helpers/url";
 import { useText } from "../../core/utils/text";
-import { Pid } from "../../core/utils/types/ids";
+import { Pid, WorkId } from "../../core/utils/types/ids";
+import { useUrls } from "../../core/utils/url";
 import HorizontalTermLine from "../horizontal-term-line/HorizontalTermLine";
 
 export interface MaterialDescriptionProps {
@@ -11,11 +16,20 @@ export interface MaterialDescriptionProps {
 
 const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
   const t = useText();
+  const { searchUrl, materialUrl } = useUrls();
   const inSeries = work.series;
-  const seriesMembersList = work.seriesMembers.map(
-    (item) => item.titles.main[0]
-  );
-  const subjectsList = work.subjects.all.map((item) => item.display);
+  const seriesMembersList = work.seriesMembers.map((item) => {
+    return {
+      url: constructMaterialUrl(materialUrl, item.workId as WorkId),
+      term: item.titles.main[0]
+    };
+  });
+  const subjectsList = work.subjects.all.map((item) => {
+    return {
+      url: constructSearchUrl(searchUrl, item.display),
+      term: item.display
+    };
+  });
   const { fictionNonfiction } = work;
 
   return (
@@ -35,7 +49,12 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
                   seriesItem.numberInSeries?.number
                 }`}
                 subTitle={t("inSeriesText")}
-                linkList={[seriesItem.title]}
+                linkList={[
+                  {
+                    url: constructSearchUrl(searchUrl, seriesItem.title),
+                    term: seriesItem.title
+                  }
+                ]}
               />
             );
           })}
@@ -54,7 +73,12 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
         {fictionNonfiction && (
           <HorizontalTermLine
             title={t("fictionNonfictionText")}
-            linkList={[fictionNonfiction.display]}
+            linkList={[
+              {
+                url: constructSearchUrl(searchUrl, fictionNonfiction.display),
+                term: fictionNonfiction.display
+              }
+            ]}
           />
         )}
       </div>

--- a/src/components/material/MaterialHeaderText.tsx
+++ b/src/components/material/MaterialHeaderText.tsx
@@ -1,5 +1,8 @@
 import React from "react";
+import { constructSearchUrl } from "../../core/utils/helpers/url";
 import { useText } from "../../core/utils/text";
+import { useUrls } from "../../core/utils/url";
+import { LinkNoStyle } from "../atoms/link-no-style";
 
 interface MaterialHeaderTextProps {
   title: string;
@@ -11,13 +14,18 @@ const MaterialHeaderText: React.FC<MaterialHeaderTextProps> = ({
   author
 }) => {
   const t = useText();
-
+  const { searchUrl } = useUrls();
   return (
     <>
       <h1 className="text-header-h1 mb-16">{title}</h1>
       <p className="text-body-large">
         <span>{t("materialHeaderAuthorByText")} </span>
-        {author}
+        <LinkNoStyle
+          url={constructSearchUrl(searchUrl, author)}
+          className="arrow__link"
+        >
+          {author}
+        </LinkNoStyle>
       </p>
     </>
   );

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -19,6 +19,7 @@ import HorizontalTermLine from "../../horizontal-term-line/HorizontalTermLine";
 import { useUrls } from "../../../core/utils/url";
 import {
   constructMaterialUrl,
+  constructSearchUrl,
   redirectTo
 } from "../../../core/utils/helpers/url";
 
@@ -38,7 +39,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   coverTint
 }) => {
   const t = useText();
-  const { materialUrl } = useUrls();
+  const { materialUrl, searchUrl } = useUrls();
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t
@@ -87,7 +88,12 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
                 numberInSeries.number?.[0]
               }`}
               subTitle={t("inSeriesText")}
-              linkList={[seriesTitle]}
+              linkList={[
+                {
+                  url: constructSearchUrl(searchUrl, seriesTitle),
+                  term: seriesTitle
+                }
+              ]}
             />
           )}
         </div>

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -72,6 +72,7 @@ fragment WorkSmall on Work {
     ...SeriesSimple
   }
   seriesMembers {
+    workId
     titles {
       main
       full

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -856,6 +856,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DidYouMean",
+        "description": null,
+        "fields": [
+          {
+            "name": "query",
+            "description": "An alternative query",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "score",
+            "description": "A probability score between 0-1 indicating how relevant the query is",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DigitalArticleService",
         "description": null,
         "fields": [
@@ -1381,6 +1424,150 @@
           {
             "name": "NOT_SPECIFIED",
             "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "HoldingsFilters",
+        "description": "Holdings Filters",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "branchId",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "department",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "HoldingsStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sublocation",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "HoldingsStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "OnLoan",
+            "description": "Holding is on loan",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OnShelf",
+            "description": "Holding is physically available at the branch",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -4845,6 +5032,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "holdingsFilters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "HoldingsFilters",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "q",
                 "description": null,
                 "type": {
@@ -5789,6 +5988,30 @@
         "name": "SearchResponse",
         "description": "The simple search response",
         "fields": [
+          {
+            "name": "didYouMean",
+            "description": "A list of alternative search queries",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DidYouMean",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "facets",
             "description": "Make sure only to fetch this when needed\nThis may take seconds to complete",

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -149,6 +149,14 @@ export type Dk5MainEntry = {
   display: Scalars["String"];
 };
 
+export type DidYouMean = {
+  __typename?: "DidYouMean";
+  /** An alternative query */
+  query: Scalars["String"];
+  /** A probability score between 0-1 indicating how relevant the query is */
+  score: Scalars["Float"];
+};
+
 export type DigitalArticleService = {
   __typename?: "DigitalArticleService";
   /** Issn which can be used to order article through Digital Article Service */
@@ -242,6 +250,22 @@ export enum FictionNonfictionCode {
   Fiction = "FICTION",
   Nonfiction = "NONFICTION",
   NotSpecified = "NOT_SPECIFIED"
+}
+
+/** Holdings Filters */
+export type HoldingsFilters = {
+  branchId?: InputMaybe<Array<Scalars["String"]>>;
+  department?: InputMaybe<Array<Scalars["String"]>>;
+  location?: InputMaybe<Array<Scalars["String"]>>;
+  status?: InputMaybe<Array<HoldingsStatus>>;
+  sublocation?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+export enum HoldingsStatus {
+  /** Holding is on loan */
+  OnLoan = "OnLoan",
+  /** Holding is physically available at the branch */
+  OnShelf = "OnShelf"
 }
 
 export type HostPublication = {
@@ -736,6 +760,7 @@ export type QueryRisArgs = {
 
 export type QuerySearchArgs = {
   filters?: InputMaybe<SearchFilters>;
+  holdingsFilters?: InputMaybe<HoldingsFilters>;
   q: SearchQuery;
 };
 
@@ -854,6 +879,8 @@ export type SearchQuery = {
 /** The simple search response */
 export type SearchResponse = {
   __typename?: "SearchResponse";
+  /** A list of alternative search queries */
+  didYouMean: Array<DidYouMean>;
   /**
    * Make sure only to fetch this when needed
    * This may take seconds to complete
@@ -1165,6 +1192,7 @@ export type GetMaterialQuery = {
     }>;
     seriesMembers: Array<{
       __typename?: "Work";
+      workId: string;
       titles: {
         __typename?: "WorkTitles";
         main: Array<string>;
@@ -1276,6 +1304,7 @@ export type SearchWithPaginationQuery = {
       }>;
       seriesMembers: Array<{
         __typename?: "Work";
+        workId: string;
         titles: {
           __typename?: "WorkTitles";
           main: Array<string>;
@@ -1449,6 +1478,7 @@ export type WorkSmallFragment = {
   }>;
   seriesMembers: Array<{
     __typename?: "Work";
+    workId: string;
     titles: {
       __typename?: "WorkTitles";
       main: Array<string>;
@@ -1576,6 +1606,7 @@ export type WorkMediumFragment = {
   }>;
   seriesMembers: Array<{
     __typename?: "Work";
+    workId: string;
     titles: {
       __typename?: "WorkTitles";
       main: Array<string>;
@@ -1705,6 +1736,7 @@ export const WorkSmallFragmentDoc = `
     ...SeriesSimple
   }
   seriesMembers {
+    workId
     titles {
       main
       full

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -15,7 +15,7 @@ import urlReducer from "./url.slice";
 const persistConfig = {
   key: "dpl-react",
   storage,
-  blacklist: ["text"]
+  blacklist: ["text", "url"]
 };
 
 export const store = configureStore({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-8f548e9376ece739167bb871359d5cc1b039f8d6":
-  version "0.0.0-8f548e9376ece739167bb871359d5cc1b039f8d6"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-8f548e9376ece739167bb871359d5cc1b039f8d6/1de15e2071c2dd0e68101b89e857987de7f42a77#1de15e2071c2dd0e68101b89e857987de7f42a77"
-  integrity sha512-fTaKCWbDEjecHaViaQ75sFWjreyIPoDnNAGn6scxeMMLnPLbx0cBeXo6ZwBS7gFYPB0hFfsdF25moc+KCJHRkA==
+"@danskernesdigitalebibliotek/dpl-design-system@1.6.0":
+  version "1.6.0"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/1.6.0/926476ede21addafd9b17d129126c21f4908954d#926476ede21addafd9b17d129126c21f4908954d"
+  integrity sha512-huMFJacLRbnCQZ01KaNn00vXokScfJyDBhAz+wt7qh/MGeDkM9b9J9uZ57h2hnWp00gBzsBTsw0OcheFcfH8KA==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-187
![image](https://user-images.githubusercontent.com/28546954/185112471-cc9ca958-0379-4c50-9be1-c3b133dab4dd.png)
-> refers to image below
![image](https://user-images.githubusercontent.com/28546954/185112868-441e9684-83d9-420e-b371-539da706b8ee.png)

#### Description
This PR adjust the Horizontal Term Line component (that's all those underscored lines of text on image above) to not create links itself, but instead receives them ready made. This "dumb-ifying" of the component lets us decide where to redirect before calling the component. ("I samme serie" items redirect to material page, as opposed to the rest.)
Minor updates to the graphQL schema adding workId as one of the keys for the array of "in the same series as". We need the WorkId to create links to material page.

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
