### PR TITLE
indloggetudlogget funktionalitet DDFSOEG 178

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,7 +58,7 @@
           "postcss.config.js",
           "orval.config.ts",
           "cypress/plugins/index.js",
-          "cypress/support/index.js",
+          "cypress/support/index.ts",
           "scripts/postcss-node-sass.js",
           "scripts/post-process-generated-graphql.ts"
         ]

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,1 +1,0 @@
-import "@cypress/code-coverage/support";

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -6,6 +6,10 @@ import "@cypress/code-coverage/support";
 const TOKEN_USER_KEY = "user";
 
 Cypress.Commands.add("createFakeAuthenticatedSession", () => {
+  // Since the user token is shared in storybook by setting it in sessionStorage
+  // we can use that and fake that we have a inlogged user session
+  // by using the same principle.
+  // See userToken handling in .storybbok/preview.js.
   window.sessionStorage.setItem(TOKEN_USER_KEY, "999");
 });
 
@@ -16,7 +20,7 @@ declare global {
        * Pretend that a user is logged in.
        * @example cy.createFakeAuthenticatedSession()
        */
-      createFakeAuthenticatedSession(): Chainable<Element>;
+      createFakeAuthenticatedSession(): void;
     }
   }
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,0 +1,22 @@
+// According to the documentation of types and Cypress commands
+// the namespace is declared like it is done here. Therefore we'll bypass errors about it.
+/* eslint-disable @typescript-eslint/no-namespace */
+import "@cypress/code-coverage/support";
+
+const TOKEN_USER_KEY = "user";
+
+Cypress.Commands.add("createFakeAuthenticatedSession", () => {
+  window.sessionStorage.setItem(TOKEN_USER_KEY, "999");
+});
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Pretend that a user is logged in.
+       * @example cy.createFakeAuthenticatedSession()
+       */
+      createFakeAuthenticatedSession(): Chainable<Element>;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/node": "^17.0.31",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.3",
+    "@types/react-redux": "^7.1.24",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "autoprefixer": "^10.4.7",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import GuardedApp from "../../components/guarded-app";
 import { withText } from "../../core/utils/text";
 import { WorkId } from "../../core/utils/types/ids";
 import { withUrls } from "../../core/utils/url";
@@ -56,8 +57,10 @@ export interface MaterialEntryProps
   wid: WorkId;
 }
 
-const MaterialEntry: React.FC<MaterialEntryProps> = ({ wid }) => {
-  return <Material wid={wid} />;
-};
+const WrappedMaterialEntry: React.FC<MaterialEntryProps> = ({ wid }) => (
+  <GuardedApp app="material">
+    <Material wid={wid} />
+  </GuardedApp>
+);
 
-export default withUrls(withText(MaterialEntry));
+export default withUrls(withText(WrappedMaterialEntry));

--- a/src/apps/search-header/search-header.entry.tsx
+++ b/src/apps/search-header/search-header.entry.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import GuardedApp from "../../components/guarded-app";
 import { withText } from "../../core/utils/text";
 import { withUrls } from "../../core/utils/url";
 import SearchHeader from "./search-header";
@@ -22,9 +21,8 @@ export interface SearchHeaderEntryProps
   extends SearchHeaderTextProps,
     SearchHeaderUrlProps {}
 
-const WrappedSearchHeader: React.FC<SearchHeaderEntryProps> = () => (
-  <GuardedApp app="search-header">
-    <SearchHeader />
-  </GuardedApp>
-);
-export default withUrls(withText(WrappedSearchHeader));
+const SearchHeaderEntry: React.FC<SearchHeaderEntryProps> = () => {
+  return <SearchHeader />;
+};
+
+export default withUrls(withText(SearchHeaderEntry));

--- a/src/apps/search-header/search-header.entry.tsx
+++ b/src/apps/search-header/search-header.entry.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import GuardedApp from "../../components/guarded-app";
 import { withText } from "../../core/utils/text";
 import { withUrls } from "../../core/utils/url";
 import SearchHeader from "./search-header";
@@ -13,23 +14,17 @@ export interface SearchHeaderTextProps {
 }
 
 export interface SearchHeaderUrlProps {
-  searchUrl: string;
-  materialUrl: string;
+  searchUrl?: string;
+  materialUrl?: string;
 }
 
 export interface SearchHeaderEntryProps
   extends SearchHeaderTextProps,
     SearchHeaderUrlProps {}
 
-const SearchHeaderEntry: React.FC<SearchHeaderEntryProps> = ({
-  altText = "search icon",
-  inputPlaceholderText = "Search here",
-  stringSuggestionAuthorText = "author",
-  stringSuggestionWorkText = "work",
-  stringSuggestionTopicText = "topic",
-  etAlText = "et al."
-}) => {
-  return <SearchHeader />;
-};
-
-export default withUrls(withText(SearchHeaderEntry));
+const WrappedSearchHeader: React.FC<SearchHeaderEntryProps> = () => (
+  <GuardedApp app="search-header">
+    <SearchHeader />
+  </GuardedApp>
+);
+export default withUrls(withText(WrappedSearchHeader));

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -22,6 +22,7 @@ const SearchHeader: React.FC = () => {
   const [suggestItems, setSuggestItems] = useState<
     SuggestionsFromQueryStringQuery["suggest"]["result"] | []
   >([]);
+  const minimalQueryLength = 3;
   // we need to convert between string and suggestion result object so
   // that the value in the search field on enter click doesn't become [object][object]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,7 +36,11 @@ const SearchHeader: React.FC = () => {
     data: SuggestionsFromQueryStringQuery | undefined;
     isLoading: boolean;
     status: string;
-  } = useSuggestionsFromQueryStringQuery({ q });
+  } = useSuggestionsFromQueryStringQuery(
+    { q },
+    { enabled: q.length >= minimalQueryLength }
+  );
+
   const { searchUrl, materialUrl } = useUrls();
 
   // Make sure to only assign the data once.
