### PR TITLE
Add MaterialPeriodical

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "1.7.0",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-dd506fcff82b3c68537f2c0daf2ce241c68cbaa3",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -31,9 +31,9 @@ export default {
       defaultValue: "År",
       control: { type: "text" }
     },
-    periodikumSelectWeekText: {
+    periodikumSelectEditionText: {
       name: "Week",
-      defaultValue: "Uge",
+      defaultValue: "Udgave",
       control: { type: "text" }
     },
     reserveBookText: {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -26,12 +26,12 @@ export default {
       defaultValue: "Af ",
       control: { type: "text" }
     },
-    periodikumSelectYearText: {
+    periodicalSelectYearText: {
       name: "Year",
       defaultValue: "År",
       control: { type: "text" }
     },
-    periodikumSelectEditionText: {
+    periodicalSelectEditionText: {
       name: "Week",
       defaultValue: "Udgave",
       control: { type: "text" }

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -7,8 +7,8 @@ import Material from "./material";
 
 interface MaterialEntryTextProps {
   materialHeaderAuthorByText: string;
-  periodikumSelectYearText: string;
-  periodikumSelectEditionText: string;
+  periodicalSelectYearText: string;
+  periodicalSelectEditionText: string;
   reserveBookText: string;
   findOnBookshelfText: string;
   descriptionHeadlineText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -8,7 +8,7 @@ import Material from "./material";
 interface MaterialEntryTextProps {
   materialHeaderAuthorByText: string;
   periodikumSelectYearText: string;
-  periodikumSelectWeekText: string;
+  periodikumSelectEditionText: string;
   reserveBookText: string;
   findOnBookshelfText: string;
   descriptionHeadlineText: string;

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -1,37 +1,37 @@
 describe("Material", () => {
-  it("Should render the material page as expected", () => {
-    cy.log("Does the Material have title?");
+  it("Does the Material have title?", () => {
     cy.contains("Dummy Some Title: Full");
-
-    cy.log("Check that cover has a src");
+  });
+  it("Check that cover has a src", () => {
     cy.get("img").should(
       "have.attr",
       "src",
       "https:res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_large/v1605727140/bogportalen.dk/9781848485532.jpg"
     );
-
-    cy.log("Does the material have favourite buttons?");
+  });
+  it("Does the material have favourite buttons?", () => {
     cy.get(".button-favourite").should(
       "have.attr",
       "aria-label",
       "Add to favorites"
     );
-
-    cy.log("Does the material have horizontal lines?");
+  });
+  it("Does the material have horizontal lines?", () => {
     cy.contains("Nr 1 i serien");
     cy.contains("Dummy Some Series");
-
-    cy.log("Does the material have authors?");
+  });
+  it("Does the material have authors?", () => {
     cy.contains("Af Dummy Jens Jensen");
+  });
 
-    cy.log("Does a material have a availibility label");
+  it("Does a material have a availibility label", () => {
     cy.contains("Dummy bog");
     cy.contains("unavailable");
-
-    cy.log("Open material details");
+  });
+  it("Open material details", () => {
     cy.get("details").click({ multiple: true });
-
-    cy.log("Does the material have a editions with a buttton to reserve");
+  });
+  it("Does the material have a editions with a buttton to reserved", () => {
     cy.contains("reserver");
   });
 

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -100,7 +100,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           currentManifestation as ManifestationsSimpleFieldsFragment
         }
         selectManifestationHandler={setCurrentManifestation}
-        selectPeriodikumSelect={setPriodikumSelect}
+        selectPeriodicalSelect={setPriodikumSelect}
       />
       <MaterialDescription pid={pid} work={data.work} />
       <Disclosure

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -39,6 +39,10 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const [currentManifestation, setCurrentManifestation] =
     useState<ManifestationsSimpleFieldsFragment | null>(null);
 
+  // periodicalSelect must be used later to change the UI and reservation when you have chosen a specific periodical
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [periodicalSelect, setPriodikumSelect] = useState<string | null>(null);
+
   const { data, isLoading } = useGetMaterialQuery({
     wid
   });
@@ -96,6 +100,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           currentManifestation as ManifestationsSimpleFieldsFragment
         }
         selectManifestationHandler={setCurrentManifestation}
+        selectPeriodikumSelect={setPriodikumSelect}
       />
       <MaterialDescription pid={pid} work={data.work} />
       <Disclosure

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -41,7 +41,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
 
   // periodicalSelect must be used later to change the UI and reservation when you have chosen a specific periodical
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [periodicalSelect, setPriodikumSelect] = useState<string | null>(null);
+  const [periodicalSelect, setPeriodicalSelect] = useState<string | null>(null);
 
   const { data, isLoading } = useGetMaterialQuery({
     wid
@@ -100,7 +100,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           currentManifestation as ManifestationsSimpleFieldsFragment
         }
         selectManifestationHandler={setCurrentManifestation}
-        selectPeriodicalSelect={setPriodikumSelect}
+        selectPeriodicalSelect={setPeriodicalSelect}
       />
       <MaterialDescription pid={pid} work={data.work} />
       <Disclosure

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -77,7 +77,9 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const coverPid =
     (manifestation?.pid as Pid) || getManifestationPid(manifestations);
 
-  const faustId = convertPostIdToFaustId(manifestation?.pid as Pid);
+  const faustId = manifestation
+    ? convertPostIdToFaustId(manifestation?.pid as Pid)
+    : "";
 
   return (
     <header className="material-header">

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -23,7 +23,7 @@ import ButtonLargeOutline from "../Buttons/ButtonLargeOutline";
 import { Cover } from "../cover/cover";
 import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialButtons from "./material-buttons/MaterialButtons";
-import MaterialPeriodikum from "./MaterialPeriodikum";
+import MaterialPeriodical from "./MaterialPeriodical";
 import { getUrlQueryParam } from "../../core/utils/helpers/url";
 
 interface MaterialHeaderProps {
@@ -33,7 +33,7 @@ interface MaterialHeaderProps {
   selectManifestationHandler: (
     manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
-  selectPeriodikumSelect: (periodikumSelect: string | null) => void;
+  selectPeriodicalSelect: (periodicalSelect: string | null) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -46,10 +46,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   },
   manifestation,
   selectManifestationHandler,
-  selectPeriodikumSelect
+  selectPeriodicalSelect
 }) => {
   // THIS MUST BE DELETED (START
-  const isDemoPeriodikum = getUrlQueryParam("periodikum");
+  const isDemoPeriodical = getUrlQueryParam("periodical");
   // THIS MUST BE DELETED (END)
   const t = useText();
   const dispatch = useDispatch<TypedDispatch>();
@@ -104,13 +104,13 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         </div>
 
         {
-          // isDemoPeriodikum logic MUST BE DELETED
-          // TODO check and show if manifestation needs PeriodikumSelect.
+          // isDemoPeriodical logic MUST BE DELETED
+          // TODO check and show if manifestation needs PeriodicalSelect.
           // manifestation?.source.includes("Dummy some source") &&
-          isDemoPeriodikum && faustId && (
-            <MaterialPeriodikum
-              faustId={isDemoPeriodikum ? "49333536" : faustId}
-              selectPeriodikumSelect={selectPeriodikumSelect}
+          isDemoPeriodical && faustId && (
+            <MaterialPeriodical
+              faustId={isDemoPeriodical ? "49333536" : faustId}
+              selectPeriodicalSelect={selectPeriodicalSelect}
             />
           )
         }

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -24,7 +24,6 @@ import { Cover } from "../cover/cover";
 import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialPeriodical from "./MaterialPeriodical";
-import { getUrlQueryParam } from "../../core/utils/helpers/url";
 
 interface MaterialHeaderProps {
   wid: WorkId;
@@ -48,9 +47,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   selectManifestationHandler,
   selectPeriodicalSelect
 }) => {
-  // THIS MUST BE DELETED (START
-  const isDemoPeriodical = getUrlQueryParam("periodical");
-  // THIS MUST BE DELETED (END)
   const t = useText();
   const dispatch = useDispatch<TypedDispatch>();
   const addToListRequest = (id: ButtonFavouriteId) => {
@@ -103,17 +99,13 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           />
         </div>
 
-        {
-          // isDemoPeriodical logic MUST BE DELETED
-          // TODO check and show if manifestation needs PeriodicalSelect.
-          // manifestation?.source.includes("Dummy some source") &&
-          isDemoPeriodical && faustId && (
-            <MaterialPeriodical
-              faustId={isDemoPeriodical ? "49333536" : faustId}
-              selectPeriodicalSelect={selectPeriodicalSelect}
-            />
-          )
-        }
+        {manifestation?.source.includes("bibliotekskatalog") && faustId && (
+          <MaterialPeriodical
+            faustId={faustId}
+            selectPeriodicalSelect={selectPeriodicalSelect}
+          />
+        )}
+
         <div className="material-header__button">
           {manifestation && <MaterialButtons manifestation={manifestation} />}
           <ButtonLargeOutline

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -7,6 +7,7 @@ import {
 import { guardedRequest } from "../../core/guardedRequests.slice";
 import { TypedDispatch } from "../../core/store";
 import {
+  convertPostIdToFaustId,
   creatorsToString,
   filterCreators,
   flattenCreators,
@@ -21,8 +22,9 @@ import ButtonFavourite, {
 import ButtonLargeOutline from "../Buttons/ButtonLargeOutline";
 import { Cover } from "../cover/cover";
 import MaterialHeaderText from "./MaterialHeaderText";
-import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
 import MaterialButtons from "./material-buttons/MaterialButtons";
+import MaterialPeriodikum from "./MaterialPeriodikum";
+import { getUrlQueryParam } from "../../core/utils/helpers/url";
 
 interface MaterialHeaderProps {
   wid: WorkId;
@@ -31,6 +33,7 @@ interface MaterialHeaderProps {
   selectManifestationHandler: (
     manifestation: ManifestationsSimpleFieldsFragment
   ) => void;
+  selectPeriodikumSelect: (periodikumSelect: string | null) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -42,8 +45,12 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     workId: wid
   },
   manifestation,
-  selectManifestationHandler
+  selectManifestationHandler,
+  selectPeriodikumSelect
 }) => {
+  // THIS MUST BE DELETED (START
+  const isDemoPeriodikum = getUrlQueryParam("periodikum");
+  // THIS MUST BE DELETED (END)
   const t = useText();
   const dispatch = useDispatch<TypedDispatch>();
   const addToListRequest = (id: ButtonFavouriteId) => {
@@ -74,6 +81,8 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const coverPid =
     (manifestation?.pid as Pid) || getManifestationPid(manifestations);
 
+  const faustId = convertPostIdToFaustId(manifestation?.pid as Pid);
+
   return (
     <header className="material-header">
       <div className="material-header__cover">
@@ -94,8 +103,17 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           />
         </div>
 
-        {/* Check and show if data has PeriodikumSelect. */}
-        {false && <MaterialPeriodikumSelect />}
+        {
+          // isDemoPeriodikum logic MUST BE DELETED
+          // TODO check and show if manifestation needs PeriodikumSelect.
+          // manifestation?.source.includes("Dummy some source") &&
+          isDemoPeriodikum && faustId && (
+            <MaterialPeriodikum
+              faustId={isDemoPeriodikum ? "49333536" : faustId}
+              selectPeriodikumSelect={selectPeriodikumSelect}
+            />
+          )
+        }
         <div className="material-header__button">
           {manifestation && <MaterialButtons manifestation={manifestation} />}
           <ButtonLargeOutline

--- a/src/components/material/MaterialPeriodical.tsx
+++ b/src/components/material/MaterialPeriodical.tsx
@@ -34,8 +34,6 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
 
   return (
     <MaterialPeriodicalSelect
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       groupList={groupObjectArrayByProperty(materialsPeriodical, "volumeYear")}
       selectPeriodicalSelect={selectPeriodicalSelect}
     />

--- a/src/components/material/MaterialPeriodical.tsx
+++ b/src/components/material/MaterialPeriodical.tsx
@@ -3,16 +3,16 @@ import { FC } from "react";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
 import { FaustId } from "../../core/utils/types/ids";
-import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
+import MaterialPeriodicalSelect from "./MaterialPeriodicalSelect";
 
-export interface MaterialPeriodikumProps {
+export interface MaterialPeriodicalProps {
   faustId: FaustId;
-  selectPeriodikumSelect: (periodikumSelect: string | null) => void;
+  selectPeriodicalSelect: (periodicalSelect: string | null) => void;
 }
 
-const MaterialPeriodikum: FC<MaterialPeriodikumProps> = ({
+const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   faustId,
-  selectPeriodikumSelect
+  selectPeriodicalSelect
 }) => {
   const { data, isLoading, isError } = useGetHoldingsV3({
     recordid: [String(faustId)]
@@ -20,8 +20,8 @@ const MaterialPeriodikum: FC<MaterialPeriodikumProps> = ({
 
   if (isLoading || isError || !data) return null;
 
-  // This make a array of all periodikum editions
-  const materialsPeriodical = data[0]?.holdings
+  // This make a array of all periodical editions
+  const materialsPeriodical = data[0].holdings
     // Get all holdings
     .map((holding) => {
       // Make all editions from holdings into one array
@@ -33,13 +33,13 @@ const MaterialPeriodikum: FC<MaterialPeriodikumProps> = ({
     .flat();
 
   return (
-    <MaterialPeriodikumSelect
+    <MaterialPeriodicalSelect
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       groupList={groupObjectArrayByProperty(materialsPeriodical, "volumeYear")}
-      selectPeriodikumSelect={selectPeriodikumSelect}
+      selectPeriodicalSelect={selectPeriodicalSelect}
     />
   );
 };
 
-export default MaterialPeriodikum;
+export default MaterialPeriodical;

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -9,6 +9,7 @@ export type GroupListItem = {
   volumeYear: string;
 };
 
+export type GroupList = { [key: string]: GroupListItem[] };
 interface MaterialPeriodicalSelectProps {
   groupList: GroupList;
   selectPeriodicalSelect: (periodicalSelect: string | null) => void;

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -9,14 +9,14 @@ export type GroupListItem = {
   volumeYear: string;
 };
 
-interface MaterialPeriodikumSelectProps {
-  groupList: { [key: string]: GroupListItem[] };
-  selectPeriodikumSelect: (periodikumSelect: string | null) => void;
+interface MaterialPeriodicalSelectProps {
+  groupList: GroupList;
+  selectPeriodicalSelect: (periodicalSelect: string | null) => void;
 }
 
-const MaterialPeriodikumSelect: React.FC<MaterialPeriodikumSelectProps> = ({
+const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   groupList,
-  selectPeriodikumSelect
+  selectPeriodicalSelect
 }) => {
   const last = String(Object.keys(groupList).sort().pop());
   const t = useText();
@@ -25,9 +25,7 @@ const MaterialPeriodikumSelect: React.FC<MaterialPeriodikumSelectProps> = ({
   return (
     <div className="text-small-caption material-periodikum ">
       <div className="material-periodikum-select">
-        {/* This is because the design requires label and select input to be separated */}
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-        <label htmlFor="year">{t("periodikumSelectYearText")}</label>
+        <label htmlFor="year">{t("periodicalSelectYearText")}</label>
         <div className="material-periodikum-select__border-container">
           <select
             id="year"
@@ -47,13 +45,11 @@ const MaterialPeriodikumSelect: React.FC<MaterialPeriodikumSelectProps> = ({
 
       {year && (
         <div className="material-periodikum-select">
-          {/* This is because the design requires label and select input to be separated */}
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label htmlFor="editions">{t("periodikumSelectEditionText")}</label>
           <div className="material-periodikum-select__border-container">
             <select
               id="editions"
-              onChange={(e) => selectPeriodikumSelect(e.target.value)}
+              onChange={(e) => selectPeriodicalSelect(e.target.value)}
             >
               {groupList[year]?.map((item) => {
                 return (
@@ -70,4 +66,4 @@ const MaterialPeriodikumSelect: React.FC<MaterialPeriodikumSelectProps> = ({
   );
 };
 
-export default MaterialPeriodikumSelect;
+export default MaterialPeriodicalSelect;

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -24,10 +24,10 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   const [year, setYear] = useState<string>(last);
 
   return (
-    <div className="text-small-caption material-periodikum ">
-      <div className="material-periodikum-select">
+    <div className="text-small-caption material-periodical ">
+      <div className="material-periodical-select">
         <label htmlFor="year">{t("periodicalSelectYearText")}</label>
-        <div className="material-periodikum-select__border-container">
+        <div className="material-periodical-select__border-container">
           <select
             id="year"
             defaultValue={year}
@@ -45,9 +45,9 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
       </div>
 
       {year && (
-        <div className="material-periodikum-select">
-          <label htmlFor="editions">{t("periodikumSelectEditionText")}</label>
-          <div className="material-periodikum-select__border-container">
+        <div className="material-periodical-select">
+          <label htmlFor="editions">{t("periodicalSelectEditionText")}</label>
+          <div className="material-periodical-select__border-container">
             <select
               id="editions"
               onChange={(e) => selectPeriodicalSelect(e.target.value)}

--- a/src/components/material/MaterialPeriodikum.tsx
+++ b/src/components/material/MaterialPeriodikum.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { FC } from "react";
+import { useGetHoldingsV3 } from "../../core/fbs/fbs";
+import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
+import { FaustId } from "../../core/utils/types/ids";
+import MaterialPeriodikumSelect from "./MaterialPeriodikumSelect";
+
+export interface MaterialPeriodikumProps {
+  faustId: FaustId;
+  selectPeriodikumSelect: (periodikumSelect: string | null) => void;
+}
+
+const MaterialPeriodikum: FC<MaterialPeriodikumProps> = ({
+  faustId,
+  selectPeriodikumSelect
+}) => {
+  const { data, isLoading, isError } = useGetHoldingsV3({
+    recordid: [String(faustId)]
+  });
+
+  if (isLoading || isError || !data) return null;
+
+  // This make a array of all periodikum editions
+  const materialsPeriodical = data[0]?.holdings
+    // Get all holdings
+    .map((holding) => {
+      // Make all editions from holdings into one array
+      return holding.materials.flat().map((material) => {
+        // Return a object that contains editions + itemNumber
+        return { ...material.periodical, itemNumber: material.itemNumber };
+      });
+    })
+    .flat();
+
+  return (
+    <MaterialPeriodikumSelect
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      groupList={groupObjectArrayByProperty(materialsPeriodical, "volumeYear")}
+      selectPeriodikumSelect={selectPeriodikumSelect}
+    />
+  );
+};
+
+export default MaterialPeriodikum;

--- a/src/components/material/MaterialPeriodikumSelect.tsx
+++ b/src/components/material/MaterialPeriodikumSelect.tsx
@@ -35,10 +35,10 @@ const MaterialPeriodikumSelect: React.FC<MaterialPeriodikumSelectProps> = ({
         <div className="material-periodikum-select">
           {/* This is because the design requires label and select input to be separated */}
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label htmlFor="weeks">{t("periodikumSelectWeekText")}</label>
+          <label htmlFor="editions">{t("periodikumSelectEditionText")}</label>
           <div className="material-periodikum-select__border-container">
             <select id="weeks">
-              {weeks.map((week) => (
+              id="editions"
                 <option key={week} value={week}>
                   {week}
                 </option>

--- a/src/components/material/MaterialPeriodikumSelect.tsx
+++ b/src/components/material/MaterialPeriodikumSelect.tsx
@@ -1,48 +1,67 @@
-import React from "react";
+import React, { useState } from "react";
 import { useText } from "../../core/utils/text";
 
-// create interface for MaterialPeriodikumSelectProps widt a list of strings
+export type GroupListItem = {
+  displayText: string;
+  itemNumber: string;
+  volume: string;
+  volumeNumber: string;
+  volumeYear: string;
+};
+
 interface MaterialPeriodikumSelectProps {
-  years?: string[];
-  weeks?: string[];
+  groupList: { [key: string]: GroupListItem[] };
+  selectPeriodikumSelect: (periodikumSelect: string | null) => void;
 }
 
 const MaterialPeriodikumSelect: React.FC<MaterialPeriodikumSelectProps> = ({
-  years,
-  weeks
+  groupList,
+  selectPeriodikumSelect
 }) => {
+  const last = String(Object.keys(groupList).sort().pop());
   const t = useText();
+  const [year, setYear] = useState<string>(last);
 
   return (
     <div className="text-small-caption material-periodikum ">
-      {years && (
-        <div className="material-periodikum-select">
-          {/* This is because the design requires label and select input to be separated */}
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label htmlFor="year">{t("periodikumSelectYearText")}</label>
-          <div className="material-periodikum-select__border-container">
-            <select id="year">
-              {years.map((year) => (
-                <option key={year} value={year}>
-                  {year}
+      <div className="material-periodikum-select">
+        {/* This is because the design requires label and select input to be separated */}
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label htmlFor="year">{t("periodikumSelectYearText")}</label>
+        <div className="material-periodikum-select__border-container">
+          <select
+            id="year"
+            defaultValue={year}
+            onChange={(e) => setYear(e.target.value)}
+          >
+            {Object.keys(groupList)
+              .sort()
+              .map((item) => (
+                <option key={item} value={item}>
+                  {item}
                 </option>
               ))}
-            </select>
-          </div>
+          </select>
         </div>
-      )}
-      {weeks && (
+      </div>
+
+      {year && (
         <div className="material-periodikum-select">
           {/* This is because the design requires label and select input to be separated */}
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label htmlFor="editions">{t("periodikumSelectEditionText")}</label>
           <div className="material-periodikum-select__border-container">
-            <select id="weeks">
+            <select
               id="editions"
-                <option key={week} value={week}>
-                  {week}
-                </option>
-              ))}
+              onChange={(e) => selectPeriodikumSelect(e.target.value)}
+            >
+              {groupList[year]?.map((item) => {
+                return (
+                  <option key={item.itemNumber} value={item.itemNumber}>
+                    {item.volumeNumber}
+                  </option>
+                );
+              })}
             </select>
           </div>
         </div>

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -10,6 +10,7 @@ fragment ManifestationsSimple on Manifestations {
 fragment ManifestationsSimpleFields on Manifestation {
   pid
   genreAndForm
+  source
   titles {
     main
     original

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -525,6 +525,201 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "ComplexSearchFilters",
+        "description": "Search Filters",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "branchId",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "department",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "HoldingsStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sublocation",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComplexSearchResponse",
+        "description": "The search response",
+        "fields": [
+          {
+            "name": "hitcount",
+            "description": "Total number of works found. May be used for pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "works",
+            "description": "The works matching the given search query. Use offset and limit for pagination.",
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "PaginationLimit",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Work",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Corporation",
         "description": null,
@@ -4565,6 +4760,51 @@
         "name": "Query",
         "description": null,
         "fields": [
+          {
+            "name": "complexSearch",
+            "description": null,
+            "args": [
+              {
+                "name": "cql",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ComplexSearchFilters",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ComplexSearchResponse",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "infomedia",
             "description": null,

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -101,6 +101,30 @@ export type Classification = {
   system: Scalars["String"];
 };
 
+/** Search Filters */
+export type ComplexSearchFilters = {
+  branchId?: InputMaybe<Array<Scalars["String"]>>;
+  department?: InputMaybe<Array<Scalars["String"]>>;
+  location?: InputMaybe<Array<Scalars["String"]>>;
+  status?: InputMaybe<Array<HoldingsStatus>>;
+  sublocation?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+/** The search response */
+export type ComplexSearchResponse = {
+  __typename?: "ComplexSearchResponse";
+  /** Total number of works found. May be used for pagination. */
+  hitcount: Scalars["Int"];
+  /** The works matching the given search query. Use offset and limit for pagination. */
+  works: Array<Work>;
+};
+
+/** The search response */
+export type ComplexSearchResponseWorksArgs = {
+  limit: Scalars["PaginationLimit"];
+  offset: Scalars["Int"];
+};
+
 export type Corporation = Creator &
   Subject & {
     __typename?: "Corporation";
@@ -699,6 +723,7 @@ export type PublicationYear = {
 
 export type Query = {
   __typename?: "Query";
+  complexSearch: ComplexSearchResponse;
   infomedia: InfomediaResponse;
   localSuggest: LocalSuggestResponse;
   manifestation?: Maybe<Manifestation>;
@@ -711,6 +736,11 @@ export type Query = {
   suggest: SuggestResponse;
   work?: Maybe<Work>;
   works: Array<Maybe<Work>>;
+};
+
+export type QueryComplexSearchArgs = {
+  cql: Scalars["String"];
+  filters?: InputMaybe<ComplexSearchFilters>;
 };
 
 export type QueryInfomediaArgs = {
@@ -1202,6 +1232,7 @@ export type GetMaterialQuery = {
         __typename?: "Manifestation";
         pid: string;
         genreAndForm: Array<string>;
+        source: Array<string>;
         titles: {
           __typename?: "ManifestationTitles";
           main: Array<string>;
@@ -1259,6 +1290,7 @@ export type GetMaterialQuery = {
         __typename?: "Manifestation";
         pid: string;
         genreAndForm: Array<string>;
+        source: Array<string>;
         titles: {
           __typename?: "ManifestationTitles";
           main: Array<string>;
@@ -1386,6 +1418,7 @@ export type SearchWithPaginationQuery = {
           __typename?: "Manifestation";
           pid: string;
           genreAndForm: Array<string>;
+          source: Array<string>;
           titles: {
             __typename?: "ManifestationTitles";
             main: Array<string>;
@@ -1449,6 +1482,7 @@ export type SearchWithPaginationQuery = {
           __typename?: "Manifestation";
           pid: string;
           genreAndForm: Array<string>;
+          source: Array<string>;
           titles: {
             __typename?: "ManifestationTitles";
             main: Array<string>;
@@ -1548,6 +1582,7 @@ export type ManifestationsSimpleFragment = {
     __typename?: "Manifestation";
     pid: string;
     genreAndForm: Array<string>;
+    source: Array<string>;
     titles: {
       __typename?: "ManifestationTitles";
       main: Array<string>;
@@ -1602,6 +1637,7 @@ export type ManifestationsSimpleFragment = {
     __typename?: "Manifestation";
     pid: string;
     genreAndForm: Array<string>;
+    source: Array<string>;
     titles: {
       __typename?: "ManifestationTitles";
       main: Array<string>;
@@ -1658,6 +1694,7 @@ export type ManifestationsSimpleFieldsFragment = {
   __typename?: "Manifestation";
   pid: string;
   genreAndForm: Array<string>;
+  source: Array<string>;
   titles: {
     __typename?: "ManifestationTitles";
     main: Array<string>;
@@ -1761,6 +1798,7 @@ export type WorkSmallFragment = {
       __typename?: "Manifestation";
       pid: string;
       genreAndForm: Array<string>;
+      source: Array<string>;
       titles: {
         __typename?: "ManifestationTitles";
         main: Array<string>;
@@ -1815,6 +1853,7 @@ export type WorkSmallFragment = {
       __typename?: "Manifestation";
       pid: string;
       genreAndForm: Array<string>;
+      source: Array<string>;
       titles: {
         __typename?: "ManifestationTitles";
         main: Array<string>;
@@ -1958,6 +1997,7 @@ export type WorkMediumFragment = {
       __typename?: "Manifestation";
       pid: string;
       genreAndForm: Array<string>;
+      source: Array<string>;
       titles: {
         __typename?: "ManifestationTitles";
         main: Array<string>;
@@ -2012,6 +2052,7 @@ export type WorkMediumFragment = {
       __typename?: "Manifestation";
       pid: string;
       genreAndForm: Array<string>;
+      source: Array<string>;
       titles: {
         __typename?: "ManifestationTitles";
         main: Array<string>;
@@ -2081,6 +2122,7 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
     fragment ManifestationsSimpleFields on Manifestation {
   pid
   genreAndForm
+  source
   titles {
     main
     original

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -151,7 +151,7 @@ export const getAmountOfRenewableLoans = (list: LoanV2[]) => {
 };
 
 // TODO FIX TS ERRORS
-// MaterialPeriodikum.tsx#L37
+// MaterialPeriodical.tsx#L37
 export const groupObjectArrayByProperty = <
   P extends string,
   T extends Record<P, string> & Record<string, unknown>

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -150,27 +150,31 @@ export const getAmountOfRenewableLoans = (list: LoanV2[]) => {
   return getRenewableMaterials(list).length;
 };
 
-// TODO FIX TS ERRORS
-// MaterialPeriodical.tsx#L37
 export const groupObjectArrayByProperty = <
   P extends string,
-  T extends Record<P, string> & Record<string, unknown>
+  T extends { [key in P]?: string },
+  Result extends { [key: string]: T[] }
 >(
   array: T[],
   property: P
 ) =>
-  array.reduce<Record<string, T[]>>(
-    (result: { [key: string]: T[] }, current: T) => {
-      const groupBy = current[property];
-      // Merge into result if the property already exist.
-      if (groupBy in result) {
-        return {
-          ...result,
-          [groupBy]: [...result[groupBy], current]
-        };
-      }
-      // Otherwise create new property.
-      return { ...result, [groupBy]: [current] };
-    },
-    {}
-  );
+  array.reduce((result: Result, current: T) => {
+    const groupBy = current[property];
+    // If for some reason we do not have a value we just return the accumulated result.
+    if (!groupBy) {
+      return result;
+    }
+
+    // Make sure that the new aggregation key is a string.
+    const key = String(groupBy);
+
+    // Merge into result if the property already exist.
+    if (key in result) {
+      return {
+        ...result,
+        [key]: [...result[key], current]
+      };
+    }
+    // Otherwise create new property.
+    return { ...result, [key]: [current] };
+  }, {} as Result);

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -149,3 +149,28 @@ export const getRenewableMaterials = (list: LoanV2[]) => {
 export const getAmountOfRenewableLoans = (list: LoanV2[]) => {
   return getRenewableMaterials(list).length;
 };
+
+// TODO FIX TS ERRORS
+// MaterialPeriodikum.tsx#L37
+export const groupObjectArrayByProperty = <
+  P extends string,
+  T extends Record<P, string> & Record<string, unknown>
+>(
+  array: T[],
+  property: P
+) =>
+  array.reduce<Record<string, T[]>>(
+    (result: { [key: string]: T[] }, current: T) => {
+      const groupBy = current[property];
+      // Merge into result if the property already exist.
+      if (groupBy in result) {
+        return {
+          ...result,
+          [groupBy]: [...result[groupBy], current]
+        };
+      }
+      // Otherwise create new property.
+      return { ...result, [groupBy]: [current] };
+    },
+    {}
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@1.7.0":
-  version "1.7.0"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/1.7.0/29a20bcaf9dba2148036917eb76190e5c9e1d35b#29a20bcaf9dba2148036917eb76190e5c9e1d35b"
-  integrity sha512-a0Py38HVzGqR2KjJdjpjzmTO2MOoUEH/nuQGffh+QjZpgVkgYCn3bD7zndIDbKGDlwS5rnX2x0sMHLqH1On2vw==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-dd506fcff82b3c68537f2c0daf2ce241c68cbaa3":
+  version "0.0.0-dd506fcff82b3c68537f2c0daf2ce241c68cbaa3"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-dd506fcff82b3c68537f2c0daf2ce241c68cbaa3/704304e87358779076743a582a85740a3d03de61#704304e87358779076743a582a85740a3d03de61"
+  integrity sha512-MyWAXnnJHVZQz2CW8ftft9MeUs20pZNFQs/PwdVBTu4rm4NTihOlG5n30tAbj3A5zktMNXWoKrbnD61dsZPV6A==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-182

#### Description

# This PR is introducing MaterialPeriodical

### MaterialPeriodical
Is a wrapper component that is only rendered if a manifestation has a source that matches types that needs a PeriodicalSelect. it also fetches data with useGetHoldingsV3 and manipulates it before it renders MaterialPeriodicalSelect

### MaterialPeriodikumSelect 
Has a setState function (selectPeriodicalSelect)  that comes from the root in the Material app. This will be used later...

#### Additional comments or questions
** groupBy  global function needs to be rewritten to typeScript **

#### Screenshot of the result
<img width="1725" alt="Skærmbillede 2022-08-31 kl  14 39 16" src="https://user-images.githubusercontent.com/49920322/187680382-b92c3973-12e1-4b70-b39b-fa46c7793016.png">
<img width="1722" alt="Skærmbillede 2022-08-31 kl  14 39 06" src="https://user-images.githubusercontent.com/49920322/187680393-bf753a81-f094-45a0-80c8-d59fa7f41756.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

