### PR TITLE
Use invert class in disclosures

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "1.6.0",
+    "@danskernesdigitalebibliotek/dpl-design-system": "1.6.1",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/material/disclosures/disclosure.tsx
+++ b/src/components/material/disclosures/disclosure.tsx
@@ -13,7 +13,7 @@ const Disclosure: FC<DisclosureProps> = ({ title, children, mainIconPath }) => {
     <details className="disclosure text-body-large">
       <summary className="disclosure__headline text-body-large">
         <div className="disclosure__icon bg-identity-tint-120 m-24">
-          <img className="disclosure__icon" src={mainIconPath} alt="" />
+          <img className="disclosure__icon invert" src={mainIconPath} alt="" />
         </div>
         {title}
         <img

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@1.6.0":
-  version "1.6.0"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/1.6.0/926476ede21addafd9b17d129126c21f4908954d#926476ede21addafd9b17d129126c21f4908954d"
-  integrity sha512-huMFJacLRbnCQZ01KaNn00vXokScfJyDBhAz+wt7qh/MGeDkM9b9J9uZ57h2hnWp00gBzsBTsw0OcheFcfH8KA==
+"@danskernesdigitalebibliotek/dpl-design-system@1.6.1":
+  version "1.6.1"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/1.6.1/1a15a29eca78dbfbc9708b3097dcebf076c2db5c#1a15a29eca78dbfbc9708b3097dcebf076c2db5c"
+  integrity sha512-Pfs7fZn4jR4WINg+BeOEV8h2f28OY0P05/Lk8xqW/JZHnOVidoqTmuk8mlugte0BKxk5wHaj6DSz7iTKeaxpcg==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
Bi-product of https://reload.atlassian.net/browse/DDFSOEG-150

#### Description
This PR updates the dpl-design-system package which introduces a new utility class "invert" that we use to get inverted disclosure icons.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/186432758-52f7c2e2-8694-4d25-8319-71bf0932c54d.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
