### PR TITLE
Select work manifestation + Material cover change

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,0 +1,26 @@
+import {
+  ManifestationsSimpleFragment,
+  WorkMediumFragment
+} from "../../core/dbc-gateway/generated/graphql";
+import { orderManifestationsByYear } from "../../core/utils/helpers/general";
+
+export const getManifestationType = (
+  manifestation: ManifestationsSimpleFieldsFragment
+) => manifestation?.materialTypes?.[0]?.specific;
+
+export const getWorkManifestation = (work: WorkMediumFragment) => {
+  return work.manifestations.latest;
+};
+
+export const getManifestationFromType = (
+  type: string,
+  work: WorkMediumFragment
+) => {
+  const allManifestations = orderManifestationsByYear(work.manifestations);
+
+  const allManifestationsThatMatchType = allManifestations.filter(
+    (item) => getManifestationType(item) === type
+  );
+
+  return allManifestationsThatMatchType.shift();
+};

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,5 +1,5 @@
 import {
-  ManifestationsSimpleFragment,
+  ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import { orderManifestationsByYear } from "../../core/utils/helpers/general";

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -121,6 +121,11 @@ export default {
       defaultValue: "Detaljer",
       control: { type: "text" }
     },
+    reviewsText: {
+      name: "Reviews",
+      defaultValue: "Anmeldelser",
+      control: { type: "text" }
+    },
     typeText: {
       name: "Type",
       defaultValue: "Type",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -24,6 +24,7 @@ interface MaterialEntryTextProps {
   reserveText: string;
   editionsText: string;
   detailsText: string;
+  reviewsText: string;
   typeText: string;
   languageText: string;
   contributorsText: string;

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -117,7 +117,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         />
       </Disclosure>
       {data.work.reviews && data.work.reviews.length >= 1 && (
-        <Disclosure title="Anmeldelser" mainIconPath={CreateIcon}>
+        <Disclosure title={t("reviewsText")} mainIconPath={CreateIcon}>
           <MaterialReviews
             listOfReviews={
               data.work.reviews as Array<

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -10,7 +10,7 @@ import {
   useGetMaterialQuery,
   ManifestationsSimpleFieldsFragment
 } from "../../core/dbc-gateway/generated/graphql";
-import { Pid, WorkId } from "../../core/utils/types/ids";
+import { WorkId } from "../../core/utils/types/ids";
 import MaterialDescription from "../../components/material/MaterialDescription";
 import Disclosure from "../../components/material/disclosures/disclosure";
 import { MaterialReviews } from "../../components/material/MaterialReviews";
@@ -92,7 +92,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   // TODO: Temporary way to get a pid we can use for showing a cover for the material.
   // It should be replaced with some dynamic feature
   // that follows the current type of the material.
-  const pid = getManifestationPid(manifestations) as Pid;
+  const pid = getManifestationPid(manifestations);
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -8,7 +8,7 @@ import {
   InfomediaReview,
   LibrariansReview,
   useGetMaterialQuery,
-  ManifestationsSimpleFragment
+  ManifestationsSimpleFieldsFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import { Pid, WorkId } from "../../core/utils/types/ids";
 import MaterialDescription from "../../components/material/MaterialDescription";
@@ -43,9 +43,8 @@ export interface MaterialProps {
 const Material: React.FC<MaterialProps> = ({ wid }) => {
   const t = useText();
 
-  const [currentManifestation, setCurrentManifestation] = useState<
-    ManifestationsSimpleFragment["latest"] | null
-  >(null);
+  const [currentManifestation, setCurrentManifestation] =
+    useState<ManifestationsSimpleFieldsFragment | null>(null);
 
   const { data, isLoading } = useGetMaterialQuery({
     wid
@@ -128,7 +127,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         wid={wid}
         work={data.work}
         manifestation={
-          currentManifestation as ManifestationsSimpleFragment["latest"]
+          currentManifestation as ManifestationsSimpleFieldsFragment
         }
         selectManifestationHandler={setCurrentManifestation}
       />

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import VariousIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Various.svg";
 import CreateIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Create.svg";
 import Receipt from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Receipt.svg";
@@ -7,7 +7,8 @@ import {
   ExternalReview,
   InfomediaReview,
   LibrariansReview,
-  useGetMaterialQuery
+  useGetMaterialQuery,
+  ManifestationsSimpleFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import { Pid, WorkId } from "../../core/utils/types/ids";
 import MaterialDescription from "../../components/material/MaterialDescription";
@@ -25,6 +26,15 @@ import {
 import MaterialDetailsList, {
   ListData
 } from "../../components/material/MaterialDetailsList";
+import {
+  getUrlQueryParam,
+  setQueryParametersInUrl
+} from "../../core/utils/helpers/url";
+import {
+  getManifestationFromType,
+  getManifestationType,
+  getWorkManifestation
+} from "./helper";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -32,9 +42,35 @@ export interface MaterialProps {
 
 const Material: React.FC<MaterialProps> = ({ wid }) => {
   const t = useText();
+
+  const [currentManifestation, setCurrentManifestation] = useState<
+    ManifestationsSimpleFragment["latest"] | null
+  >(null);
+
   const { data, isLoading } = useGetMaterialQuery({
     wid
   });
+
+  // This useEffect selects the current manifestation
+  useEffect(() => {
+    if (!data?.work) return;
+    const { work } = data;
+    const type = getUrlQueryParam("type");
+    // if there is no type in the url, getWorkManifestation is used to set the state and url type parameters
+    if (!type) {
+      const workManifestation = getWorkManifestation(work);
+      setCurrentManifestation(workManifestation);
+      setQueryParametersInUrl({
+        type: getManifestationType(workManifestation)
+      });
+      return;
+    }
+    // if there is a type, getManifestationFromType will sort and filter all manifestation and choose the first one
+    const manifestationFromType = getManifestationFromType(type, work);
+    if (manifestationFromType) {
+      setCurrentManifestation(manifestationFromType);
+    }
+  }, [data]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -88,7 +124,14 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
 
   return (
     <main className="material-page">
-      <MaterialHeader wid={wid} work={data.work} />
+      <MaterialHeader
+        wid={wid}
+        work={data.work}
+        manifestation={
+          currentManifestation as ManifestationsSimpleFragment["latest"]
+        }
+        selectManifestationHandler={setCurrentManifestation}
+      />
       <MaterialDescription pid={pid} work={data.work} />
       <Disclosure
         mainIconPath={VariousIcon}

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -10,13 +10,15 @@ export interface AvailabilityLabelProps {
   selected?: boolean;
   url?: URL;
   faustIds: string[];
+  handleSelectManifestation?: () => void | undefined;
 }
 
 export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   manifestText,
   selected = false,
   url,
-  faustIds
+  faustIds,
+  handleSelectManifestation
 }) => {
   const t = useText();
   const { data, isLoading, isError } = useGetAvailabilityV3({
@@ -53,7 +55,13 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   };
 
   const availabilityLabel = (
-    <div className={classes.parent}>
+    <div
+      className={classes.parent}
+      onClick={handleSelectManifestation ?? undefined}
+      onKeyPress={handleSelectManifestation ?? undefined}
+      role="button"
+      tabIndex={0}
+    >
       <div className={classes.triangle} />
       <img className={classes.check} src={CheckIcon} alt="check-icon" />
       <p className="text-label-semibold ml-24">{manifestText}</p>
@@ -62,7 +70,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     </div>
   );
 
-  return url ? (
+  return url && !handleSelectManifestation ? (
     <LinkNoStyle url={url}>{availabilityLabel}</LinkNoStyle>
   ) : (
     availabilityLabel

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { getManifestationType } from "../../apps/material/helper";
-import { ManifestationsSimpleFragment } from "../../core/dbc-gateway/generated/graphql";
+import {
+  ManifestationsSimpleFieldsFragment,
+  ManifestationsSimpleFragment
+} from "../../core/dbc-gateway/generated/graphql";
 import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
@@ -13,9 +16,9 @@ import { AvailabilityLabel } from "./availability-label";
 export interface AvailabilityLabelsProps {
   manifestations: ManifestationsSimpleFragment;
   workId: WorkId;
-  manifestation?: ManifestationsSimpleFragment["latest"];
+  manifestation?: ManifestationsSimpleFieldsFragment;
   selectManifestationHandler?: (
-    manifestation: ManifestationsSimpleFragment["latest"]
+    manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
 }
 

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
+import {
+  ManifestationsSimpleFragment,
+  WorkMediumFragment
+} from "../../core/dbc-gateway/generated/graphql";
 import {
   creatorsToString,
   filterCreators,
@@ -19,6 +22,10 @@ import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
 interface MaterialHeaderProps {
   wid: WorkId;
   work: WorkMediumFragment;
+  manifestation?: ManifestationsSimpleFragment["latest"];
+  selectManifestationHandler: (
+    manifestation: ManifestationsSimpleFragment["latest"]
+  ) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -28,7 +35,9 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     manifestations,
     mainLanguages,
     workId: wid
-  }
+  },
+  manifestation,
+  selectManifestationHandler
 }) => {
   const t = useText();
 
@@ -65,6 +74,8 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           <AvailabiltityLabels
             workId={wid as WorkId}
             manifestations={manifestations}
+            manifestation={manifestation}
+            selectManifestationHandler={selectManifestationHandler}
           />
         </div>
 

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -46,10 +46,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     t
   );
 
-  // TODO: Temporary way to get a pid we can use for showing a cover for the material.
-  // It should be replaced with some dynamic feature
-  // that follows the current type of the material.
-  const pid = getManifestationPid(manifestations) as Pid;
   const author = creatorsText || "[Creators are missing]";
 
   const containsDanish = mainLanguages.some((language) =>
@@ -61,11 +57,13 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     .join(", ");
 
   const title = containsDanish ? fullTitle : `${fullTitle} (${allLanguages})`;
+  const coverPid =
+    (manifestation?.pid as Pid) || getManifestationPid(manifestations);
 
   return (
     <header className="material-header">
       <div className="material-header__cover">
-        <Cover pid={pid} size="xlarge" animate={false} />
+        <Cover pid={coverPid} size="xlarge" animate={false} />
       </div>
       <div className="material-header__content">
         <ButtonFavourite id={wid as WorkId} />

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  ManifestationsSimpleFragment,
+  ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
 import {
@@ -22,9 +22,9 @@ import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
 interface MaterialHeaderProps {
   wid: WorkId;
   work: WorkMediumFragment;
-  manifestation?: ManifestationsSimpleFragment["latest"];
+  manifestation?: ManifestationsSimpleFieldsFragment;
   selectManifestationHandler: (
-    manifestation: ManifestationsSimpleFragment["latest"]
+    manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
 }
 

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -63,7 +63,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   return (
     <header className="material-header">
       <div className="material-header__cover">
-        <Cover pid={coverPid} size="xlarge" animate={false} />
+        <Cover pid={coverPid} size="xlarge" animate />
       </div>
       <div className="material-header__content">
         <ButtonFavourite id={wid as WorkId} />

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -11,13 +11,13 @@ import {
 } from "../../core/utils/helpers/general";
 import { Pid } from "../../core/utils/types/ids";
 import ButtonSmallFilled from "../Buttons/ButtonSmallFilled";
-import { ManifestationsSimpleFragment } from "../../core/dbc-gateway/generated/graphql";
+import { ManifestationsSimpleFieldsFragment } from "../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../core/utils/text";
 import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 
 export interface MaterialMainfestationItemProps {
-  manifestation: ManifestationsSimpleFragment["all"][0];
+  manifestation: ManifestationsSimpleFieldsFragment;
 }
 
 const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { WorkSmallFragment } from "../../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../../core/utils/text";
-import { Pid, WorkId } from "../../../core/utils/types/ids";
+import { WorkId } from "../../../core/utils/types/ids";
 import Arrow from "../../atoms/icons/arrow/arrow";
 import { AvailabiltityLabels } from "../../availability-label/availability-labels";
 import ButtonFavourite from "../../button-favourite/button-favourite";
@@ -73,7 +73,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     >
       <div className="search-result-item__cover">
         <SearchResultListItemCover
-          pid={manifestationPid as Pid}
+          pid={manifestationPid}
           description={String(fullTitle)}
           url={materialFullUrl}
           tint={coverTint}

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -44,6 +44,51 @@ fragment ManifestationsSimple on Manifestations {
       numberOfPages
     }
   }
+  latest {
+    pid
+    titles {
+      main
+      original
+    }
+    publicationYear {
+      display
+    }
+    materialTypes {
+      specific
+    }
+    creators {
+      display
+      __typename
+    }
+    hostPublication {
+      title
+      creator
+      publisher
+      year {
+        year
+      }
+    }
+    languages {
+      main {
+        display
+      }
+    }
+    identifiers {
+      value
+    }
+    contributors {
+      display
+    }
+    edition {
+      summary
+    }
+    audience {
+      generalAudience
+    }
+    physicalDescriptions {
+      numberOfPages
+    }
+  }
 }
 
 fragment SeriesSimple on Series {

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -1,51 +1,17 @@
+
+
 fragment ManifestationsSimple on Manifestations {
   all {
-    pid
-    titles {
-      main
-      original
-    }
-    publicationYear {
-      display
-    }
-    materialTypes {
-      specific
-    }
-    creators {
-      display
-      __typename
-    }
-    hostPublication {
-      title
-      creator
-      publisher
-      year {
-        year
-      }
-    }
-    languages {
-      main {
-        display
-      }
-    }
-    identifiers {
-      value
-    }
-    contributors {
-      display
-    }
-    edition {
-      summary
-    }
-    audience {
-      generalAudience
-    }
-    physicalDescriptions {
-      numberOfPages
-    }
+   ...ManifestationsSimpleFields
   }
   latest {
-    pid
+   ...ManifestationsSimpleFields
+  }
+}
+
+
+fragment ManifestationsSimpleFields on Manifestation {
+  pid
     titles {
       main
       original
@@ -88,7 +54,6 @@ fragment ManifestationsSimple on Manifestations {
     physicalDescriptions {
       numberOfPages
     }
-  }
 }
 
 fragment SeriesSimple on Series {

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -1441,117 +1441,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "HoldingsFilters",
-        "description": "Holdings Filters",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "branchId",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "department",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "location",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "HoldingsStatus",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sublocation",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "HoldingsStatus",
         "description": null,
@@ -5032,18 +4921,6 @@
                 "deprecationReason": null
               },
               {
-                "name": "holdingsFilters",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "HoldingsFilters",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "q",
                 "description": null,
                 "type": {
@@ -5740,6 +5617,26 @@
             "deprecationReason": null
           },
           {
+            "name": "branchId",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "childrenOrAdults",
             "description": null,
             "type": {
@@ -5761,6 +5658,26 @@
           },
           {
             "name": "creators",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "department",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -5840,6 +5757,26 @@
             "deprecationReason": null
           },
           {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "mainLanguages",
             "description": null,
             "type": {
@@ -5880,7 +5817,47 @@
             "deprecationReason": null
           },
           {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "HoldingsStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "subjects",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sublocation",
             "description": null,
             "type": {
               "kind": "LIST",

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -252,15 +252,6 @@ export enum FictionNonfictionCode {
   NotSpecified = "NOT_SPECIFIED"
 }
 
-/** Holdings Filters */
-export type HoldingsFilters = {
-  branchId?: InputMaybe<Array<Scalars["String"]>>;
-  department?: InputMaybe<Array<Scalars["String"]>>;
-  location?: InputMaybe<Array<Scalars["String"]>>;
-  status?: InputMaybe<Array<HoldingsStatus>>;
-  sublocation?: InputMaybe<Array<Scalars["String"]>>;
-};
-
 export enum HoldingsStatus {
   /** Holding is on loan */
   OnLoan = "OnLoan",
@@ -760,7 +751,6 @@ export type QueryRisArgs = {
 
 export type QuerySearchArgs = {
   filters?: InputMaybe<SearchFilters>;
-  holdingsFilters?: InputMaybe<HoldingsFilters>;
   q: SearchQuery;
 };
 
@@ -850,14 +840,19 @@ export enum SchoolUseCode {
 /** Search Filters */
 export type SearchFilters = {
   accessTypes?: InputMaybe<Array<Scalars["String"]>>;
+  branchId?: InputMaybe<Array<Scalars["String"]>>;
   childrenOrAdults?: InputMaybe<Array<Scalars["String"]>>;
   creators?: InputMaybe<Array<Scalars["String"]>>;
+  department?: InputMaybe<Array<Scalars["String"]>>;
   fictionNonfiction?: InputMaybe<Array<Scalars["String"]>>;
   fictionalCharacter?: InputMaybe<Array<Scalars["String"]>>;
   genreAndForm?: InputMaybe<Array<Scalars["String"]>>;
+  location?: InputMaybe<Array<Scalars["String"]>>;
   mainLanguages?: InputMaybe<Array<Scalars["String"]>>;
   materialTypes?: InputMaybe<Array<Scalars["String"]>>;
+  status?: InputMaybe<Array<HoldingsStatus>>;
   subjects?: InputMaybe<Array<Scalars["String"]>>;
+  sublocation?: InputMaybe<Array<Scalars["String"]>>;
   workTypes?: InputMaybe<Array<Scalars["String"]>>;
 };
 
@@ -1567,6 +1562,44 @@ export type ManifestationsSimpleFragment = {
   };
 };
 
+export type ManifestationsSimpleFieldsFragment = {
+  __typename?: "Manifestation";
+  pid: string;
+  titles: {
+    __typename?: "ManifestationTitles";
+    main: Array<string>;
+    original?: Array<string> | null;
+  };
+  publicationYear: { __typename?: "PublicationYear"; display: string };
+  materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+  creators: Array<
+    | { __typename: "Corporation"; display: string }
+    | { __typename: "Person"; display: string }
+  >;
+  hostPublication?: {
+    __typename?: "HostPublication";
+    title: string;
+    creator?: string | null;
+    publisher?: string | null;
+    year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+  } | null;
+  languages?: {
+    __typename?: "Languages";
+    main?: Array<{ __typename?: "Language"; display: string }> | null;
+  } | null;
+  identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+  contributors: Array<
+    | { __typename?: "Corporation"; display: string }
+    | { __typename?: "Person"; display: string }
+  >;
+  edition: { __typename?: "Edition"; summary: string };
+  audience?: { __typename?: "Audience"; generalAudience: Array<string> } | null;
+  physicalDescriptions: Array<{
+    __typename?: "PhysicalDescription";
+    numberOfPages?: number | null;
+  }>;
+};
+
 export type SeriesSimpleFragment = {
   __typename?: "Series";
   title: string;
@@ -1880,100 +1913,63 @@ export const SeriesSimpleFragmentDoc = `
   readThisWhenever
 }
     `;
-export const ManifestationsSimpleFragmentDoc = `
-    fragment ManifestationsSimple on Manifestations {
-  all {
-    pid
-    titles {
-      main
-      original
-    }
-    publicationYear {
-      display
-    }
-    materialTypes {
-      specific
-    }
-    creators {
-      display
-      __typename
-    }
-    hostPublication {
-      title
-      creator
-      publisher
-      year {
-        year
-      }
-    }
-    languages {
-      main {
-        display
-      }
-    }
-    identifiers {
-      value
-    }
-    contributors {
-      display
-    }
-    edition {
-      summary
-    }
-    audience {
-      generalAudience
-    }
-    physicalDescriptions {
-      numberOfPages
+export const ManifestationsSimpleFieldsFragmentDoc = `
+    fragment ManifestationsSimpleFields on Manifestation {
+  pid
+  titles {
+    main
+    original
+  }
+  publicationYear {
+    display
+  }
+  materialTypes {
+    specific
+  }
+  creators {
+    display
+    __typename
+  }
+  hostPublication {
+    title
+    creator
+    publisher
+    year {
+      year
     }
   }
-  latest {
-    pid
-    titles {
-      main
-      original
-    }
-    publicationYear {
+  languages {
+    main {
       display
     }
-    materialTypes {
-      specific
-    }
-    creators {
-      display
-      __typename
-    }
-    hostPublication {
-      title
-      creator
-      publisher
-      year {
-        year
-      }
-    }
-    languages {
-      main {
-        display
-      }
-    }
-    identifiers {
-      value
-    }
-    contributors {
-      display
-    }
-    edition {
-      summary
-    }
-    audience {
-      generalAudience
-    }
-    physicalDescriptions {
-      numberOfPages
-    }
+  }
+  identifiers {
+    value
+  }
+  contributors {
+    display
+  }
+  edition {
+    summary
+  }
+  audience {
+    generalAudience
+  }
+  physicalDescriptions {
+    numberOfPages
   }
 }
     `;
+export const ManifestationsSimpleFragmentDoc = `
+    fragment ManifestationsSimple on Manifestations {
+  all {
+    ...ManifestationsSimpleFields
+  }
+  latest {
+    ...ManifestationsSimpleFields
+  }
+}
+    ${ManifestationsSimpleFieldsFragmentDoc}`;
 export const WorkSmallFragmentDoc = `
     fragment WorkSmall on Work {
   workId

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -1245,6 +1245,49 @@ export type GetMaterialQuery = {
           numberOfPages?: number | null;
         }>;
       }>;
+      latest: {
+        __typename?: "Manifestation";
+        pid: string;
+        titles: {
+          __typename?: "ManifestationTitles";
+          main: Array<string>;
+          original?: Array<string> | null;
+        };
+        publicationYear: { __typename?: "PublicationYear"; display: string };
+        materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+        creators: Array<
+          | { __typename: "Corporation"; display: string }
+          | { __typename: "Person"; display: string }
+        >;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          title: string;
+          creator?: string | null;
+          publisher?: string | null;
+          year?: {
+            __typename?: "PublicationYear";
+            year?: number | null;
+          } | null;
+        } | null;
+        languages?: {
+          __typename?: "Languages";
+          main?: Array<{ __typename?: "Language"; display: string }> | null;
+        } | null;
+        identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+        contributors: Array<
+          | { __typename?: "Corporation"; display: string }
+          | { __typename?: "Person"; display: string }
+        >;
+        edition: { __typename?: "Edition"; summary: string };
+        audience?: {
+          __typename?: "Audience";
+          generalAudience: Array<string>;
+        } | null;
+        physicalDescriptions: Array<{
+          __typename?: "PhysicalDescription";
+          numberOfPages?: number | null;
+        }>;
+      };
     };
   } | null;
 };
@@ -1360,6 +1403,52 @@ export type SearchWithPaginationQuery = {
             numberOfPages?: number | null;
           }>;
         }>;
+        latest: {
+          __typename?: "Manifestation";
+          pid: string;
+          titles: {
+            __typename?: "ManifestationTitles";
+            main: Array<string>;
+            original?: Array<string> | null;
+          };
+          publicationYear: { __typename?: "PublicationYear"; display: string };
+          materialTypes: Array<{
+            __typename?: "MaterialType";
+            specific: string;
+          }>;
+          creators: Array<
+            | { __typename: "Corporation"; display: string }
+            | { __typename: "Person"; display: string }
+          >;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            title: string;
+            creator?: string | null;
+            publisher?: string | null;
+            year?: {
+              __typename?: "PublicationYear";
+              year?: number | null;
+            } | null;
+          } | null;
+          languages?: {
+            __typename?: "Languages";
+            main?: Array<{ __typename?: "Language"; display: string }> | null;
+          } | null;
+          identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+          contributors: Array<
+            | { __typename?: "Corporation"; display: string }
+            | { __typename?: "Person"; display: string }
+          >;
+          edition: { __typename?: "Edition"; summary: string };
+          audience?: {
+            __typename?: "Audience";
+            generalAudience: Array<string>;
+          } | null;
+          physicalDescriptions: Array<{
+            __typename?: "PhysicalDescription";
+            numberOfPages?: number | null;
+          }>;
+        };
       };
     }>;
   };
@@ -1436,6 +1525,46 @@ export type ManifestationsSimpleFragment = {
       numberOfPages?: number | null;
     }>;
   }>;
+  latest: {
+    __typename?: "Manifestation";
+    pid: string;
+    titles: {
+      __typename?: "ManifestationTitles";
+      main: Array<string>;
+      original?: Array<string> | null;
+    };
+    publicationYear: { __typename?: "PublicationYear"; display: string };
+    materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+    creators: Array<
+      | { __typename: "Corporation"; display: string }
+      | { __typename: "Person"; display: string }
+    >;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      title: string;
+      creator?: string | null;
+      publisher?: string | null;
+      year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    } | null;
+    languages?: {
+      __typename?: "Languages";
+      main?: Array<{ __typename?: "Language"; display: string }> | null;
+    } | null;
+    identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+    contributors: Array<
+      | { __typename?: "Corporation"; display: string }
+      | { __typename?: "Person"; display: string }
+    >;
+    edition: { __typename?: "Edition"; summary: string };
+    audience?: {
+      __typename?: "Audience";
+      generalAudience: Array<string>;
+    } | null;
+    physicalDescriptions: Array<{
+      __typename?: "PhysicalDescription";
+      numberOfPages?: number | null;
+    }>;
+  };
 };
 
 export type SeriesSimpleFragment = {
@@ -1528,6 +1657,46 @@ export type WorkSmallFragment = {
         numberOfPages?: number | null;
       }>;
     }>;
+    latest: {
+      __typename?: "Manifestation";
+      pid: string;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      publicationYear: { __typename?: "PublicationYear"; display: string };
+      materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string }
+        | { __typename: "Person"; display: string }
+      >;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        title: string;
+        creator?: string | null;
+        publisher?: string | null;
+        year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{ __typename?: "Language"; display: string }> | null;
+      } | null;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | { __typename?: "Corporation"; display: string }
+        | { __typename?: "Person"; display: string }
+      >;
+      edition: { __typename?: "Edition"; summary: string };
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+      } | null;
+      physicalDescriptions: Array<{
+        __typename?: "PhysicalDescription";
+        numberOfPages?: number | null;
+      }>;
+    };
   };
 };
 
@@ -1656,6 +1825,46 @@ export type WorkMediumFragment = {
         numberOfPages?: number | null;
       }>;
     }>;
+    latest: {
+      __typename?: "Manifestation";
+      pid: string;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      publicationYear: { __typename?: "PublicationYear"; display: string };
+      materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string }
+        | { __typename: "Person"; display: string }
+      >;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        title: string;
+        creator?: string | null;
+        publisher?: string | null;
+        year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{ __typename?: "Language"; display: string }> | null;
+      } | null;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | { __typename?: "Corporation"; display: string }
+        | { __typename?: "Person"; display: string }
+      >;
+      edition: { __typename?: "Edition"; summary: string };
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+      } | null;
+      physicalDescriptions: Array<{
+        __typename?: "PhysicalDescription";
+        numberOfPages?: number | null;
+      }>;
+    };
   };
 };
 
@@ -1674,6 +1883,51 @@ export const SeriesSimpleFragmentDoc = `
 export const ManifestationsSimpleFragmentDoc = `
     fragment ManifestationsSimple on Manifestations {
   all {
+    pid
+    titles {
+      main
+      original
+    }
+    publicationYear {
+      display
+    }
+    materialTypes {
+      specific
+    }
+    creators {
+      display
+      __typename
+    }
+    hostPublication {
+      title
+      creator
+      publisher
+      year {
+        year
+      }
+    }
+    languages {
+      main {
+        display
+      }
+    }
+    identifiers {
+      value
+    }
+    contributors {
+      display
+    }
+    edition {
+      summary
+    }
+    audience {
+      generalAudience
+    }
+    physicalDescriptions {
+      numberOfPages
+    }
+  }
+  latest {
     pid
     titles {
       main

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -88,7 +88,7 @@ export const getManifestationPid = (
   manifestations: ManifestationsSimpleFragment
 ) => {
   const ordered = orderManifestationsByYear(manifestations);
-  return ordered[0].pid;
+  return ordered[0].pid as Pid;
 };
 
 export const getCoverTint = (index: number) => {

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -69,7 +69,7 @@ export const getCreatorTextFromManifestations = (
   return creatorsToString(creators, t);
 };
 
-const getFirstPublishedManifestation = (
+export const getFirstPublishedManifestation = (
   manifestations: ManifestationsSimpleFragment
 ) => {
   const ordered = orderManifestationsByYear(manifestations);

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -17,7 +17,21 @@ export const appendQueryParametersToUrl = (
 
 export const getUrlQueryParam = (param: string): null | string => {
   const queryParams = new URLSearchParams(window.location.search);
-  return queryParams.get(param);
+
+  return queryParams.get(param)
+    ? decodeURI(String(queryParams.get(param)))
+    : null;
+};
+
+export const setQueryParametersInUrl = (parameters: {
+  [key: string]: string;
+}) => {
+  const processedUrl = new URL(getCurrentLocation());
+  Object.keys(parameters).forEach((key) => {
+    processedUrl.searchParams.set(key, parameters[key]);
+  });
+
+  window.history.replaceState(null, "", processedUrl);
 };
 
 export const redirectTo = (url: URL): void => {


### PR DESCRIPTION
#### Link to issues
https://reload.atlassian.net/browse/DDFSOEG-154
https://reload.atlassian.net/browse/DDFSOEG-190

#### Description
This PR adds select work manifestation logic and display the cover image for the selected manifestation

- Material type is now specified in the URL and will be set to first published manifestation if not. 
- A currentManifestation state has been added so that we can choose based on it how the material page should be displayed, for example, cover and buttons.
- Availability labels can be clicked on to change both state and URL
- Availability labels show as selected if the type of material text is the same

#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-08-22 kl  14 30 34" src="https://user-images.githubusercontent.com/49920322/185921551-472f7569-e61a-4d7b-bf66-e97d66c1eb03.png">
<img width="1728" alt="Skærmbillede 2022-08-22 kl  14 30 27" src="https://user-images.githubusercontent.com/49920322/185921566-aa0bea4f-0678-4165-9202-cf41cdda0710.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
**There is also added a translation of Reviews**