### PR TITLE
Info text under buttons in the material header.

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -5,6 +5,7 @@
     "src/core/cover-service-api/**/*.*",
     "src/core/dbc-gateway/**/*.*",
     "src/core/fbs/**/*.*",
-    "src/core/material-list-api/**/*.*"
+    "src/core/material-list-api/**/*.*",
+    "src/core/publizoni/**/*.*"
   ]
 }

--- a/.nycrc
+++ b/.nycrc
@@ -6,6 +6,6 @@
     "src/core/dbc-gateway/**/*.*",
     "src/core/fbs/**/*.*",
     "src/core/material-list-api/**/*.*",
-    "src/core/publizoni/**/*.*"
+    "src/core/publizon/**/*.*"
   ]
 }

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -93,7 +93,7 @@ export default {
     },
     outOfText: {
       name: "X 'out of' Y",
-      defaultValue: "out of",
+      defaultValue: "ud af",
       control: { type: "text" }
     },
     heartsIconText: {
@@ -224,6 +224,41 @@ export default {
     findOnShelfExpandButtonExplanationText: {
       name: "Find on shelf expand button explanation text",
       defaultValue: "This button opens a modal",
+      control: { type: "text" }
+    },
+    materialIsIncludedText: {
+      name: "Material is included",
+      defaultValue: "Materialet tæller ikke med i din lånerkvote",
+      control: { type: "text" }
+    },
+    weHaveShoppedText: {
+      name: "We have shopped",
+      defaultValue: "Vi har købt",
+      control: { type: "text" }
+    },
+    copiesThereIsText: {
+      name: "copies there is",
+      defaultValue: "eksemplarer. Der er",
+      control: { type: "text" }
+    },
+    reservationsForThisMaterialText: {
+      name: "Reservations for this material",
+      defaultValue: "reserveringer til dette materiale",
+      control: { type: "text" }
+    },
+    youHaveBorrowedText: {
+      name: "You have borrowed",
+      defaultValue: "Du har lånt",
+      control: { type: "text" }
+    },
+    possibleText: {
+      name: "Possible",
+      defaultValue: "mulige",
+      control: { type: "text" }
+    },
+    thisMonthText: {
+      name: "This month",
+      defaultValue: "denne måned",
       control: { type: "text" }
     }
   }

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -47,6 +47,13 @@ interface MaterialEntryTextProps {
   goToText: string;
   materialIsLoanedOutText: string;
   findOnShelfExpandButtonExplanationText: string;
+  materialIsIncludedText: string;
+  weHaveShoppedText: string;
+  copiesThereIsText: string;
+  reservationsForThisMaterialText: string;
+  youHaveBorrowedText: string;
+  possibleText: string;
+  thisMonthText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -11,6 +11,7 @@ export interface AvailabilityLabelProps {
   url?: URL;
   faustIds: string[];
   handleSelectManifestation?: () => void | undefined;
+  cursorPointer?: boolean;
 }
 
 export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
@@ -18,7 +19,8 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   selected = false,
   url,
   faustIds,
-  handleSelectManifestation
+  handleSelectManifestation,
+  cursorPointer = false
 }) => {
   const t = useText();
   const { data, isLoading, isError } = useGetAvailabilityV3({
@@ -41,6 +43,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
       {
         "pagefold-parent--xsmall availability-label--unselected": !selected
       },
+      { "cursor-pointer": cursorPointer },
       "text-label",
       "availability-label"
     ),

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -20,13 +20,15 @@ export interface AvailabilityLabelsProps {
   selectManifestationHandler?: (
     manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
+  cursorPointer?: boolean;
 }
 
 export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
   manifestations,
   workId,
   manifestation,
-  selectManifestationHandler
+  selectManifestationHandler,
+  cursorPointer = false
 }) => {
   const { materialUrl } = useUrls();
 
@@ -46,6 +48,7 @@ export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
           <AvailabilityLabel
             key={pid}
             url={url}
+            cursorPointer={cursorPointer}
             faustIds={[faustId]}
             manifestText={materialType}
             selected={

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -19,7 +19,7 @@ const MaterialAvailabilityText: React.FC<Props> = ({ manifestation }) => {
         if (item.code === "ONLINE" && manifestation.identifiers)
           return (
             <MaterialAvailabilityTextOnline
-              isbn={manifestation.identifiers?.[0].value}
+              isbn={manifestation.identifiers[0].value}
             />
           );
         return null;

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { ManifestationsSimpleFieldsFragment } from "../../../core/dbc-gateway/generated/graphql";
+import { Pid } from "../../../core/utils/types/ids";
+import MaterialAvailabilityTextOnline from "./online/MaterialAvailabilityTextOnline";
+import MaterialAvailabilityTextPhysical from "./physical/MaterialAvailabilityTextPhysical";
+
+interface Props {
+  manifestation: ManifestationsSimpleFieldsFragment;
+}
+
+const MaterialAvailabilityText: React.FC<Props> = ({ manifestation }) => {
+  return (
+    <>
+      {manifestation.accessTypes.map((item) => {
+        if (item.code === "PHYSICAL")
+          return (
+            <MaterialAvailabilityTextPhysical pid={manifestation.pid as Pid} />
+          );
+        if (item.code === "ONLINE") return <MaterialAvailabilityTextOnline />;
+        return null;
+      })}
+    </>
+  );
+};
+
+export default MaterialAvailabilityText;

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -16,7 +16,12 @@ const MaterialAvailabilityText: React.FC<Props> = ({ manifestation }) => {
           return (
             <MaterialAvailabilityTextPhysical pid={manifestation.pid as Pid} />
           );
-        if (item.code === "ONLINE") return <MaterialAvailabilityTextOnline />;
+        if (item.code === "ONLINE" && manifestation.identifiers)
+          return (
+            <MaterialAvailabilityTextOnline
+              isbn={manifestation.identifiers?.[0].value}
+            />
+          );
         return null;
       })}
     </>

--- a/src/components/material/MaterialAvailabilityText/generic/MaterialAvailabilityTextParagraph.tsx
+++ b/src/components/material/MaterialAvailabilityText/generic/MaterialAvailabilityTextParagraph.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+interface MaterialAvailabilityTextParagraphProps {
+  children: React.ReactNode | string;
+}
+
+const MaterialAvailabilityTextParagraph: React.FC<
+  MaterialAvailabilityTextParagraphProps
+> = ({ children }) => {
+  return <p className="mt-16 text-small-caption">{children}</p>;
+};
+
+export default MaterialAvailabilityTextParagraph;

--- a/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
+++ b/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
@@ -1,15 +1,58 @@
 import * as React from "react";
-import { Pid } from "../../../../core/utils/types/ids";
+import {
+  useGetV1ProductsIdentifier,
+  useGetV1UserLoansIdentifier
+} from "../../../../core/publizon/publizon";
+import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
 
 interface MaterialAvailabilityTextOnlineProps {
-  pid?: Pid;
+  isbn: string;
 }
 
 const MaterialAvailabilityTextOnline: React.FC<
   MaterialAvailabilityTextOnlineProps
-> = () => {
+> = ({ isbn }) => {
+  const t = useText();
+  // const costfreeID = "9788711321683";
+  // const notCostfreeID = "9788740047905";
+
+  //  TODO: get access to user details for checking number of reservations and loans
+  // const {
+  //   data: userLoansData,
+  //   isLoading: userLoansIsLoading,
+  //   isError: userLoansIsError
+  // } = useGetV1UserLoansIdentifier("9788771076950");
+
+  const {
+    data: productsData,
+    isLoading: productsIsLoading,
+    isError: productsIsError
+  } = useGetV1ProductsIdentifier(isbn);
+
+  if (productsIsLoading || productsIsError || !productsData) return null;
+
+  const costFree = productsData.product?.costFree;
+
+  if (costFree) {
+    return (
+      <MaterialAvailabilityTextParagraph>
+        Materialet tæller ikke med i din lånerkvote
+      </MaterialAvailabilityTextParagraph>
+    );
+  }
+
+  if (!costFree) {
+    return (
+      <MaterialAvailabilityTextParagraph>
+        Du har lånt X ud af Y mulige [materialte-type] denne måned
+      </MaterialAvailabilityTextParagraph>
+    );
+  }
+
   return (
-    <p className="mt-16 text-small-caption">MaterialAvailabilityTextOnline</p>
+    <MaterialAvailabilityTextParagraph>
+      MaterialAvailabilityTextOnline
+    </MaterialAvailabilityTextParagraph>
   );
 };
 

--- a/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
+++ b/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
@@ -3,6 +3,7 @@ import {
   useGetV1ProductsIdentifier,
   useGetV1UserLoansIdentifier
 } from "../../../../core/publizon/publizon";
+import { useText } from "../../../../core/utils/text";
 import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
 
 interface MaterialAvailabilityTextOnlineProps {
@@ -36,7 +37,7 @@ const MaterialAvailabilityTextOnline: React.FC<
   if (costFree) {
     return (
       <MaterialAvailabilityTextParagraph>
-        Materialet tæller ikke med i din lånerkvote
+        {t("materialIsIncludedText")}
       </MaterialAvailabilityTextParagraph>
     );
   }
@@ -44,16 +45,14 @@ const MaterialAvailabilityTextOnline: React.FC<
   if (!costFree) {
     return (
       <MaterialAvailabilityTextParagraph>
-        Du har lånt X ud af Y mulige [materialte-type] denne måned
+        {`${t("youHaveBorrowedText")} X ${t(
+          "outOfText"
+        )} Y [materialte-type] ${t("thisMonthText")}`}
       </MaterialAvailabilityTextParagraph>
     );
   }
 
-  return (
-    <MaterialAvailabilityTextParagraph>
-      MaterialAvailabilityTextOnline
-    </MaterialAvailabilityTextParagraph>
-  );
+  return null;
 };
 
 export default MaterialAvailabilityTextOnline;

--- a/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
+++ b/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {
-  useGetV1ProductsIdentifier,
-  useGetV1UserLoansIdentifier
+  useGetV1ProductsIdentifier
+  // useGetV1UserLoansIdentifier
 } from "../../../../core/publizon/publizon";
 import { useText } from "../../../../core/utils/text";
 import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
@@ -14,6 +14,7 @@ const MaterialAvailabilityTextOnline: React.FC<
   MaterialAvailabilityTextOnlineProps
 > = ({ isbn }) => {
   const t = useText();
+  // TODO: Below there are 2 different isbn numbers that can be used in useGetV1ProductsIdentifier. with and without "blue title"
   // const costfreeID = "9788711321683";
   // const notCostfreeID = "9788740047905";
 
@@ -32,27 +33,18 @@ const MaterialAvailabilityTextOnline: React.FC<
 
   if (productsIsLoading || productsIsError || !productsData) return null;
 
-  const costFree = productsData.product?.costFree;
+  // const costFree = productsData.product?.costFree;
+  const availabilityText = productsData.product?.costFree
+    ? t("materialIsIncludedText")
+    : `${t("youHaveBorrowedText")} X ${t("outOfText")} Y [materialte-type] ${t(
+        "thisMonthText"
+      )}`;
 
-  if (costFree) {
-    return (
-      <MaterialAvailabilityTextParagraph>
-        {t("materialIsIncludedText")}
-      </MaterialAvailabilityTextParagraph>
-    );
-  }
-
-  if (!costFree) {
-    return (
-      <MaterialAvailabilityTextParagraph>
-        {`${t("youHaveBorrowedText")} X ${t(
-          "outOfText"
-        )} Y [materialte-type] ${t("thisMonthText")}`}
-      </MaterialAvailabilityTextParagraph>
-    );
-  }
-
-  return null;
+  return (
+    <MaterialAvailabilityTextParagraph>
+      {availabilityText}
+    </MaterialAvailabilityTextParagraph>
+  );
 };
 
 export default MaterialAvailabilityTextOnline;

--- a/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
+++ b/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Pid } from "../../../../core/utils/types/ids";
+
+interface MaterialAvailabilityTextOnlineProps {
+  pid?: Pid;
+}
+
+const MaterialAvailabilityTextOnline: React.FC<
+  MaterialAvailabilityTextOnlineProps
+> = () => {
+  return (
+    <p className="mt-16 text-small-caption">MaterialAvailabilityTextOnline</p>
+  );
+};
+
+export default MaterialAvailabilityTextOnline;

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
+import { useText } from "../../../../core/utils/text";
 import { Pid } from "../../../../core/utils/types/ids";
 import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
 
@@ -11,6 +12,7 @@ interface MaterialAvailabilityTextPhysicalProps {
 const MaterialAvailabilityTextPhysical: React.FC<
   MaterialAvailabilityTextPhysicalProps
 > = ({ pid }) => {
+  const t = useText();
   const faustId = convertPostIdToFaustId(pid as Pid);
   const { data, isLoading, isError } = useGetHoldingsV3({
     recordid: [String(faustId)]
@@ -25,7 +27,11 @@ const MaterialAvailabilityTextPhysical: React.FC<
   );
 
   return (
-    <MaterialAvailabilityTextParagraph>{`Vi har indkøbt ${totalMaterials} eksemplarer. Der er ${totalReservations} reserveringer til dette materiale`}</MaterialAvailabilityTextParagraph>
+    <MaterialAvailabilityTextParagraph>{`${t(
+      "weHaveShoppedText"
+    )} ${totalMaterials} ${t("copiesThereIsText")} ${totalReservations} ${t(
+      "reservationsForThisMaterialText"
+    )}`}</MaterialAvailabilityTextParagraph>
   );
 };
 

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
+import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
+import { Pid } from "../../../../core/utils/types/ids";
+import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
+
+interface MaterialAvailabilityTextPhysicalProps {
+  pid: Pid;
+}
+
+const MaterialAvailabilityTextPhysical: React.FC<
+  MaterialAvailabilityTextPhysicalProps
+> = ({ pid }) => {
+  const faustId = convertPostIdToFaustId(pid as Pid);
+  const { data, isLoading, isError } = useGetHoldingsV3({
+    recordid: [String(faustId)]
+  });
+
+  if (isLoading || isError || !data) return null;
+
+  const totalReservations = data[0].reservations;
+  const totalMaterials = data[0].holdings.reduce(
+    (acc, curr) => acc + curr.materials.length,
+    0
+  );
+
+  return (
+    <MaterialAvailabilityTextParagraph>{`Vi har indkøbt ${totalMaterials} eksemplarer. Der er ${totalReservations} reserveringer til dette materiale`}</MaterialAvailabilityTextParagraph>
+  );
+};
+
+export default MaterialAvailabilityTextPhysical;

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { useDispatch } from "react-redux";
 import {
   ManifestationsSimpleFieldsFragment,
@@ -20,6 +20,7 @@ import ButtonFavourite, {
   ButtonFavouriteId
 } from "../button-favourite/button-favourite";
 import { Cover } from "../cover/cover";
+import MaterialAvailabilityText from "./MaterialAvailabilityText/MaterialAvailabilityText";
 import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialPeriodical from "./MaterialPeriodical";
@@ -110,6 +111,9 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <div className="material-header__button">
           {manifestation && <MaterialButtons manifestation={manifestation} />}
         </div>
+        {manifestation && (
+          <MaterialAvailabilityText manifestation={manifestation} />
+        )}
       </div>
     </header>
   );

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -94,6 +94,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <MaterialHeaderText title={String(title)} author={author} />
         <div className="material-header__availability-label">
           <AvailabiltityLabels
+            cursorPointer
             workId={wid as WorkId}
             manifestations={manifestations}
             manifestation={manifestation}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { useDispatch } from "react-redux";
 import {
   ManifestationsSimpleFieldsFragment,

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -129,6 +129,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
       </div>
       <div className="search-result-item__availability">
         <AvailabiltityLabels
+          cursorPointer
           workId={workId as WorkId}
           manifestations={manifestations}
         />

--- a/src/core/publizon/mutator/fetcher.ts
+++ b/src/core/publizon/mutator/fetcher.ts
@@ -1,6 +1,11 @@
 import { getToken, TOKEN_USER_KEY, TOKEN_LIBRARY_KEY } from "../../token";
 
-const baseURL = "https://pubhub-openplatform.dbc.dk/"; // use your own URL here or environment variable
+// const baseURL = "https://pubhub-openplatform.dbc.dk"; // use your own URL here or environment variable
+// TODO: This is a test url because the one above is not ready yet
+// You can test with these two ids in MaterialAvailabilityTextOnline
+// const costfreeID = "9788711321683";
+// const notCostfreeID = "9788740047905";
+const baseURL = "https://pubhub-openplatform.test.dbc.dk";
 
 type FetchParams =
   | string


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-149

#### Description
# This PR adds logic for the info text below buttons on the material header.

### MaterialAvailabilityText is a wrapper component
That checks whether the manifestation accessTypes is PHYSICAL or ONLINE where after it shows **MaterialAvailabilityTextPhysical**, **MaterialAvailabilityTextOnline** or both

### MaterialAvailabilityTextPhysical
Takes a PID id which it then turns into a FaustId and uses useGetHoldingsV3 to get total materials and total reservations

### MaterialAvailabilityTextOnline
Takes an ISBN number and uses useGetV1ProductsIdentifier to  check if manifestation is costFree (blue title)

### Still missing.
useGetV1UserLoansIdentifier must be used to find user's totalEbookLoans and ebookLoansRemaining

#### Screenshot of the result
<img width="416" alt="Skærmbillede 2022-08-29 kl  13 53 51" src="https://user-images.githubusercontent.com/49920322/187202247-5096752b-74a3-4454-bcaf-cf49f733a582.png">
<img width="416" alt="Skærmbillede 2022-08-29 kl  13 53 30" src="https://user-images.githubusercontent.com/49920322/187202254-a1c264bf-7260-4a0d-b700-399813feffcf.png">
<img width="426" alt="Skærmbillede 2022-08-29 kl  13 52 34" src="https://user-images.githubusercontent.com/49920322/187202256-d9298a1a-0f7d-41d7-9763-e130351dbe71.png">

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions