### PR TITLE
Select work manifestation 

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,11 +1,11 @@
 import {
-  ManifestationsSimpleFragment,
+  ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import { orderManifestationsByYear } from "../../core/utils/helpers/general";
 
 export const getManifestationType = (
-  manifestation: ManifestationsSimpleFragment["latest"] | undefined
+  manifestation: ManifestationsSimpleFieldsFragment | undefined
 ) => String(manifestation?.materialTypes?.[0]?.specific);
 
 export const getWorkManifestation = (work: WorkMediumFragment) => {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,0 +1,26 @@
+import {
+  ManifestationsSimpleFragment,
+  WorkMediumFragment
+} from "../../core/dbc-gateway/generated/graphql";
+import { orderManifestationsByYear } from "../../core/utils/helpers/general";
+
+export const getManifestationType = (
+  manifestation: ManifestationsSimpleFragment["latest"] | undefined
+) => String(manifestation?.materialTypes?.[0]?.specific);
+
+export const getWorkManifestation = (work: WorkMediumFragment) => {
+  return work.manifestations.latest;
+};
+
+export const getManifestationFromType = (
+  type: string,
+  work: WorkMediumFragment
+) => {
+  const allManifestations = orderManifestationsByYear(work.manifestations);
+
+  const allManifestationsThatMatchType = allManifestations.filter(
+    (item) => getManifestationType(item) === type
+  );
+
+  return allManifestationsThatMatchType[0];
+};

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -121,6 +121,11 @@ export default {
       defaultValue: "Detaljer",
       control: { type: "text" }
     },
+    reviewsText: {
+      name: "Reviews",
+      defaultValue: "Anmeldelser",
+      control: { type: "text" }
+    },
     typeText: {
       name: "Type",
       defaultValue: "Type",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -24,6 +24,7 @@ interface MaterialEntryTextProps {
   reserveText: string;
   editionsText: string;
   detailsText: string;
+  reviewsText: string;
   typeText: string;
   languageText: string;
   contributorsText: string;

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -117,7 +117,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         />
       </Disclosure>
       {data.work.reviews && data.work.reviews.length >= 1 && (
-        <Disclosure title="Anmeldelser" mainIconPath={CreateIcon}>
+        <Disclosure title={t("reviewsText")} mainIconPath={CreateIcon}>
           <MaterialReviews
             listOfReviews={
               data.work.reviews as Array<

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -8,7 +8,7 @@ import {
   InfomediaReview,
   LibrariansReview,
   useGetMaterialQuery,
-  ManifestationsSimpleFragment
+  ManifestationsSimpleFieldsFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import { Pid, WorkId } from "../../core/utils/types/ids";
 import MaterialDescription from "../../components/material/MaterialDescription";
@@ -43,9 +43,8 @@ export interface MaterialProps {
 const Material: React.FC<MaterialProps> = ({ wid }) => {
   const t = useText();
 
-  const [currentManifestation, setCurrentManifestation] = useState<
-    ManifestationsSimpleFragment["latest"] | null
-  >(null);
+  const [currentManifestation, setCurrentManifestation] =
+    useState<ManifestationsSimpleFieldsFragment | null>(null);
 
   const { data, isLoading } = useGetMaterialQuery({
     wid
@@ -126,7 +125,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         wid={wid}
         work={data.work}
         manifestation={
-          currentManifestation as ManifestationsSimpleFragment["latest"]
+          currentManifestation as ManifestationsSimpleFieldsFragment
         }
         selectManifestationHandler={setCurrentManifestation}
       />

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -10,13 +10,15 @@ export interface AvailabilityLabelProps {
   selected?: boolean;
   url?: URL;
   faustIds: string[];
+  handleSelectManifestation?: () => void | undefined;
 }
 
 export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   manifestText,
   selected = false,
   url,
-  faustIds
+  faustIds,
+  handleSelectManifestation
 }) => {
   const t = useText();
   const { data, isLoading, isError } = useGetAvailabilityV3({
@@ -53,7 +55,13 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   };
 
   const availabilityLabel = (
-    <div className={classes.parent}>
+    <div
+      className={classes.parent}
+      onClick={handleSelectManifestation ?? undefined}
+      onKeyPress={handleSelectManifestation ?? undefined}
+      role="button"
+      tabIndex={0}
+    >
       <div className={classes.triangle} />
       <img className={classes.check} src={CheckIcon} alt="check-icon" />
       <p className="text-label-semibold ml-24">{manifestText}</p>
@@ -62,7 +70,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     </div>
   );
 
-  return url ? (
+  return url && !handleSelectManifestation ? (
     <LinkNoStyle url={url}>{availabilityLabel}</LinkNoStyle>
   ) : (
     availabilityLabel

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { getManifestationType } from "../../apps/material/helper";
-import { ManifestationsSimpleFragment } from "../../core/dbc-gateway/generated/graphql";
+import {
+  ManifestationsSimpleFieldsFragment,
+  ManifestationsSimpleFragment
+} from "../../core/dbc-gateway/generated/graphql";
 import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
@@ -13,9 +16,9 @@ import { AvailabilityLabel } from "./availability-label";
 export interface AvailabilityLabelsProps {
   manifestations: ManifestationsSimpleFragment;
   workId: WorkId;
-  manifestation?: ManifestationsSimpleFragment["latest"];
+  manifestation?: ManifestationsSimpleFieldsFragment;
   selectManifestationHandler?: (
-    manifestation: ManifestationsSimpleFragment["latest"]
+    manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
 }
 

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,7 +1,11 @@
 import React from "react";
+import { getManifestationType } from "../../apps/material/helper";
 import { ManifestationsSimpleFragment } from "../../core/dbc-gateway/generated/graphql";
 import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
-import { constructMaterialUrl } from "../../core/utils/helpers/url";
+import {
+  constructMaterialUrl,
+  setQueryParametersInUrl
+} from "../../core/utils/helpers/url";
 import { Pid, WorkId } from "../../core/utils/types/ids";
 import { useUrls } from "../../core/utils/url";
 import { AvailabilityLabel } from "./availability-label";
@@ -9,18 +13,24 @@ import { AvailabilityLabel } from "./availability-label";
 export interface AvailabilityLabelsProps {
   manifestations: ManifestationsSimpleFragment;
   workId: WorkId;
+  manifestation?: ManifestationsSimpleFragment["latest"];
+  selectManifestationHandler?: (
+    manifestation: ManifestationsSimpleFragment["latest"]
+  ) => void;
 }
 
 export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
   manifestations,
-  workId
+  workId,
+  manifestation,
+  selectManifestationHandler
 }) => {
   const { materialUrl } = useUrls();
 
   return (
     <>
-      {manifestations.all.map((manifestation) => {
-        const { pid, materialTypes } = manifestation;
+      {manifestations.all.map((item) => {
+        const { pid, materialTypes } = item;
         const materialType = materialTypes[0].specific;
         const faustId = convertPostIdToFaustId(pid as Pid);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
@@ -29,13 +39,23 @@ export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
           return null;
         }
 
-        // TODO: Make AvailabilityLabel use URL object instead of string.
         return (
           <AvailabilityLabel
             key={pid}
             url={url}
             faustIds={[faustId]}
             manifestText={materialType}
+            selected={materialType === getManifestationType(manifestation)}
+            handleSelectManifestation={
+              selectManifestationHandler
+                ? () => {
+                    selectManifestationHandler(item);
+                    setQueryParametersInUrl({
+                      type: materialType
+                    });
+                  }
+                : undefined
+            }
           />
         );
       })}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
+import {
+  ManifestationsSimpleFragment,
+  WorkMediumFragment
+} from "../../core/dbc-gateway/generated/graphql";
 import {
   creatorsToString,
   filterCreators,
@@ -19,6 +22,10 @@ import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
 interface MaterialHeaderProps {
   wid: WorkId;
   work: WorkMediumFragment;
+  manifestation?: ManifestationsSimpleFragment["latest"];
+  selectManifestationHandler: (
+    manifestation: ManifestationsSimpleFragment["latest"]
+  ) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -28,7 +35,9 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     manifestations,
     mainLanguages,
     workId: wid
-  }
+  },
+  manifestation,
+  selectManifestationHandler
 }) => {
   const t = useText();
 
@@ -65,6 +74,8 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           <AvailabiltityLabels
             workId={wid as WorkId}
             manifestations={manifestations}
+            manifestation={manifestation}
+            selectManifestationHandler={selectManifestationHandler}
           />
         </div>
 

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  ManifestationsSimpleFragment,
+  ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import {
@@ -22,9 +22,9 @@ import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
 interface MaterialHeaderProps {
   wid: WorkId;
   work: WorkMediumFragment;
-  manifestation?: ManifestationsSimpleFragment["latest"];
+  manifestation?: ManifestationsSimpleFieldsFragment;
   selectManifestationHandler: (
-    manifestation: ManifestationsSimpleFragment["latest"]
+    manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
 }
 

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -11,13 +11,13 @@ import {
 } from "../../core/utils/helpers/general";
 import { Pid } from "../../core/utils/types/ids";
 import ButtonSmallFilled from "../Buttons/ButtonSmallFilled";
-import { ManifestationsSimpleFragment } from "../../core/dbc-gateway/generated/graphql";
+import { ManifestationsSimpleFieldsFragment } from "../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../core/utils/text";
 import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 
 export interface MaterialMainfestationItemProps {
-  manifestation: ManifestationsSimpleFragment["all"][0];
+  manifestation: ManifestationsSimpleFieldsFragment;
 }
 
 const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -44,6 +44,51 @@ fragment ManifestationsSimple on Manifestations {
       numberOfPages
     }
   }
+  latest {
+    pid
+    titles {
+      main
+      original
+    }
+    publicationYear {
+      display
+    }
+    materialTypes {
+      specific
+    }
+    creators {
+      display
+      __typename
+    }
+    hostPublication {
+      title
+      creator
+      publisher
+      year {
+        year
+      }
+    }
+    languages {
+      main {
+        display
+      }
+    }
+    identifiers {
+      value
+    }
+    contributors {
+      display
+    }
+    edition {
+      summary
+    }
+    audience {
+      generalAudience
+    }
+    physicalDescriptions {
+      numberOfPages
+    }
+  }
 }
 
 fragment SeriesSimple on Series {

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -1,51 +1,17 @@
+
+
 fragment ManifestationsSimple on Manifestations {
   all {
-    pid
-    titles {
-      main
-      original
-    }
-    publicationYear {
-      display
-    }
-    materialTypes {
-      specific
-    }
-    creators {
-      display
-      __typename
-    }
-    hostPublication {
-      title
-      creator
-      publisher
-      year {
-        year
-      }
-    }
-    languages {
-      main {
-        display
-      }
-    }
-    identifiers {
-      value
-    }
-    contributors {
-      display
-    }
-    edition {
-      summary
-    }
-    audience {
-      generalAudience
-    }
-    physicalDescriptions {
-      numberOfPages
-    }
+   ...ManifestationsSimpleFields
   }
   latest {
-    pid
+   ...ManifestationsSimpleFields
+  }
+}
+
+
+fragment ManifestationsSimpleFields on Manifestation {
+  pid
     titles {
       main
       original
@@ -88,7 +54,6 @@ fragment ManifestationsSimple on Manifestations {
     physicalDescriptions {
       numberOfPages
     }
-  }
 }
 
 fragment SeriesSimple on Series {

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -1441,117 +1441,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "HoldingsFilters",
-        "description": "Holdings Filters",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "branchId",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "department",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "location",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "HoldingsStatus",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sublocation",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "HoldingsStatus",
         "description": null,
@@ -5032,18 +4921,6 @@
                 "deprecationReason": null
               },
               {
-                "name": "holdingsFilters",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "HoldingsFilters",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "q",
                 "description": null,
                 "type": {
@@ -5740,6 +5617,26 @@
             "deprecationReason": null
           },
           {
+            "name": "branchId",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "childrenOrAdults",
             "description": null,
             "type": {
@@ -5761,6 +5658,26 @@
           },
           {
             "name": "creators",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "department",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -5840,6 +5757,26 @@
             "deprecationReason": null
           },
           {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "mainLanguages",
             "description": null,
             "type": {
@@ -5880,7 +5817,47 @@
             "deprecationReason": null
           },
           {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "HoldingsStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "subjects",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sublocation",
             "description": null,
             "type": {
               "kind": "LIST",

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -252,15 +252,6 @@ export enum FictionNonfictionCode {
   NotSpecified = "NOT_SPECIFIED"
 }
 
-/** Holdings Filters */
-export type HoldingsFilters = {
-  branchId?: InputMaybe<Array<Scalars["String"]>>;
-  department?: InputMaybe<Array<Scalars["String"]>>;
-  location?: InputMaybe<Array<Scalars["String"]>>;
-  status?: InputMaybe<Array<HoldingsStatus>>;
-  sublocation?: InputMaybe<Array<Scalars["String"]>>;
-};
-
 export enum HoldingsStatus {
   /** Holding is on loan */
   OnLoan = "OnLoan",
@@ -760,7 +751,6 @@ export type QueryRisArgs = {
 
 export type QuerySearchArgs = {
   filters?: InputMaybe<SearchFilters>;
-  holdingsFilters?: InputMaybe<HoldingsFilters>;
   q: SearchQuery;
 };
 
@@ -850,14 +840,19 @@ export enum SchoolUseCode {
 /** Search Filters */
 export type SearchFilters = {
   accessTypes?: InputMaybe<Array<Scalars["String"]>>;
+  branchId?: InputMaybe<Array<Scalars["String"]>>;
   childrenOrAdults?: InputMaybe<Array<Scalars["String"]>>;
   creators?: InputMaybe<Array<Scalars["String"]>>;
+  department?: InputMaybe<Array<Scalars["String"]>>;
   fictionNonfiction?: InputMaybe<Array<Scalars["String"]>>;
   fictionalCharacter?: InputMaybe<Array<Scalars["String"]>>;
   genreAndForm?: InputMaybe<Array<Scalars["String"]>>;
+  location?: InputMaybe<Array<Scalars["String"]>>;
   mainLanguages?: InputMaybe<Array<Scalars["String"]>>;
   materialTypes?: InputMaybe<Array<Scalars["String"]>>;
+  status?: InputMaybe<Array<HoldingsStatus>>;
   subjects?: InputMaybe<Array<Scalars["String"]>>;
+  sublocation?: InputMaybe<Array<Scalars["String"]>>;
   workTypes?: InputMaybe<Array<Scalars["String"]>>;
 };
 
@@ -1565,6 +1560,44 @@ export type ManifestationsSimpleFragment = {
   };
 };
 
+export type ManifestationsSimpleFieldsFragment = {
+  __typename?: "Manifestation";
+  pid: string;
+  titles: {
+    __typename?: "ManifestationTitles";
+    main: Array<string>;
+    original?: Array<string> | null;
+  };
+  publicationYear: { __typename?: "PublicationYear"; display: string };
+  materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+  creators: Array<
+    | { __typename: "Corporation"; display: string }
+    | { __typename: "Person"; display: string }
+  >;
+  hostPublication?: {
+    __typename?: "HostPublication";
+    title: string;
+    creator?: string | null;
+    publisher?: string | null;
+    year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+  } | null;
+  languages?: {
+    __typename?: "Languages";
+    main?: Array<{ __typename?: "Language"; display: string }> | null;
+  } | null;
+  identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+  contributors: Array<
+    | { __typename?: "Corporation"; display: string }
+    | { __typename?: "Person"; display: string }
+  >;
+  edition: { __typename?: "Edition"; summary: string };
+  audience?: { __typename?: "Audience"; generalAudience: Array<string> } | null;
+  physicalDescriptions: Array<{
+    __typename?: "PhysicalDescription";
+    numberOfPages?: number | null;
+  }>;
+};
+
 export type SeriesSimpleFragment = {
   __typename?: "Series";
   title: string;
@@ -1876,100 +1909,63 @@ export const SeriesSimpleFragmentDoc = `
   readThisWhenever
 }
     `;
-export const ManifestationsSimpleFragmentDoc = `
-    fragment ManifestationsSimple on Manifestations {
-  all {
-    pid
-    titles {
-      main
-      original
-    }
-    publicationYear {
-      display
-    }
-    materialTypes {
-      specific
-    }
-    creators {
-      display
-      __typename
-    }
-    hostPublication {
-      title
-      creator
-      publisher
-      year {
-        year
-      }
-    }
-    languages {
-      main {
-        display
-      }
-    }
-    identifiers {
-      value
-    }
-    contributors {
-      display
-    }
-    edition {
-      summary
-    }
-    audience {
-      generalAudience
-    }
-    physicalDescriptions {
-      numberOfPages
+export const ManifestationsSimpleFieldsFragmentDoc = `
+    fragment ManifestationsSimpleFields on Manifestation {
+  pid
+  titles {
+    main
+    original
+  }
+  publicationYear {
+    display
+  }
+  materialTypes {
+    specific
+  }
+  creators {
+    display
+    __typename
+  }
+  hostPublication {
+    title
+    creator
+    publisher
+    year {
+      year
     }
   }
-  latest {
-    pid
-    titles {
-      main
-      original
-    }
-    publicationYear {
+  languages {
+    main {
       display
     }
-    materialTypes {
-      specific
-    }
-    creators {
-      display
-      __typename
-    }
-    hostPublication {
-      title
-      creator
-      publisher
-      year {
-        year
-      }
-    }
-    languages {
-      main {
-        display
-      }
-    }
-    identifiers {
-      value
-    }
-    contributors {
-      display
-    }
-    edition {
-      summary
-    }
-    audience {
-      generalAudience
-    }
-    physicalDescriptions {
-      numberOfPages
-    }
+  }
+  identifiers {
+    value
+  }
+  contributors {
+    display
+  }
+  edition {
+    summary
+  }
+  audience {
+    generalAudience
+  }
+  physicalDescriptions {
+    numberOfPages
   }
 }
     `;
+export const ManifestationsSimpleFragmentDoc = `
+    fragment ManifestationsSimple on Manifestations {
+  all {
+    ...ManifestationsSimpleFields
+  }
+  latest {
+    ...ManifestationsSimpleFields
+  }
+}
+    ${ManifestationsSimpleFieldsFragmentDoc}`;
 export const WorkSmallFragmentDoc = `
     fragment WorkSmall on Work {
   workId

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -1244,6 +1244,49 @@ export type GetMaterialQuery = {
           numberOfPages?: number | null;
         }>;
       }>;
+      latest: {
+        __typename?: "Manifestation";
+        pid: string;
+        titles: {
+          __typename?: "ManifestationTitles";
+          main: Array<string>;
+          original?: Array<string> | null;
+        };
+        publicationYear: { __typename?: "PublicationYear"; display: string };
+        materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+        creators: Array<
+          | { __typename: "Corporation"; display: string }
+          | { __typename: "Person"; display: string }
+        >;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          title: string;
+          creator?: string | null;
+          publisher?: string | null;
+          year?: {
+            __typename?: "PublicationYear";
+            year?: number | null;
+          } | null;
+        } | null;
+        languages?: {
+          __typename?: "Languages";
+          main?: Array<{ __typename?: "Language"; display: string }> | null;
+        } | null;
+        identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+        contributors: Array<
+          | { __typename?: "Corporation"; display: string }
+          | { __typename?: "Person"; display: string }
+        >;
+        edition: { __typename?: "Edition"; summary: string };
+        audience?: {
+          __typename?: "Audience";
+          generalAudience: Array<string>;
+        } | null;
+        physicalDescriptions: Array<{
+          __typename?: "PhysicalDescription";
+          numberOfPages?: number | null;
+        }>;
+      };
     };
   } | null;
 };
@@ -1358,6 +1401,52 @@ export type SearchWithPaginationQuery = {
             numberOfPages?: number | null;
           }>;
         }>;
+        latest: {
+          __typename?: "Manifestation";
+          pid: string;
+          titles: {
+            __typename?: "ManifestationTitles";
+            main: Array<string>;
+            original?: Array<string> | null;
+          };
+          publicationYear: { __typename?: "PublicationYear"; display: string };
+          materialTypes: Array<{
+            __typename?: "MaterialType";
+            specific: string;
+          }>;
+          creators: Array<
+            | { __typename: "Corporation"; display: string }
+            | { __typename: "Person"; display: string }
+          >;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            title: string;
+            creator?: string | null;
+            publisher?: string | null;
+            year?: {
+              __typename?: "PublicationYear";
+              year?: number | null;
+            } | null;
+          } | null;
+          languages?: {
+            __typename?: "Languages";
+            main?: Array<{ __typename?: "Language"; display: string }> | null;
+          } | null;
+          identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+          contributors: Array<
+            | { __typename?: "Corporation"; display: string }
+            | { __typename?: "Person"; display: string }
+          >;
+          edition: { __typename?: "Edition"; summary: string };
+          audience?: {
+            __typename?: "Audience";
+            generalAudience: Array<string>;
+          } | null;
+          physicalDescriptions: Array<{
+            __typename?: "PhysicalDescription";
+            numberOfPages?: number | null;
+          }>;
+        };
       };
     }>;
   };
@@ -1434,6 +1523,46 @@ export type ManifestationsSimpleFragment = {
       numberOfPages?: number | null;
     }>;
   }>;
+  latest: {
+    __typename?: "Manifestation";
+    pid: string;
+    titles: {
+      __typename?: "ManifestationTitles";
+      main: Array<string>;
+      original?: Array<string> | null;
+    };
+    publicationYear: { __typename?: "PublicationYear"; display: string };
+    materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+    creators: Array<
+      | { __typename: "Corporation"; display: string }
+      | { __typename: "Person"; display: string }
+    >;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      title: string;
+      creator?: string | null;
+      publisher?: string | null;
+      year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    } | null;
+    languages?: {
+      __typename?: "Languages";
+      main?: Array<{ __typename?: "Language"; display: string }> | null;
+    } | null;
+    identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+    contributors: Array<
+      | { __typename?: "Corporation"; display: string }
+      | { __typename?: "Person"; display: string }
+    >;
+    edition: { __typename?: "Edition"; summary: string };
+    audience?: {
+      __typename?: "Audience";
+      generalAudience: Array<string>;
+    } | null;
+    physicalDescriptions: Array<{
+      __typename?: "PhysicalDescription";
+      numberOfPages?: number | null;
+    }>;
+  };
 };
 
 export type SeriesSimpleFragment = {
@@ -1525,6 +1654,46 @@ export type WorkSmallFragment = {
         numberOfPages?: number | null;
       }>;
     }>;
+    latest: {
+      __typename?: "Manifestation";
+      pid: string;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      publicationYear: { __typename?: "PublicationYear"; display: string };
+      materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string }
+        | { __typename: "Person"; display: string }
+      >;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        title: string;
+        creator?: string | null;
+        publisher?: string | null;
+        year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{ __typename?: "Language"; display: string }> | null;
+      } | null;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | { __typename?: "Corporation"; display: string }
+        | { __typename?: "Person"; display: string }
+      >;
+      edition: { __typename?: "Edition"; summary: string };
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+      } | null;
+      physicalDescriptions: Array<{
+        __typename?: "PhysicalDescription";
+        numberOfPages?: number | null;
+      }>;
+    };
   };
 };
 
@@ -1652,6 +1821,46 @@ export type WorkMediumFragment = {
         numberOfPages?: number | null;
       }>;
     }>;
+    latest: {
+      __typename?: "Manifestation";
+      pid: string;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      publicationYear: { __typename?: "PublicationYear"; display: string };
+      materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string }
+        | { __typename: "Person"; display: string }
+      >;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        title: string;
+        creator?: string | null;
+        publisher?: string | null;
+        year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{ __typename?: "Language"; display: string }> | null;
+      } | null;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | { __typename?: "Corporation"; display: string }
+        | { __typename?: "Person"; display: string }
+      >;
+      edition: { __typename?: "Edition"; summary: string };
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+      } | null;
+      physicalDescriptions: Array<{
+        __typename?: "PhysicalDescription";
+        numberOfPages?: number | null;
+      }>;
+    };
   };
 };
 
@@ -1670,6 +1879,51 @@ export const SeriesSimpleFragmentDoc = `
 export const ManifestationsSimpleFragmentDoc = `
     fragment ManifestationsSimple on Manifestations {
   all {
+    pid
+    titles {
+      main
+      original
+    }
+    publicationYear {
+      display
+    }
+    materialTypes {
+      specific
+    }
+    creators {
+      display
+      __typename
+    }
+    hostPublication {
+      title
+      creator
+      publisher
+      year {
+        year
+      }
+    }
+    languages {
+      main {
+        display
+      }
+    }
+    identifiers {
+      value
+    }
+    contributors {
+      display
+    }
+    edition {
+      summary
+    }
+    audience {
+      generalAudience
+    }
+    physicalDescriptions {
+      numberOfPages
+    }
+  }
+  latest {
     pid
     titles {
       main

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -69,7 +69,7 @@ export const getCreatorTextFromManifestations = (
   return creatorsToString(creators, t);
 };
 
-const getFirstPublishedManifestation = (
+export const getFirstPublishedManifestation = (
   manifestations: ManifestationsSimpleFragment
 ) => {
   const ordered = orderManifestationsByYear(manifestations);

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -17,7 +17,21 @@ export const appendQueryParametersToUrl = (
 
 export const getUrlQueryParam = (param: string): null | string => {
   const queryParams = new URLSearchParams(window.location.search);
-  return queryParams.get(param);
+
+  return queryParams.get(param)
+    ? decodeURI(String(queryParams.get(param)))
+    : null;
+};
+
+export const setQueryParametersInUrl = (parameters: {
+  [key: string]: string;
+}) => {
+  const processedUrl = new URL(getCurrentLocation());
+  Object.keys(parameters).forEach((key) => {
+    processedUrl.searchParams.set(key, parameters[key]);
+  });
+
+  window.history.replaceState(null, "", processedUrl);
 };
 
 export const redirectTo = (url: URL): void => {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-190

#### Description
This PR adds select work manifestation logic.

- Material type is now specified in the URL and will be set to first published manifestation if not. 
- A currentManifestation state has been added so that we can choose based on it how the material page should be displayed, for example, cover and buttons.
- Availability labels can be clicked on to change both state and URL
- Availability labels show as selected if the type of material text is the same

There is also added a translation of Reviews

#### Screenshot of the result
**type=Dummy+bog**
<img width="1728" alt="Skærmbillede 2022-08-22 kl  13 47 42" src="https://user-images.githubusercontent.com/49920322/185914176-3fbda3cb-9cf1-4380-8b65-e432db4d543b.png">
**type=e-bog**  (not selected)
<img width="1728" alt="Skærmbillede 2022-08-22 kl  13 47 35" src="https://user-images.githubusercontent.com/49920322/185914196-96e2306f-d0d1-478e-aca8-7a0ad29f704a.png">



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.


