### PR TITLE
Feature/infomedia reviews

### DIFF
--- a/src/components/material/ReviewInfomedia.tsx
+++ b/src/components/material/ReviewInfomedia.tsx
@@ -51,9 +51,16 @@ const ReviewInfomedia: React.FC<ReviewInfomediaProps> = ({ review }) => {
           {infomedia.article.headLine}
         </div>
       )}
+      {/* We consider infomedia to be a trustworthy source & decided not to
+      sanitize the text data that we render as HTML. */}
+      {/* eslint-disable react/no-danger */}
       {infomedia.article?.text && (
-        <p className="review__body mb-8">{infomedia.article?.text}</p>
+        <p
+          className="review__body mb-8"
+          dangerouslySetInnerHTML={{ __html: infomedia.article?.text }}
+        />
       )}
+      {/* eslint-enable react/no-danger */}
       {review.origin && (
         <ReviewMetadata
           author={review.author}

--- a/src/core/dbc-gateway/graphql-fetcher.ts
+++ b/src/core/dbc-gateway/graphql-fetcher.ts
@@ -1,4 +1,4 @@
-import { getToken, TOKEN_LIBRARY_KEY } from "../token";
+import { getToken, TOKEN_LIBRARY_KEY, TOKEN_USER_KEY } from "../token";
 
 export const fetcher = <TData, TVariables>(
   query: string,
@@ -7,13 +7,13 @@ export const fetcher = <TData, TVariables>(
   return async (): Promise<TData> => {
     // The whole concept of agency id, profile and and bearer token needs to be refined.
     // First version is with a library token.
-    const libraryToken = getToken(TOKEN_LIBRARY_KEY);
+    const token = getToken(TOKEN_USER_KEY) || getToken(TOKEN_LIBRARY_KEY);
 
     const headers = {
       "Content-Type": "application/json"
     };
-    const authHeaders = libraryToken
-      ? ({ Authorization: `Bearer ${libraryToken}` } as object)
+    const authHeaders = token
+      ? ({ Authorization: `Bearer ${token}` } as object)
       : {};
 
     const res = await fetch(


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-194

#### Description
In this PR we display the infomedia reviews text that come from infomedia service. 
A decision has been taken to not sanitize the data but instead directly display it as inner HTML. The consideration is that infomedia is a trustworthy service that takes care of this for us, and the library used for sanitizing HTML is quite hefty - thus would impact performance. All is commented in the code too ;)

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/188652679-d6ddf116-af38-46c1-b3d2-83614b09f59f.png)

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a