### PR TITLE
Aben modal ved tryk pa reserverknap real ddfsoeg 203

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "^0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -3,6 +3,7 @@ import {
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
+import { AgencyBranch } from "../../core/fbs/model";
 import {
   creatorsToString,
   filterCreators,
@@ -116,4 +117,27 @@ export const getWorkDescriptionListData = ({
       type: "standard"
     }
   ];
+};
+
+export const getNoInterestAfter = (days: number) => {
+  switch (days) {
+    case 30:
+      return "1 måned";
+    case 60:
+      return "2 måneder";
+    case 90:
+      return "3 måneder";
+    case 180:
+      return "6 måneder";
+    case 360:
+      return "12 måneder";
+    default:
+      return `${days} dage`;
+  }
+};
+
+export const getPreferredLocation = (id: string, array: AgencyBranch[]) => {
+  const locationItem = array.find((item) => item.branchId === id);
+  if (!locationItem) return id;
+  return locationItem.title;
 };

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -225,6 +225,51 @@ export default {
       name: "Find on shelf expand button explanation text",
       defaultValue: "This button opens a modal",
       control: { type: "text" }
+    },
+    approveReservationText: {
+      name: "Approve reservation",
+      defaultValue: "Godkend reservation",
+      control: { type: "text" }
+    },
+    weHaveShoppedText: {
+      name: "We have shopped",
+      defaultValue: "Vi har købt",
+      control: { type: "text" }
+    },
+    copiesThereIsText: {
+      name: "copies there is",
+      defaultValue: "eksemplarer. Der er",
+      control: { type: "text" }
+    },
+    reservationsForThisMaterialText: {
+      name: "Reservations for this material",
+      defaultValue: "reserveringer til dette materiale",
+      control: { type: "text" }
+    },
+    shiftText: {
+      name: "Shift",
+      defaultValue: "Skift",
+      control: { type: "text" }
+    },
+    pickupLocationText: {
+      name: "Pick up at",
+      defaultValue: "Afhentes på",
+      control: { type: "text" }
+    },
+    receiveSmsWhenMaterialReadyText: {
+      name: "Receive SMS when the material is ready",
+      defaultValue: "Du får en sms, når materialet er klar",
+      control: { type: "text" }
+    },
+    receiveEmailWhenMaterialReadyText: {
+      name: "Receive mail when the material is ready",
+      defaultValue: "Du får besked, når materialet er klar",
+      control: { type: "text" }
+    },
+    haveNoInterestAfterText: {
+      name: "Have no interest after",
+      defaultValue: "Har ingen interesse efter",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -47,6 +47,15 @@ interface MaterialEntryTextProps {
   goToText: string;
   materialIsLoanedOutText: string;
   findOnShelfExpandButtonExplanationText: string;
+  approveReservationText: string;
+  weHaveShoppedText: string;
+  copiesThereIsText: string;
+  reservationsForThisMaterialText: string;
+  shiftText: string;
+  pickupLocationText: string;
+  receiveSmsWhenMaterialReadyText: string;
+  receiveEmailWhenMaterialReadyText: string;
+  haveNoInterestAfterText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -28,6 +28,7 @@ import {
   getManifestationType,
   getWorkManifestation
 } from "./helper";
+import ReserVationModal from "../../components/reservation/reservation-modal";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -110,10 +111,13 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       >
         {manifestations.all.map((manifestation) => {
           return (
-            <MaterialMainfestationItem
-              key={manifestation.pid}
-              manifestation={manifestation}
-            />
+            <>
+              <MaterialMainfestationItem
+                key={manifestation.pid}
+                manifestation={manifestation}
+              />
+              <ReserVationModal manifestation={manifestation} work={work} />
+            </>
           );
         })}
       </Disclosure>
@@ -137,6 +141,9 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             }
           />
         </Disclosure>
+      )}
+      {currentManifestation && (
+        <ReserVationModal manifestation={currentManifestation} work={work} />
       )}
     </main>
   );

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -28,7 +28,7 @@ import {
   getManifestationType,
   getWorkManifestation
 } from "./helper";
-import ReserVationModal from "../../components/reservation/reservation-modal";
+import ReservationModal from "../../components/reservation/reservation-modal";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -116,7 +116,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
                 key={manifestation.pid}
                 manifestation={manifestation}
               />