@@ -67,17 +72,12 @@ const SearchHeader: React.FC = () => {
 
   // Autosuggest opening and closing based on input text length.
   useEffect(() => {
-    if (q) {
-      const minimalLengthQuery = 3;
-      if (q.length >= minimalLengthQuery) {
-        setIsAutosuggestOpen(true);
-      } else {
-        setIsAutosuggestOpen(false);
-      }
+    if (data) {
+      setIsAutosuggestOpen(true);
     } else {
       setIsAutosuggestOpen(false);
     }
-  }, [q]);
+  }, [data]);
 
   function determineSuggestionTerm(suggestion: Suggestion): string {
     if (suggestion.type === SuggestionType.Composit) {

--- a/src/apps/search-result/search-result.dev.tsx
+++ b/src/apps/search-result/search-result.dev.tsx
@@ -23,6 +23,11 @@ export default {
       defaultValue: 20,
       control: { type: "number" }
     },
+    authUrl: {
+      name: "Url where user can authenticate",
+      defaultValue: "",
+      control: { type: "text" }
+    },
     searchUrl: {
       name: "Path to the search result page",
       defaultValue: "/search",

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import GuardedApp from "../../components/guarded-app";
 import { getParams } from "../../core/utils/helpers/general";
 import { withText } from "../../core/utils/text";
 import { withUrls } from "../../core/utils/url";
@@ -48,7 +49,11 @@ const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
 
   return (
     <div>
-      {searchQuery && <SearchResult q={searchQuery} pageSize={pageSize} />}
+      {searchQuery && (
+        <GuardedApp app="search-result">
+          <SearchResult q={searchQuery} pageSize={pageSize} />
+        </GuardedApp>
+      )}
     </div>
   );
 };

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { getParams } from "../../core/utils/helpers/general";
 import { withText } from "../../core/utils/text";
 import { withUrls } from "../../core/utils/url";
@@ -19,6 +19,7 @@ interface SearchResultEntryTextProps {
 interface SearchResultEntryUrlProps {
   searchUrl: string;
   materialUrl: string;
+  authUrl: string;
 }
 
 export interface SearchResultEntryProps

--- a/src/components/button-favourite/button-favourite.dev.tsx
+++ b/src/components/button-favourite/button-favourite.dev.tsx
@@ -2,7 +2,10 @@ import React from "react";
 
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import ButtonFavourite, { ButtonFavouriteProps } from "./button-favourite";
+import ButtonFavourite, {
+  ButtonFavouriteId,
+  ButtonFavouriteProps
+} from "./button-favourite";
 
 export default {
   title: "Components  / Button Favourite",
@@ -18,7 +21,14 @@ export default {
 
 const Template: ComponentStory<typeof ButtonFavourite> = (
   args: ButtonFavouriteProps
-) => <ButtonFavourite {...args} />;
+) => {
+  // This is a fake situation where we just need to give the button a handler.
+  // The handler does nothing.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const addToListRequest = (id: ButtonFavouriteId) => {};
+
+  return <ButtonFavourite {...args} addToListRequest={addToListRequest} />;
+};
 
 export const favourite = Template.bind({});
 favourite.args = {};

--- a/src/components/button-favourite/button-favourite.tsx
+++ b/src/components/button-favourite/button-favourite.tsx
@@ -7,20 +7,22 @@ import {
 } from "../../core/material-list-api/material-list";
 import { useText } from "../../core/utils/text";
 import { Pid, WorkId } from "../../core/utils/types/ids";
-import { guardedRequest } from "../../core/guardedRequests.slice";
-import { TypedDispatch } from "../../core/store";
 
+export type ButtonFavouriteId = WorkId | Pid;
 export interface ButtonFavouriteProps {
-  id: WorkId | Pid;
+  id: ButtonFavouriteId;
+  addToListRequest: (id: ButtonFavouriteId) => void;
 }
 
 // TODO We have to check if user is login and redirect if not
 
-const ButtonFavourite: React.FC<ButtonFavouriteProps> = ({ id }) => {
+const ButtonFavourite: React.FC<ButtonFavouriteProps> = ({
+  id,
+  addToListRequest
+}) => {
   const [fillState, setFillState] = useState<boolean>(false);
   const t = useText();
   const { mutate } = useHasItem();
-  const dispatch = useDispatch<TypedDispatch>();
 
   useEffect(() => {
     mutate(
@@ -48,14 +50,14 @@ const ButtonFavourite: React.FC<ButtonFavouriteProps> = ({ id }) => {
         removeItem("default", id);
         setFillState(false);
       } else {
-        dispatch(guardedRequest({ type: "addFavorite", args: { id } }));
+        addToListRequest(id);
         setFillState(true);
       }
       // Prevent event from bubbling up. If other components includes the favourite button
       // this wont interfere with their click handler.
       e.stopPropagation();
     },
-    [dispatch, fillState, id]
+    [addToListRequest, fillState, id]
   );
 
   return (

--- a/src/components/button-favourite/button-favourite.tsx
+++ b/src/components/button-favourite/button-favourite.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
 import { IconFavourite } from "../icon-favourite/icon-favourite";
 import {
   removeItem,

--- a/src/components/button-favourite/button-favourite.tsx
+++ b/src/components/button-favourite/button-favourite.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { IconFavourite } from "../icon-favourite/icon-favourite";
 import {
-  addItem,
   removeItem,
   useHasItem
 } from "../../core/material-list-api/material-list";
 import { useText } from "../../core/utils/text";
 import { Pid, WorkId } from "../../core/utils/types/ids";
+import { guardedRequest } from "../../core/guardedRequests.slice";
+import { TypedDispatch } from "../../core/store";
 
 export interface ButtonFavouriteProps {
   id: WorkId | Pid;
@@ -17,8 +19,8 @@ export interface ButtonFavouriteProps {
 const ButtonFavourite: React.FC<ButtonFavouriteProps> = ({ id }) => {
   const [fillState, setFillState] = useState<boolean>(false);
   const t = useText();
-
   const { mutate } = useHasItem();
+  const dispatch = useDispatch<TypedDispatch>();
 
   useEffect(() => {
     mutate(
@@ -46,14 +48,14 @@ const ButtonFavourite: React.FC<ButtonFavouriteProps> = ({ id }) => {
         removeItem("default", id);
         setFillState(false);
       } else {
-        addItem("default", id);
+        dispatch(guardedRequest({ type: "addFavorite", args: { id } }));
         setFillState(true);
       }
       // Prevent event from bubbling up. If other components includes the favourite button
       // this wont interfere with their click handler.
       e.stopPropagation();
     },
-    [fillState, id]
+    [dispatch, fillState, id]
   );
 
   return (

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -2,7 +2,12 @@ import { FC, ReactElement, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { removeRequest, reRunRequest } from "../core/guardedRequests.slice";
 import { RootState, TypedDispatch } from "../core/store";
-import { getUrlQueryParam } from "../core/utils/helpers/url";
+import {
+  getCurrentLocation,
+  getUrlQueryParam,
+  removeQueryParametersFromUrl,
+  replaceCurrentLocation
+} from "../core/utils/helpers/url";
 
 export interface GuardedAppProps {
   children: ReactElement<any, any> | null;
@@ -15,7 +20,8 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
   const { request: persistedRequest } = useSelector(
     (state: RootState) => state.guardedRequests
   );
-  const didAuthenticate = getUrlQueryParam("didAuthenticate");
+  const AUTH_PARAM = "didAuthenticate";
+  const didAuthenticate = getUrlQueryParam(AUTH_PARAM);
   console.log("PERSISTED REQUEST:", persistedRequest);
 
   useEffect(() => {
@@ -24,6 +30,11 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
     }
 
     (async () => {
+      const currentUrlWithoutAuthParam = removeQueryParametersFromUrl(
+        new URL(getCurrentLocation()),
+        AUTH_PARAM
+      );
+      replaceCurrentLocation(currentUrlWithoutAuthParam);
       await dispatch(reRunRequest(persistedRequest));
       // TODO: fix:
       // @ts-ignore

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -2,6 +2,7 @@ import { FC, ReactElement, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { removeRequest, reRunRequest } from "../core/guardedRequests.slice";
 import { RootState, TypedDispatch } from "../core/store";
+import { getUrlQueryParam } from "../core/utils/helpers/url";
 
 export interface GuardedAppProps {
   children: ReactElement<any, any> | null;
@@ -14,10 +15,11 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
   const { request: persistedRequest } = useSelector(
     (state: RootState) => state.guardedRequests
   );
+  const didAuthenticate = getUrlQueryParam("didAuthenticate");
   console.log("PERSISTED REQUEST:", persistedRequest);
 
   useEffect(() => {
-    if (!persistedRequest) {
+    if (!persistedRequest || !didAuthenticate) {
       return;
     }
 
@@ -27,7 +29,7 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
       // @ts-ignore
       dispatch(removeRequest());
     })();
-  }, [dispatch, persistedRequest]);
+  }, [didAuthenticate, dispatch, persistedRequest]);
 
   if (persistedRequest) {
     return null;

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -40,7 +40,7 @@ const GuardedApp = ({ app, children }: GuardedAppProps) => {
     }
 
     console.log("HAS REQUEST EXPIRED?", hasRequestExpired(persistedRequest));
-    console.log("CURRRENT TIMESTAMP", getCurrentUnixTime());
+    console.log("CURRENT TIMESTAMP", getCurrentUnixTime());
     console.log("EXPIRE TIMESTAMP", persistedRequest.expire);
 
     // If request has expired remove it.

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement } from "react";
+import { FC, ReactElement, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { removeRequest, reRunRequest } from "../core/guardedRequests.slice";
 import { RootState, TypedDispatch } from "../core/store";
@@ -14,7 +14,9 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
   const { request: persistedRequest } = useSelector(
     (state: RootState) => state.guardedRequests
   );
-  React.useLayoutEffect(() => {
+  console.log("PERSISTED REQUEST:", persistedRequest);
+
+  useEffect(() => {
     if (!persistedRequest) {
       return;
     }

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -4,7 +4,6 @@ import {
   AUTH_PARAM,
   hasRequestExpired,
   removeRequest,
-  RequestItem,
   reRunRequest
 } from "../core/guardedRequests.slice";
 import { RootState } from "../core/store";
@@ -16,10 +15,10 @@ import {
   replaceCurrentLocation
 } from "../core/utils/helpers/url";
 import { userIsAnonymous } from "../core/utils/helpers/user";
-import { App } from "../core/utils/types/ids";
+import { GuardedAppId } from "../core/utils/types/ids";
 
 export interface GuardedAppProps {
-  app: App;
+  app: GuardedAppId;
   children: ReactNode;
 }
 

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -32,16 +32,16 @@ const GuardedApp = ({ app, children }: GuardedAppProps) => {
   const isApplicationBlocked = persistedRequest && !userIsAnonymous();
   const didAuthenticate = getUrlQueryParam(AUTH_PARAM);
 
-  console.log("PERSISTED REQUEST:", persistedRequest);
+  console.debug("PERSISTED REQUEST:", persistedRequest);
 
   useEffect(() => {
     if (!persistedRequest) {
       return;
     }
 
-    console.log("HAS REQUEST EXPIRED?", hasRequestExpired(persistedRequest));
-    console.log("CURRENT TIMESTAMP", getCurrentUnixTime());
-    console.log("EXPIRE TIMESTAMP", persistedRequest.expire);
+    console.debug("HAS REQUEST EXPIRED?", hasRequestExpired(persistedRequest));
+    console.debug("CURRENT TIMESTAMP", getCurrentUnixTime());
+    console.debug("EXPIRE TIMESTAMP", persistedRequest.expire);
 
     // If request has expired remove it.
     if (hasRequestExpired(persistedRequest)) {

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -12,6 +12,7 @@ import {
 export interface GuardedAppProps {
   children: ReactElement<any, any> | null;
 }
+export const AUTH_PARAM = "didAuthenticate";
 
 // This component makes sure to withhold app rendering
 // until the persisted request has been executed.
@@ -20,7 +21,6 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
   const { request: persistedRequest } = useSelector(
     (state: RootState) => state.guardedRequests
   );
-  const AUTH_PARAM = "didAuthenticate";
   const didAuthenticate = getUrlQueryParam(AUTH_PARAM);
   console.log("PERSISTED REQUEST:", persistedRequest);
 

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, useEffect } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { removeRequest, reRunRequest } from "../core/guardedRequests.slice";
 import { RootState, TypedDispatch } from "../core/store";
@@ -8,15 +8,17 @@ import {
   removeQueryParametersFromUrl,
   replaceCurrentLocation
 } from "../core/utils/helpers/url";
+import { App } from "../core/utils/types/ids";
 
 export interface GuardedAppProps {
-  children: ReactElement<any, any> | null;
+  app: App;
+  children: ReactNode;
 }
 export const AUTH_PARAM = "didAuthenticate";
 
 // This component makes sure to withhold app rendering
 // until the persisted request has been executed.
-const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
+const GuardedApp = ({ app, children }: GuardedAppProps) => {
   const dispatch = useDispatch<TypedDispatch>();
   const { request: persistedRequest } = useSelector(
     (state: RootState) => state.guardedRequests
@@ -25,7 +27,16 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
   console.log("PERSISTED REQUEST:", persistedRequest);
 
   useEffect(() => {
+    // If we do not have persisted a request
+    // or we did not come back from an authentication
+    // do nothing.
     if (!persistedRequest || !didAuthenticate) {
+      return;
+    }
+    const { app: persistedRequestApp } = persistedRequest;
+
+    // If the request is not connected to this app do nothing.
+    if (app !== persistedRequestApp) {
       return;
     }
 
@@ -37,16 +48,20 @@ const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
       replaceCurrentLocation(currentUrlWithoutAuthParam);
       await dispatch(reRunRequest(persistedRequest));
       // TODO: fix:
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       dispatch(removeRequest());
     })();
-  }, [didAuthenticate, dispatch, persistedRequest]);
+  }, [app, didAuthenticate, dispatch, persistedRequest]);
 
   if (persistedRequest) {
-    return null;
+    return <div />;
   }
 
-  return children;
+  // This is a special case. We need to return a JSX element
+  // and children is not a JSX element.
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
 };
 
 export default GuardedApp;

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -1,0 +1,37 @@
+import React, { FC, ReactElement } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { removeRequest, reRunRequest } from "../core/guardedRequests.slice";
+import { RootState, TypedDispatch } from "../core/store";
+
+export interface GuardedAppProps {
+  children: ReactElement<any, any> | null;
+}
+
+// This component makes sure to withhold app rendering
+// until the persisted request has been executed.
+const GuardedApp: FC<GuardedAppProps> = ({ children }) => {
+  const dispatch = useDispatch<TypedDispatch>();
+  const { request: persistedRequest } = useSelector(
+    (state: RootState) => state.guardedRequests
+  );
+  React.useLayoutEffect(() => {
+    if (!persistedRequest) {
+      return;
+    }
+
+    (async () => {
+      await dispatch(reRunRequest(persistedRequest));
+      // TODO: fix:
+      // @ts-ignore
+      dispatch(removeRequest());
+    })();
+  }, [dispatch, persistedRequest]);
+
+  if (persistedRequest) {
+    return null;
+  }
+
+  return children;
+};
+
+export default GuardedApp;

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,8 +1,11 @@
 import React from "react";
+import { useDispatch } from "react-redux";
 import {
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
+import { guardedRequest } from "../../core/guardedRequests.slice";
+import { TypedDispatch } from "../../core/store";
 import {
   creatorsToString,
   filterCreators,
@@ -12,7 +15,9 @@ import {
 import { useText } from "../../core/utils/text";
 import { Pid, WorkId } from "../../core/utils/types/ids";
 import { AvailabiltityLabels } from "../availability-label/availability-labels";
-import ButtonFavourite from "../button-favourite/button-favourite";
+import ButtonFavourite, {
+  ButtonFavouriteId
+} from "../button-favourite/button-favourite";
 import ButtonLargeOutline from "../Buttons/ButtonLargeOutline";
 import { Cover } from "../cover/cover";
 import MaterialHeaderText from "./MaterialHeaderText";
@@ -40,7 +45,16 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   selectManifestationHandler
 }) => {
   const t = useText();
-
+  const dispatch = useDispatch<TypedDispatch>();
+  const addToListRequest = (id: ButtonFavouriteId) => {
+    dispatch(
+      guardedRequest({
+        type: "addFavorite",
+        args: { id },
+        app: "material"
+      })
+    );
+  };
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t
@@ -66,7 +80,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <Cover pid={coverPid} size="xlarge" animate />
       </div>
       <div className="material-header__content">
-        <ButtonFavourite id={wid as WorkId} />
+        <ButtonFavourite
+          id={wid as WorkId}
+          addToListRequest={addToListRequest}
+        />
         <MaterialHeaderText title={String(title)} author={author} />
         <div className="material-header__availability-label">
           <AvailabiltityLabels

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback } from "react";
+import { useDispatch } from "react-redux";
 import { WorkSmallFragment } from "../../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../../core/utils/text";
 import { WorkId } from "../../../core/utils/types/ids";
 import Arrow from "../../atoms/icons/arrow/arrow";
 import { AvailabiltityLabels } from "../../availability-label/availability-labels";
-import ButtonFavourite from "../../button-favourite/button-favourite";
+import ButtonFavourite, {
+  ButtonFavouriteId
+} from "../../button-favourite/button-favourite";
 import { CoverProps } from "../../cover/cover";
 import { Link } from "../../atoms/link";
 import {
@@ -22,6 +25,8 @@ import {
   constructSearchUrl,
   redirectTo
 } from "../../../core/utils/helpers/url";
+import { TypedDispatch } from "../../../core/store";
+import { guardedRequest } from "../../../core/guardedRequests.slice";
 
 export interface SearchResultListItemProps {
   item: WorkSmallFragment;
@@ -40,6 +45,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
 }) => {
   const t = useText();
   const { materialUrl, searchUrl } = useUrls();
+  const dispatch = useDispatch<TypedDispatch>();
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t
@@ -54,6 +60,16 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   const handleClick = useCallback(() => {
     redirectTo(materialFullUrl);
   }, [materialFullUrl]);
+
+  const addToListRequest = (id: ButtonFavouriteId) => {
+    dispatch(
+      guardedRequest({
+        type: "addFavorite",
+        args: { id },
+        app: "search-result"
+      })
+    );
+  };
 
   return (
     // We know that is not following a11y recommendations to have an onclick handler
@@ -81,7 +97,10 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
       </div>
       <div className="search-result-item__text">
         <div className="search-result-item__meta">
-          <ButtonFavourite id={workId as WorkId} />
+          <ButtonFavourite
+            id={workId as WorkId}
+            addToListRequest={addToListRequest}
+          />
           {numberInSeries && seriesTitle && (
             <HorizontalTermLine
               title={`${t("numberDescriptionText")} ${

--- a/src/components/store.jsx
+++ b/src/components/store.jsx
@@ -4,6 +4,7 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { store, persistor } from "../core/store";
+import GuardedApp from "./guarded-app";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,7 +19,9 @@ const queryClient = new QueryClient({
 const Store = ({ children }) => (
   <Provider store={store}>
     <QueryClientProvider client={queryClient}>
-      <PersistGate persistor={persistor}>{children}</PersistGate>
+      <PersistGate persistor={persistor}>
+        <GuardedApp>{children}</GuardedApp>
+      </PersistGate>
     </QueryClientProvider>
   </Provider>
 );

--- a/src/components/store.jsx
+++ b/src/components/store.jsx
@@ -4,7 +4,6 @@ import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { store, persistor } from "../core/store";
-import GuardedApp from "./guarded-app";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,9 +18,7 @@ const queryClient = new QueryClient({
 const Store = ({ children }) => (
   <Provider store={store}>
     <QueryClientProvider client={queryClient}>
-      <PersistGate persistor={persistor}>
-        <GuardedApp>{children}</GuardedApp>
-      </PersistGate>
+      <PersistGate persistor={persistor}>{children}</PersistGate>
     </QueryClientProvider>
   </Provider>
 );

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -4,6 +4,7 @@ import { persistor, RootState } from "./store";
 import { hasToken } from "./token";
 import {
   appendQueryParametersToUrl,
+  getCurrentLocation,
   redirectTo,
   turnUrlStringsIntoObjects
 } from "./utils/helpers/url";
@@ -85,8 +86,12 @@ export const guardedRequest = createAsyncThunk(
         // And redirect to external login.
         const { authUrl } = getUrlsFromState(getState() as RootState);
         if (authUrl) {
+          let currentUrl = new URL(getCurrentLocation());
+          currentUrl = appendQueryParametersToUrl(currentUrl, {
+            didAuthenticate: "1"
+          });
           const redirectUrl = appendQueryParametersToUrl(authUrl, {
-            "current-path": "/search?q=harry+potter&didAuthenticate=1"
+            "current-path": String(currentUrl)
           });
           console.log("REDIRECTING TO AUTH URL:", redirectUrl);
           redirectTo(redirectUrl);

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -111,13 +111,13 @@ export const guardedRequest = createAsyncThunk(
           const redirectUrl = appendQueryParametersToUrl(authUrl, {
             "current-path": `${pathname}${search}`
           });
-          console.log("REDIRECTING TO AUTH URL:", String(redirectUrl));
+          console.debug("REDIRECTING TO AUTH URL:", String(redirectUrl));
           redirectTo(redirectUrl);
         }
       });
     }
 
-    console.log("PERFORMING REQUEST CALLBACK");
+    console.debug("PERFORMING REQUEST CALLBACK");
     // The user is authorized to perform callback. Let's do it!
     const requestCallback = getRequestCallback(type);
     return requestCallback(args);
@@ -132,7 +132,7 @@ export const reRunRequest = createAsyncThunk(
     // Run request callback.
     if (requestCallbackExists(type)) {
       const requestCallback = getRequestCallback(type);
-      console.log("RERUNNING REQUEST");
+      console.debug("RERUNNING REQUEST");
       return requestCallback(args);
     }
 

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -13,7 +13,7 @@ import {
   redirectTo,
   turnUrlStringsIntoObjects
 } from "./utils/helpers/url";
-import { App } from "./utils/types/ids";
+import { GuardedAppId } from "./utils/types/ids";
 import { userIsAnonymous } from "./utils/helpers/user";
 
 export const AUTH_PARAM = "didAuthenticate";
@@ -35,7 +35,7 @@ type CallbackType = keyof typeof requestCallbacks;
 export type RequestItem = {
   type: CallbackType;
   args: Record<string, unknown>;
-  app: App;
+  app: GuardedAppId;
   expire?: number;
 };
 const getExpireTimestamp = () => getCurrentUnixTime() + 60;

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { AUTH_PARAM } from "../components/guarded-app";
 import { addItem } from "./material-list-api/material-list";
 import { persistor, RootState } from "./store";
@@ -9,6 +9,7 @@ import {
   redirectTo,
   turnUrlStringsIntoObjects
 } from "./utils/helpers/url";
+import { App } from "./utils/types/ids";
 
 interface Callback<T1, T2 = void> {
   (args: T1): T2;
@@ -27,6 +28,7 @@ type CallbackType = keyof typeof requestCallbacks;
 export type RequestItem = {
   type: CallbackType;
   args: Record<string, unknown>;
+  app: App;
 };
 
 const initialState: { request: RequestItem | null } = { request: null };
@@ -43,10 +45,7 @@ const guardedRequests = createSlice({
     }
   }
 });
-
 export const { addRequest, removeRequest } = guardedRequests.actions;
-
-export default guardedRequests.reducer;
 
 const getRequestCallback = (
   type: CallbackType
@@ -64,7 +63,7 @@ const getUrlsFromState = (state: RootState) => {
 export const guardedRequest = createAsyncThunk(
   "guardedRequests/performRequest",
   async (
-    { type, args }: RequestItem,
+    { type, args, app }: RequestItem,
     { dispatch, fulfillWithValue, getState }
   ) => {
     // The callback is unknown and we cannot continue.
@@ -78,7 +77,8 @@ export const guardedRequest = createAsyncThunk(
       dispatch(
         addRequest({
           type,
-          args
+          args,
+          app
         })
       );
 
@@ -118,3 +118,5 @@ export const reRunRequest = createAsyncThunk(
     return fulfillWithValue({ status: "success", message: "" });
   }
 );
+
+export default guardedRequests.reducer;

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -102,6 +102,7 @@ export const guardedRequest = createAsyncThunk(
       });
     }
 
+    console.log("PERFORMING REQUEST CALLBACK");
     // The user is authorized to perform callback. Let's do it!
     const requestCallback = getRequestCallback(type);
     return requestCallback(args);
@@ -113,6 +114,7 @@ export const reRunRequest = createAsyncThunk(
   async ({ type, args }: RequestItem, { fulfillWithValue }) => {
     if (requestCallbackExists(type)) {
       const requestCallback = getRequestCallback(type);
+      console.log("RERUNNING REQUEST");
       return requestCallback(args);
     }
     return fulfillWithValue({ status: "success", message: "" });

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { addItem } from "./material-list-api/material-list";
-import { RootState } from "./store";
+import { persistor, RootState } from "./store";
 import { hasToken } from "./token";
 import { redirectTo, turnUrlStringsIntoObjects } from "./utils/helpers/url";
 
@@ -75,11 +75,16 @@ export const guardedRequest = createAsyncThunk(
           args
         })
       );
-      // And redirect to external login.
-      const { authUrl } = getUrlsFromState(getState() as RootState);
-      if (authUrl) {
-        redirectTo(authUrl);
-      }
+
+      // Make sure that the request is persisted.
+      persistor.flush().then(() => {
+        // And redirect to external login.
+        const { authUrl } = getUrlsFromState(getState() as RootState);
+        if (authUrl) {
+          console.log("REDIRECTING TO AUTH URL:", authUrl);
+          redirectTo(authUrl);
+        }
+      });
     }
 
     // The user is authorized to perform callback. Let's do it!

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -1,0 +1,100 @@
+import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
+import { addItem } from "./material-list-api/material-list";
+import { RootState } from "./store";
+import { hasToken } from "./token";
+import { redirectTo, turnUrlStringsIntoObjects } from "./utils/helpers/url";
+
+interface Callback<T1, T2 = void> {
+  (args: T1): T2;
+}
+
+const requestCallbacks: {
+  [key: string]: Callback<Record<string, unknown>>;
+} = {
+  addFavorite: ({ id }) => {
+    return addItem("default", id as string);
+  }
+};
+
+type CallbackType = keyof typeof requestCallbacks;
+
+export type RequestItem = {
+  type: CallbackType;
+  args: Record<string, unknown>;
+};
+
+const initialState: { request: RequestItem | null } = { request: null };
+const guardedRequests = createSlice({
+  name: "guardedRequests",
+  initialState,
+  reducers: {
+    addRequest(state, action) {
+      const { payload } = action;
+      state.request = payload;
+    },
+    removeRequest(state) {
+      state.request = null;
+    }
+  }
+});
+
+export const { addRequest, removeRequest } = guardedRequests.actions;
+
+export default guardedRequests.reducer;
+
+const getRequestCallback = (
+  type: CallbackType
+): Callback<Record<string, unknown>> => requestCallbacks?.[type];
+
+const requestCallbackExists = (type: CallbackType) =>
+  Boolean(getRequestCallback(type));
+
+const getUrlsFromState = (state: RootState) => {
+  const {
+    url: { data }
+  } = state;
+  return turnUrlStringsIntoObjects(data);
+};
+export const guardedRequest = createAsyncThunk(
+  "guardedRequests/performRequest",
+  async (
+    { type, args }: RequestItem,
+    { dispatch, fulfillWithValue, getState }
+  ) => {
+    // The callback is unknown and we cannot continue.
+    if (!requestCallbackExists(type)) {
+      return fulfillWithValue({ status: "ignored", message: "Nothing to do" });
+    }
+
+    // User is anonymous and the requests is known.
+    if (!hasToken("user")) {
+      // So we'll store the request for later execution.
+      dispatch(
+        addRequest({
+          type,
+          args
+        })
+      );
+      // And redirect to external login.
+      const { authUrl } = getUrlsFromState(getState() as RootState);
+      if (authUrl) {
+        redirectTo(authUrl);
+      }
+    }
+
+    // The user is authorized to perform callback. Let's do it!
+    const requestCallback = getRequestCallback(type);
+    return requestCallback(args);
+  }
+);
+
+export const reRunRequest = createAsyncThunk(
+  "guardedRequests/reRunRequest",
+  async ({ type, args }: RequestItem, { fulfillWithValue }) => {
+    if (requestCallbackExists(type)) {
+      const requestCallback = getRequestCallback(type);
+      return requestCallback(args);
+    }
+    return fulfillWithValue({ status: "success", message: "" });
+  }
+);

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -1,4 +1,5 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
+import { AUTH_PARAM } from "../components/guarded-app";
 import { addItem } from "./material-list-api/material-list";
 import { persistor, RootState } from "./store";
 import { hasToken } from "./token";
@@ -86,14 +87,16 @@ export const guardedRequest = createAsyncThunk(
         // And redirect to external login.
         const { authUrl } = getUrlsFromState(getState() as RootState);
         if (authUrl) {
-          let currentUrl = new URL(getCurrentLocation());
-          currentUrl = appendQueryParametersToUrl(currentUrl, {
-            didAuthenticate: "1"
-          });
+          const { pathname, search } = appendQueryParametersToUrl(
+            new URL(getCurrentLocation()),
+            {
+              [AUTH_PARAM]: "1"
+            }
+          );
           const redirectUrl = appendQueryParametersToUrl(authUrl, {
-            "current-path": String(currentUrl)
+            "current-path": `${pathname}${search}`
           });
-          console.log("REDIRECTING TO AUTH URL:", redirectUrl);
+          console.log("REDIRECTING TO AUTH URL:", String(redirectUrl));
           redirectTo(redirectUrl);
         }
       });

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -2,7 +2,11 @@ import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
 import { addItem } from "./material-list-api/material-list";
 import { persistor, RootState } from "./store";
 import { hasToken } from "./token";
-import { redirectTo, turnUrlStringsIntoObjects } from "./utils/helpers/url";
+import {
+  appendQueryParametersToUrl,
+  redirectTo,
+  turnUrlStringsIntoObjects
+} from "./utils/helpers/url";
 
 interface Callback<T1, T2 = void> {
   (args: T1): T2;
@@ -81,8 +85,11 @@ export const guardedRequest = createAsyncThunk(
         // And redirect to external login.
         const { authUrl } = getUrlsFromState(getState() as RootState);
         if (authUrl) {
-          console.log("REDIRECTING TO AUTH URL:", authUrl);
-          redirectTo(authUrl);
+          const redirectUrl = appendQueryParametersToUrl(authUrl, {
+            "current-path": "/search?q=harry+potter&didAuthenticate=1"
+          });
+          console.log("REDIRECTING TO AUTH URL:", redirectUrl);
+          redirectTo(redirectUrl);
         }
       });
     }

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -34,7 +34,10 @@ export const store = configureStore({
       guardedRequests: guardedRequestsReducer
     })
   ),
-  devTools: process.env.NODE_ENV === "development"
+  // TODO: Change this back after debugging
+  devTools: true
+  // Should be:
+  // devTools: process.env.NODE_ENV === "development"
 });
 
 export const persistor = persistStore(store);

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -13,6 +13,10 @@ import textReducer from "./text.slice";
 import userReducer from "./user.slice";
 import modalReducer from "./modal.slice";
 import urlReducer from "./url.slice";
+// TODO: Fix dependency cycle problem
+// There is not an obvious solution but we need access to the persistor
+// in the guardedRequest thunk.
+// eslint-disable-next-line import/no-cycle
 import guardedRequestsReducer from "./guardedRequests.slice";
 
 // TODO: We have planned to get rid of redux-persist.

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -38,10 +38,7 @@ export const store = configureStore({
       guardedRequests: guardedRequestsReducer
     })
   ),
-  // TODO: Change this back after debugging
-  devTools: true
-  // Should be:
-  // devTools: process.env.NODE_ENV === "development"
+  devTools: process.env.NODE_ENV === "development"
 });
 
 export const persistor = persistStore(store);

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,4 +1,8 @@
-import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import {
+  configureStore,
+  combineReducers,
+  ThunkDispatch
+} from "@reduxjs/toolkit";
 import {
   TypedUseSelectorHook,
   useSelector as rawUseSelector
@@ -9,6 +13,7 @@ import textReducer from "./text.slice";
 import userReducer from "./user.slice";
 import modalReducer from "./modal.slice";
 import urlReducer from "./url.slice";
+import guardedRequestsReducer from "./guardedRequests.slice";
 
 // TODO: We have planned to get rid of redux-persist.
 // When the step has been made to remove it all the persist setup should go as well.
@@ -25,7 +30,8 @@ export const store = configureStore({
       user: userReducer,
       text: textReducer,
       modal: modalReducer,
-      url: urlReducer
+      url: urlReducer,
+      guardedRequests: guardedRequestsReducer
     })
   ),
   devTools: process.env.NODE_ENV === "development"
@@ -34,4 +40,6 @@ export const store = configureStore({
 export const persistor = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export type TypedDispatch = ThunkDispatch<RootState, never, never>;
 export const useSelector: TypedUseSelectorHook<RootState> = rawUseSelector;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -5,5 +5,6 @@ const dateMatchesUsFormat = (date: string | null) => {
   const returnValue = dateFound && dateFound.length > 0 ? dateFound[0] : null;
   return returnValue;
 };
+export const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
 
 export default dateMatchesUsFormat;

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -9,7 +9,7 @@ export const appendQueryParametersToUrl = (
   // We need to clone url in order not to manipulate the incoming object.
   const processedUrl = new URL(url);
   Object.keys(parameters).forEach((key) => {
-    processedUrl.searchParams.append(key, parameters[key]);
+    processedUrl.searchParams.set(key, parameters[key]);
   });
 
   return processedUrl;

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -35,7 +35,7 @@ export const setQueryParametersInUrl = (parameters: {
 };
 
 export const redirectTo = (url: URL): void => {
-  window.location.replace(url);
+  window.location.assign(url);
 };
 
 export const constructUrlWithPlaceholder = (

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -102,3 +102,12 @@ export const turnUrlStringsIntoObjects = (urls: { [key: string]: string }) => {
     {}
   );
 };
+
+export const replaceCurrentLocation = (replacementUrl: URL) => {
+  window.history.replaceState(null, "", replacementUrl);
+};
+
+export const removeQueryParametersFromUrl = (url: URL, parameter: string) => {
+  url.searchParams.delete(parameter);
+  return url;
+};

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -1,0 +1,6 @@
+import { hasToken } from "../../token";
+
+export const userIsAnonymous = () => {
+  return !hasToken("user");
+};
+export default {};

--- a/src/core/utils/types/ids.ts
+++ b/src/core/utils/types/ids.ts
@@ -1,3 +1,4 @@
 export type FaustId = `${number}`;
 export type Pid = `${number}-${string}:${FaustId}`;
 export type WorkId = `work-of:${number}-${string}:${FaustId}`;
+export type App = "material" | "search-header" | "search-result";

--- a/src/core/utils/types/ids.ts
+++ b/src/core/utils/types/ids.ts
@@ -1,4 +1,4 @@
 export type FaustId = `${number}`;
 export type Pid = `${number}-${string}:${FaustId}`;
 export type WorkId = `work-of:${number}-${string}:${FaustId}`;
-export type App = "material" | "search-header" | "search-result";
+export type GuardedAppId = "material" | "search-result";

--- a/src/core/utils/withSuffix.tsx
+++ b/src/core/utils/withSuffix.tsx
@@ -22,12 +22,14 @@ export default <T,>(
       })
     );
 
-    // Put found urls in redux store.
-    store.dispatch(
-      reduxAction({
-        entries: suffixEntries
-      })
-    );
+    // Put found props in redux store - if any.
+    if (Object.keys(suffixEntries).length) {
+      store.dispatch(
+        reduxAction({
+          entries: suffixEntries
+        })
+      );
+    }
     // Since this is a High Order Functional Component
     // we do not know what props we are dealing with.
     // That is a part of the design.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4531,7 +4531,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/hoist-non-react-statics@^3.3.1":
+"@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -4715,6 +4715,16 @@
   integrity sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.24":
+  version "7.1.24"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
+  integrity sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
@@ -16508,7 +16518,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.1.2, redux@^4.2.0:
+redux@^4.0.0, redux@^4.1.2, redux@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==


### PR DESCRIPTION
This PR is dealing with the scenario where a user wants to perform an action that is prohibited for anonymous users.
As it is now It has been implemented on the favourite button on search results and on the material page.

The flow that is covers:
* An anonymous user clicks the favourite button
* The request that should be fired for storing the material on the users favourite list is persisted via redux-persist
* The user is being redirected to dpl-cms via the authUrl that has been provided to the app. The authUrl gets a `current-path` url parameter attached so the user is redirected back to place where the favourite button was clicked.
* User logs in.
* User is being rediredted back to where the user came from
* The persisted request is fired and the app is being blocked until the request has been fired.
* The application runs after the request has been fires and the user can see the material has been added to the list by the heart that should be filled

The functionality consists of two major areas:
1. A redux (persisted) store that holds a request that could not be called before the user has been authenticated
2. A GuardedApp component that holds back the app if a user has been authenticated and has a persisted request. The app is withheld until the request has been executed.

 #### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-178

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Another PR is soon to be released on dpl-cms that handles the auth handling which this PR is depending upon:
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/122

Codecov is complaining. Please ignore it for now. It is not following the coverage we have agreed on in this project.