-              <ReserVationModal manifestation={manifestation} work={work} />
+              <ReservationModal manifestation={manifestation} work={work} />
             </>
           );
         })}
@@ -143,7 +143,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         </Disclosure>
       )}
       {currentManifestation && (
-        <ReserVationModal manifestation={currentManifestation} work={work} />
+        <ReservationModal manifestation={currentManifestation} work={work} />
       )}
     </main>
   );

--- a/src/components/Buttons/ButtonSmallFilled.tsx
+++ b/src/components/Buttons/ButtonSmallFilled.tsx
@@ -5,9 +5,14 @@ import { Button } from "./Button";
 export interface ButtonSmallFilledProps {
   label: string;
   disabled: boolean;
+  onClick: () => void;
 }
 
-const ButtonSmallFilled: FC<ButtonSmallFilledProps> = ({ label, disabled }) => {
+const ButtonSmallFilled: FC<ButtonSmallFilledProps> = ({
+  label,
+  disabled,
+  onClick
+}) => {
   return (
     <Button
       label={label}
@@ -16,6 +21,7 @@ const ButtonSmallFilled: FC<ButtonSmallFilledProps> = ({ label, disabled }) => {
       disabled={disabled}
       collapsible={false}
       size="small"
+      onClick={onClick}
     />
   );
 };

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { FC, useState } from "react";
 import ExpandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
-import { useDispatch } from "react-redux";
 import { AvailabilityLabel } from "../availability-label/availability-label";
 import { Cover } from "../cover/cover";
 import {
@@ -17,8 +16,6 @@ import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialButtonsFindOnShelf from "./material-buttons/physical/MaterialButtonsFindOnShelf";
-import { reservationModalId } from "../reservation/reservation-modal";
-import { openModal } from "../../core/modal.slice";
 
 export interface MaterialMainfestationItemProps {
   manifestation: ManifestationsSimpleFieldsFragment;
@@ -42,16 +39,8 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   manifestation
 }) => {
   const t = useText();
-  const dispatch = useDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid as Pid);
-
-  const onClick = () => {
-    if (faustId) {
-      dispatch(openModal({ modalId: reservationModalId(faustId) }));
-    }
-  };
-
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FC, useState } from "react";
 import ExpandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
+import { useDispatch } from "react-redux";
 import { AvailabilityLabel } from "../availability-label/availability-label";
 import { Cover } from "../cover/cover";
 import {
@@ -16,6 +17,8 @@ import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialButtonsFindOnShelf from "./material-buttons/physical/MaterialButtonsFindOnShelf";
+import { reservationModalId } from "../reservation/reservation-modal";
+import { openModal } from "../../core/modal.slice";
 
 export interface MaterialMainfestationItemProps {
   manifestation: ManifestationsSimpleFieldsFragment;
@@ -39,8 +42,15 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   manifestation
 }) => {
   const t = useText();
+  const dispatch = useDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid as Pid);
+
+  const onClick = () => {
+    if (faustId) {
+      dispatch(openModal({ modalId: reservationModalId(faustId) }));
+    }
+  };
 
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -1,13 +1,16 @@
-import * as React from "react";
-import { FC } from "react";
+import React, { FC } from "react";
+import { useDispatch } from "react-redux";
+import { openModal } from "../../../../core/modal.slice";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
+import { FaustId } from "../../../../core/utils/types/ids";
 import { Button } from "../../../Buttons/Button";
+import { reservationModalId } from "../../../reservation/reservation-modal";
 
 export interface MaterialButtonPhysicalProps {
   manifestationMaterialType: string;
-  faustId: string;
   size?: ButtonSize;
+  faustId: FaustId;
 }
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
@@ -16,12 +19,10 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   size
 }) => {
   const t = useText();
+  const dispatch = useDispatch();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClick = () => {
-    // TODO: open the modal and reserve + remove console.log()
-    // eslint-disable-next-line no-console
-    console.log(faustId);
+    dispatch(openModal({ modalId: reservationModalId(faustId) }));
   };
 
   return (

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -19,9 +19,9 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   size
 }) => {
   const { pid } = manifestation;
-  const faustId = convertPostIdToFaustId(pid as Pid);
+  const faustId = convertPostIdToFaustId(pid as Pid) ?? "";
   const { data, isLoading } = useGetAvailabilityV3({
-    recordid: [faustId as string]
+    recordid: [faustId]
   });
 
   // TODO: use useGetPatronInformationByPatronIdV2() when we get the correctly

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -3,7 +3,7 @@ import { ManifestationsSimpleFieldsFragment } from "../../../../core/dbc-gateway
 import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { Pid } from "../../../../core/utils/types/ids";
+import { FaustId, Pid } from "../../../../core/utils/types/ids";
 import MaterialButtonCantReserve from "../generic/MaterialButtonCantReserve";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonUserBlocked from "../generic/MaterialButtonUserBlocked";
@@ -19,7 +19,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   size
 }) => {
   const { pid } = manifestation;
-  const faustId = convertPostIdToFaustId(pid as Pid) ?? "";
+  const faustId = (convertPostIdToFaustId(pid as Pid) ?? "") as FaustId;
   const { data, isLoading } = useGetAvailabilityV3({
     recordid: [faustId]
   });
@@ -49,7 +49,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   return (
     <MaterialButtonReservePhysical
       manifestationMaterialType={manifestationMaterialType}
-      faustId={faustId as string}
+      faustId={faustId}
       size={size}
     />
   );

--- a/src/components/reservation/ReservationFormListItem.tsx
+++ b/src/components/reservation/ReservationFormListItem.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { useText } from "../../core/utils/text";
+
+interface ReservationFormListItemProps {
+  icon: string;
+  title: string;
+  text: string;
+}
+
+const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
+  icon,
+  title,
+  text
+}) => {
+  const t = useText();
+  return (
+    <div className="reservation-modal-list-item">
+      <img src={icon} alt="" />
+      <div className="reservation-modal-list-item-text">
+        <h3 className="text-header-h5">{title}</h3>
+        <p className="text-small-caption">{text ?? `Mangler data`}</p>
+      </div>
+      {/* <button
+        type="button"
+        className="link-tag text-small-caption cursor-pointer"
+      >
+        {t("shiftText")}
+      </button> */}
+    </div>
+  );
+};
+
+export default ReservationFormListItem;

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import Location from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Location.svg";
+import Subtitles from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Subtitles.svg";
+import Message from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Message.svg";
+import LoanHistory from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/LoanHistory.svg";
+import { FC } from "react";
+import { useText } from "../../core/utils/text";
+import ReservationFormListItem from "./ReservationFormListItem";
+import {
+  getNoInterestAfter,
+  getPreferredLocation
+} from "../../apps/material/helper";
+import { AgencyBranch, PatronV5 } from "../../core/fbs/model";
+
+export interface UserListItemsProps {
+  patron: PatronV5;
+  branchData: AgencyBranch[];
+}
+
+const UserListItems: FC<UserListItemsProps> = ({
+  patron: {
+    defaultInterestPeriod,
+    preferredPickupBranch,
+    phoneNumber,
+    emailAddress
+  },
+  branchData
+}) => {
+  const t = useText();
+  return (
+    <>
+      {defaultInterestPeriod && (
+        <ReservationFormListItem
+          icon={LoanHistory}
+          title={t("haveNoInterestAfterText")}
+          text={getNoInterestAfter(defaultInterestPeriod)}
+        />
+      )}
+      {preferredPickupBranch && branchData && (
+        <ReservationFormListItem
+          icon={Location}
+          title={t("pickupLocationText")}
+          text={getPreferredLocation(preferredPickupBranch, branchData)}
+        />
+      )}
+      {phoneNumber && (
+        <ReservationFormListItem
+          icon={Subtitles}
+          title={t("receiveSmsWhenMaterialReadyText")}
+          text={phoneNumber}
+        />
+      )}
+      {emailAddress && (
+        <ReservationFormListItem
+          icon={Message}
+          title={t("receiveEmailWhenMaterialReadyText")}
+          text={emailAddress}
+        />
+      )}
+    </>
+  );
+};
+
+export default UserListItems;

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -1,30 +1,70 @@
 import * as React from "react";
+import Location from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Location.svg";
+import Various from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Various.svg";
+import Subtitles from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Subtitles.svg";
+import Message from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Message.svg";
+import LoanHistory from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/LoanHistory.svg";
 import {
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
-import { useAddReservationsV2 } from "../../core/fbs/fbs";
-import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import {
+  useAddReservationsV2,
+  useGetBranches,
+  useGetHoldingsV3,
+  useGetPatronInformationByPatronIdV2
+} from "../../core/fbs/fbs";
+import {
+  convertPostIdToFaustId,
+  creatorsToString,
+  filterCreators,
+  flattenCreators
+} from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { FaustId, Pid } from "../../core/utils/types/ids";
 import { Button } from "../Buttons/Button";
 import { Cover } from "../cover/cover";
+import ReservationFormListItem from "./ReservationFormListItem";
+import {
+  getNoInterestAfter,
+  getPreferredLocation
+} from "../../apps/material/helper";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;
 
-type ReserVationModalProps = {
+type ReservationModalProps = {
   manifestation: ManifestationsSimpleFieldsFragment;
   work: WorkMediumFragment;
 };
 
-const ReserVationModal = ({
-  manifestation: { pid }
-}: ReserVationModalProps) => {
+const ReservationModal = ({ manifestation }: ReservationModalProps) => {
+  const { pid, materialTypes, creators, titles, publicationYear, edition } =
+    manifestation;
   const t = useText();
   const faustId = convertPostIdToFaustId(pid as Pid);
   const { mutate } = useAddReservationsV2();
+
+  const { data: branchData } = useGetBranches();
+  const { data: userData } = useGetPatronInformationByPatronIdV2();
+  const { data: holdingsData } = useGetHoldingsV3({
+    recordid: [String(faustId)]
+  });
+
+  // TODO move to material/helper.ts because it is used in multiple places (Info text under buttons in the material header)
+  const totalReservations = holdingsData?.[0].reservations;
+  const totalMaterials = holdingsData?.[0].holdings.reduce(
+    (acc, curr) => acc + curr.materials.length,
+    0
+  );
+
+  const author =
+    creatorsToString(
+      flattenCreators(filterCreators(creators, ["Person"])),
+      t
+    ) || t("creatorsAreMissingText");
+
   const onClick = () => {
     if (faustId) {
       const batch = {
@@ -40,7 +80,7 @@ const ReserVationModal = ({
     }
   };
 
-  if (!faustId) {
+  if (!faustId || !userData) {
     return null;
   }
 
@@ -50,26 +90,81 @@ const ReserVationModal = ({
       screenReaderModalDescriptionText={t("screenReaderModalDescriptionText")}
       closeModalAriaLabelText={t("ariaLabelModalTwoText")}
     >
-      <div>
+      <section className="reservation-modal">
+        <header className="reservation-modal-header">
+          <Cover pid={pid as Pid} size="medium" animate />
+          <div className="reservation-modal-description">
+            <div className="reservation-modal-tag">
+              {materialTypes[0].specific}
+            </div>
+            <h2 className="text-header-h2 mt-22 mb-8">{titles.main[0]}</h2>
+            <p className="text-body-medium-regular">
+              {t("materialHeaderAuthorByText")} {author} (
+              {publicationYear.display})
+            </p>
+          </div>
+        </header>
         <div>
-          {" "}
-          <Cover pid={pid as Pid} size="xlarge" animate />
+          <div className="reservation-modal-submit">
+            <p className="text-small-caption">
+              {`${t("weHaveShoppedText")} ${totalMaterials} ${t(
+                "copiesThereIsText"
+              )} ${totalReservations} ${t("reservationsForThisMaterialText")}`}
+            </p>
+            <Button
+              label={t("approveReservationText")}
+              buttonType="none"
+              variant="filled"
+              disabled={false}
+              collapsible={false}
+              size="small"
+              onClick={onClick}
+            />
+          </div>
+          <div className="reservation-modal-list">
+            {edition?.summary && (
+              <ReservationFormListItem
+                icon={Various}
+                title={t("editionText")}
+                text={edition.summary}
+              />
+            )}
+            {userData?.patron?.defaultInterestPeriod && (
+              <ReservationFormListItem
+                icon={LoanHistory}
+                title={t("haveNoInterestAfterText")}
+                text={getNoInterestAfter(userData.patron.defaultInterestPeriod)}
+              />
+            )}
+            {userData?.patron?.preferredPickupBranch && branchData && (
+              <ReservationFormListItem
+                icon={Location}
+                title={t("pickupLocationText")}
+                text={getPreferredLocation(
+                  userData.patron.preferredPickupBranch,
+                  branchData
+                )}
+              />
+            )}
+            {userData?.patron?.phoneNumber && (
+              <ReservationFormListItem
+                icon={Subtitles}
+                title={t("receiveSmsWhenMaterialReadyText")}
+                text={userData.patron.phoneNumber}
+              />
+            )}
+            {userData?.patron?.emailAddress && (
+              <ReservationFormListItem
+                icon={Message}
+                title={t("receiveEmailWhenMaterialReadyText")}
+                text={userData.patron.emailAddress}
+              />
+            )}
+          </div>
         </div>
-        <div>
-          {" "}
-          <Button
-            label={t("reserveText")}
-            buttonType="none"
-            variant="filled"
-            disabled={false}
-            collapsible={false}
-            size="large"
-            onClick={onClick}
-          />
-        </div>
-      </div>
+      </section>
     </Modal>
   );
 };
 
-export default ReserVationModal;
+export default ReservationModal;

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import {
+  ManifestationsSimpleFieldsFragment,
+  WorkMediumFragment
+} from "../../core/dbc-gateway/generated/graphql";
+import { useAddReservationsV2 } from "../../core/fbs/fbs";
+import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import Modal from "../../core/utils/modal";
+import { useText } from "../../core/utils/text";
+import { FaustId, Pid } from "../../core/utils/types/ids";
+import { Button } from "../Buttons/Button";
+import { Cover } from "../cover/cover";
+
+export const reservationModalId = (faustId: FaustId) =>
+  `reservation-modal-${faustId}`;
+
+type ReserVationModalProps = {
+  manifestation: ManifestationsSimpleFieldsFragment;
+  work: WorkMediumFragment;
+};
+
+const ReserVationModal = ({
+  manifestation: { pid }
+}: ReserVationModalProps) => {
+  const t = useText();
+  const faustId = convertPostIdToFaustId(pid as Pid);
+  const { mutate } = useAddReservationsV2();
+  const onClick = () => {
+    if (faustId) {
+      const batch = {
+        data: {
+          reservations: [
+            {
+              recordId: faustId
+            }
+          ]
+        }
+      };
+      mutate(batch);
+    }
+  };
+
+  if (!faustId) {
+    return null;
+  }
+
+  return (
+    <Modal
+      modalId={reservationModalId(faustId)}
+      screenReaderModalDescriptionText={t("screenReaderModalDescriptionText")}
+      closeModalAriaLabelText={t("ariaLabelModalTwoText")}
+    >
+      <div>
+        <div>
+          {" "}
+          <Cover pid={pid as Pid} size="xlarge" animate />
+        </div>
+        <div>
+          {" "}
+          <Button
+            label={t("reserveText")}
+            buttonType="none"
+            variant="filled"
+            disabled={false}
+            collapsible={false}
+            size="large"
+            onClick={onClick}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ReserVationModal;

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -60,7 +60,7 @@ function Modal({
       </div>
       <button
         type="button"
-        /* A focusable element in a modal must have focus when opened, 
+        /* A focusable element in a modal must have focus when opened,
         or else the screen reader will remain on the main page */
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@^0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609":
-  version "0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609/71df1333bc3d070c691b5c3d0f8aeb2eed74a755#71df1333bc3d070c691b5c3d0f8aeb2eed74a755"
-  integrity sha512-Fu/uaeDpKElq8wY9dvAshyBNRFsj8UYPzz7g9KQFCVulhBOjJ2iIGIh7ZoogBMbuPaBSguK0aDgCNjqUv/YKFw==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca":
+  version "0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca/444207047f073fb5bc41aa67fb255c05c6a63f06#444207047f073fb5bc41aa67fb255c05c6a63f06"
+  integrity sha512-O4TTxk8UOtf+6Bv473OYSYggo8ClLKWmPOGb/MnMt9AfMv5t2DCOfNvA7E1faYgJpi2rf+bN8y2M49ywD1UO/A==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-203

#### Description

This PR adds a simple modal that displays manifestation and user data before reservation confirmation

Here is added: 
- markup and css classes from design-system
- a reusable ReservationFormListItem
- add all the translations that are needed

**2 help functions:**
- **getNoInterestAfter**: 
rewrite days into months
- **getPreferredLocation**: 
find branch name with id
#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-09-07 kl  15 24 38" src="https://user-images.githubusercontent.com/49920322/188890877-678ed05c-a318-4eee-a73e-2056f1d82237.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.


