### PR TITLE
Reservation modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "npm:@reload/dpl-design-system@feature-reservation-succes",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-8e89921140308155fa592ee1d305f34b5bba7ccd",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca",
+    "@danskernesdigitalebibliotek/dpl-design-system": "npm:@reload/dpl-design-system@feature-reservation-succes",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "^0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -3,6 +3,7 @@ import {
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
+import { AgencyBranch } from "../../core/fbs/model";
 import {
   creatorsToString,
   filterCreators,
@@ -116,4 +117,27 @@ export const getWorkDescriptionListData = ({
       type: "standard"
     }
   ];
+};
+
+export const getNoInterestAfter = (days: number) => {
+  switch (days) {
+    case 30:
+      return "1 måned";
+    case 60:
+      return "2 måneder";
+    case 90:
+      return "3 måneder";
+    case 180:
+      return "6 måneder";
+    case 360:
+      return "12 måneder";
+    default:
+      return `${days} dage`;
+  }
+};
+
+export const getPreferredLocation = (id: string, array: AgencyBranch[]) => {
+  const locationItem = array.find((item) => item.branchId === id);
+  if (!locationItem) return id;
+  return locationItem.title;
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -3,7 +3,7 @@ import {
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
-import { AgencyBranch } from "../../core/fbs/model";
+import { AgencyBranch, HoldingsV3 } from "../../core/fbs/model";
 import {
   creatorsToString,
   filterCreators,
@@ -125,7 +125,7 @@ export const getNoInterestAfter = (days: number, t: UseTextFunction) => {
     "60": t("twoMonthsText"),
     "90": t("threeMonthsText"),
     "180": t("sixMonthsText"),
-    "360": t("twelveMonthsText"),
+    "360": t("oneYearText"),
     default: `${days} ${t("daysText")}`
   } as const;
 
@@ -138,6 +138,9 @@ export const getNoInterestAfter = (days: number, t: UseTextFunction) => {
 
 export const getPreferredLocation = (id: string, array: AgencyBranch[]) => {
   const locationItem = array.find((item) => item.branchId === id);
-  if (!locationItem) return id;
-  return locationItem.title;
+  return locationItem ? locationItem.title : id;
+};
+
+export const totalMaterials = (holdings: HoldingsV3[]) => {
+  return holdings.reduce((acc, curr) => acc + curr.materials.length, 0);
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -119,21 +119,21 @@ export const getWorkDescriptionListData = ({
   ];
 };
 
-export const getNoInterestAfter = (days: number) => {
-  switch (days) {
-    case 30:
-      return "1 måned";
-    case 60:
-      return "2 måneder";
-    case 90:
-      return "3 måneder";
-    case 180:
-      return "6 måneder";
-    case 360:
-      return "12 måneder";
-    default:
-      return `${days} dage`;
-  }
+export const getNoInterestAfter = (days: number, t: UseTextFunction) => {
+  const reservationInterestIntervals: { [key: string]: string } = {
+    "30": t("oneMonthText"),
+    "60": t("twoMonthsText"),
+    "90": t("threeMonthsText"),
+    "180": t("sixMonthsText"),
+    "360": t("twelveMonthsText"),
+    default: `${days} ${t("daysText")}`
+  } as const;
+
+  const lookupKey = String(days);
+  return (
+    reservationInterestIntervals[lookupKey] ??
+    reservationInterestIntervals.default
+  );
 };
 
 export const getPreferredLocation = (id: string, array: AgencyBranch[]) => {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -320,6 +320,43 @@ export default {
       name: "Days",
       defaultValue: "Dage",
       control: { type: "text" }
+    },
+    reservationSuccesTitleText: {
+      name: "Reservation Success title",
+      defaultValue: "Materialet er hjemme og er nu reserveret til dig!",
+      control: { type: "text" }
+    },
+    reservationSuccesIsReservedForYouText: {
+      name: "Reservation Success Title",
+      defaultValue: "er reserveret til dig",
+      control: { type: "text" }
+    },
+    reservationSuccesPreferredPickupBranchText: {
+      name: "Reservation Preferred pickup branch",
+      defaultValue:
+        "Materialet er hjemme, og du får beksed så snart der ligger klar til dig - afhentning på",
+      control: { type: "text" }
+    },
+    reservationErrorsTitleText: {
+      name: "Reservation Error title",
+      defaultValue: "Reservationsfejl",
+      control: { type: "text" }
+    },
+    reservationErrorsDescriptionText: {
+      name: "Reservation Error description",
+      defaultValue:
+        "Der er desværre sket en fejl. Vi beklager ulejligheden. Prøv igen",
+      control: { type: "text" }
+    },
+    tryAginButtonText: {
+      name: "Try again button text",
+      defaultValue: "Prøv igen",
+      control: { type: "text" }
+    },
+    okButtonText: {
+      name: "Ok button text",
+      defaultValue: "Ok",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -290,6 +290,36 @@ export default {
       name: "Have no interest after",
       defaultValue: "Har ingen interesse efter",
       control: { type: "text" }
+    },
+    oneMonthText: {
+      name: "One month",
+      defaultValue: "1 måned",
+      control: { type: "text" }
+    },
+    twoMonthsText: {
+      name: "Two months",
+      defaultValue: "2 måneder",
+      control: { type: "text" }
+    },
+    threeMonthsText: {
+      name: "Three months",
+      defaultValue: "3 måneder",
+      control: { type: "text" }
+    },
+    sixMonthsText: {
+      name: "Six months",
+      defaultValue: "6 måneder",
+      control: { type: "text" }
+    },
+    twelveMonthsText: {
+      name: "Twelve months",
+      defaultValue: "12 måneder",
+      control: { type: "text" }
+    },
+    daysText: {
+      name: "Days",
+      defaultValue: "Dage",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -362,6 +362,16 @@ export default {
       name: "Missing data text",
       defaultValue: "Mangler data",
       control: { type: "text" }
+    },
+    reservationModalScreenReaderModalDescriptionText: {
+      name: "Reservation modal screen reader description",
+      defaultValue: "Modal for reservation",
+      control: { type: "text" }
+    },
+    reservationModalCloseModalAriaLabelText: {
+      name: "Reservation modal aria label modal two",
+      defaultValue: "Luk reservation modal",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -260,6 +260,36 @@ export default {
       name: "This month",
       defaultValue: "denne måned",
       control: { type: "text" }
+    },
+    approveReservationText: {
+      name: "Approve reservation",
+      defaultValue: "Godkend reservation",
+      control: { type: "text" }
+    },
+    shiftText: {
+      name: "Shift",
+      defaultValue: "Skift",
+      control: { type: "text" }
+    },
+    pickupLocationText: {
+      name: "Pick up at",
+      defaultValue: "Afhentes på",
+      control: { type: "text" }
+    },
+    receiveSmsWhenMaterialReadyText: {
+      name: "Receive SMS when the material is ready",
+      defaultValue: "Du får en sms, når materialet er klar",
+      control: { type: "text" }
+    },
+    receiveEmailWhenMaterialReadyText: {
+      name: "Receive mail when the material is ready",
+      defaultValue: "Du får besked, når materialet er klar",
+      control: { type: "text" }
+    },
+    haveNoInterestAfterText: {
+      name: "Have no interest after",
+      defaultValue: "Har ingen interesse efter",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -311,7 +311,7 @@ export default {
       defaultValue: "6 måneder",
       control: { type: "text" }
     },
-    twelveMonthsText: {
+    oneYearText: {
       name: "Twelve months",
       defaultValue: "12 måneder",
       control: { type: "text" }
@@ -356,6 +356,11 @@ export default {
     okButtonText: {
       name: "Ok button text",
       defaultValue: "Ok",
+      control: { type: "text" }
+    },
+    missingDataText: {
+      name: "Missing data text",
+      defaultValue: "Mangler data",
       control: { type: "text" }
     }
   }

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -60,6 +60,12 @@ interface MaterialEntryTextProps {
   receiveSmsWhenMaterialReadyText: string;
   receiveEmailWhenMaterialReadyText: string;
   haveNoInterestAfterText: string;
+  oneMonthText: string;
+  twoMonthsText: string;
+  threeMonthsText: string;
+  sixMonthsText: string;
+  twelveMonthsText: string;
+  daysText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -64,7 +64,7 @@ interface MaterialEntryTextProps {
   twoMonthsText: string;
   threeMonthsText: string;
   sixMonthsText: string;
-  twelveMonthsText: string;
+  oneYearText: string;
   daysText: string;
   reservationSuccesTitleText: string;
   reservationSuccesIsReservedForYouText: string;
@@ -73,6 +73,7 @@ interface MaterialEntryTextProps {
   reservationErrorsDescriptionText: string;
   tryAginButtonText: string;
   okButtonText: string;
+  missingDataText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -66,6 +66,13 @@ interface MaterialEntryTextProps {
   sixMonthsText: string;
   twelveMonthsText: string;
   daysText: string;
+  reservationSuccesTitleText: string;
+  reservationSuccesIsReservedForYouText: string;
+  reservationSuccesPreferredPickupBranchText: string;
+  reservationErrorsTitleText: string;
+  reservationErrorsDescriptionText: string;
+  tryAginButtonText: string;
+  okButtonText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -54,6 +54,12 @@ interface MaterialEntryTextProps {
   youHaveBorrowedText: string;
   possibleText: string;
   thisMonthText: string;
+  approveReservationText: string;
+  shiftText: string;
+  pickupLocationText: string;
+  receiveSmsWhenMaterialReadyText: string;
+  receiveEmailWhenMaterialReadyText: string;
+  haveNoInterestAfterText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -74,6 +74,8 @@ interface MaterialEntryTextProps {
   tryAginButtonText: string;
   okButtonText: string;
   missingDataText: string;
+  reservationModalScreenReaderModalDescriptionText: string;
+  reservationModalCloseModalAriaLabelText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -28,6 +28,7 @@ import {
   getManifestationType,
   getWorkManifestation
 } from "./helper";
+import ReserVationModal from "../../components/reservation/reservation-modal";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -110,10 +111,13 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       >
         {manifestations.all.map((manifestation) => {
           return (
-            <MaterialMainfestationItem
-              key={manifestation.pid}
-              manifestation={manifestation}
-            />
+            <>
+              <MaterialMainfestationItem
+                key={manifestation.pid}
+                manifestation={manifestation}
+              />
+              <ReserVationModal manifestation={manifestation} work={work} />
+            </>
           );
         })}
       </Disclosure>
@@ -137,6 +141,9 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             }
           />
         </Disclosure>
+      )}
+      {currentManifestation && (
+        <ReserVationModal manifestation={currentManifestation} work={work} />
       )}
     </main>
   );

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -28,7 +28,7 @@ import {
   getManifestationType,
   getWorkManifestation
 } from "./helper";
-import ReserVationModal from "../../components/reservation/reservation-modal";
+import ReservationModal from "../../components/reservation/reservation-modal";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -116,7 +116,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
                 key={manifestation.pid}
                 manifestation={manifestation}
               />
-              <ReserVationModal manifestation={manifestation} work={work} />
+              <ReservationModal manifestation={manifestation} work={work} />
             </>
           );
         })}
@@ -143,7 +143,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         </Disclosure>
       )}
       {currentManifestation && (
-        <ReserVationModal manifestation={currentManifestation} work={work} />
+        <ReservationModal manifestation={currentManifestation} work={work} />
       )}
     </main>
   );

--- a/src/components/Buttons/ButtonSmallFilled.tsx
+++ b/src/components/Buttons/ButtonSmallFilled.tsx
@@ -5,9 +5,14 @@ import { Button } from "./Button";
 export interface ButtonSmallFilledProps {
   label: string;
   disabled: boolean;
+  onClick: () => void;
 }
 
-const ButtonSmallFilled: FC<ButtonSmallFilledProps> = ({ label, disabled }) => {
+const ButtonSmallFilled: FC<ButtonSmallFilledProps> = ({
+  label,
+  disabled,
+  onClick
+}) => {
   return (
     <Button
       label={label}
@@ -16,6 +21,7 @@ const ButtonSmallFilled: FC<ButtonSmallFilledProps> = ({ label, disabled }) => {
       disabled={disabled}
       collapsible={false}
       size="small"
+      onClick={onClick}
     />
   );
 };

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -40,10 +40,6 @@ export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
         const faustId = convertPostIdToFaustId(pid as Pid);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
 
-        if (!faustId) {
-          return null;
-        }
-
         return (
           <AvailabilityLabel
             key={pid}

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { totalMaterials } from "../../../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
 import { useText } from "../../../../core/utils/text";
@@ -20,16 +21,14 @@ const MaterialAvailabilityTextPhysical: React.FC<
 
   if (isLoading || isError || !data) return null;
 
-  const totalReservations = data[0].reservations;
-  const totalMaterials = data[0].holdings.reduce(
-    (acc, curr) => acc + curr.materials.length,
-    0
-  );
+  const { reservations, holdings } = data[0];
 
   return (
     <MaterialAvailabilityTextParagraph>{`${t(
       "weHaveShoppedText"
-    )} ${totalMaterials} ${t("copiesThereIsText")} ${totalReservations} ${t(
+    )} ${totalMaterials(holdings)} ${t(
+      "copiesThereIsText"
+    )} ${reservations} ${t(
       "reservationsForThisMaterialText"
     )}`}</MaterialAvailabilityTextParagraph>
   );

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -16,7 +16,7 @@ const MaterialAvailabilityTextPhysical: React.FC<
   const t = useText();
   const faustId = convertPostIdToFaustId(pid as Pid);
   const { data, isLoading, isError } = useGetHoldingsV3({
-    recordid: [String(faustId)]
+    recordid: [faustId]
   });
 
   if (isLoading || isError || !data) return null;

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -77,10 +77,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const coverPid =
     (manifestation?.pid as Pid) || getManifestationPid(manifestations);
 
-  const faustId = manifestation
-    ? convertPostIdToFaustId(manifestation?.pid as Pid)
-    : "";
-
   return (
     <header className="material-header">
       <div className="material-header__cover">
@@ -102,9 +98,9 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           />
         </div>
 
-        {manifestation?.source?.includes("bibliotekskatalog") && faustId && (
+        {manifestation?.source?.includes("bibliotekskatalog") && (
           <MaterialPeriodical
-            faustId={faustId}
+            faustId={convertPostIdToFaustId(manifestation?.pid as Pid)}
             selectPeriodicalSelect={selectPeriodicalSelect}
           />
         )}

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { FC, useState } from "react";
 import ExpandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
-import { useDispatch } from "react-redux";
 import { AvailabilityLabel } from "../availability-label/availability-label";
 import { Cover } from "../cover/cover";
 import {
@@ -17,8 +16,6 @@ import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialButtonsFindOnShelf from "./material-buttons/physical/MaterialButtonsFindOnShelf";
-import { reservationModalId } from "../reservation/reservation-modal";
-import { openModal } from "../../core/modal.slice";
 
 export interface MaterialMainfestationItemProps {
   manifestation: ManifestationsSimpleFieldsFragment;
@@ -42,16 +39,8 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   manifestation
 }) => {
   const t = useText();
-  const dispatch = useDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid as Pid);
-
-  const onClick = () => {
-    if (faustId) {
-      dispatch(openModal({ modalId: reservationModalId(faustId) }));
-    }
-  };
-
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FC, useState } from "react";
 import ExpandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
+import { useDispatch } from "react-redux";
 import { AvailabilityLabel } from "../availability-label/availability-label";
 import { Cover } from "../cover/cover";
 import {
@@ -15,6 +16,9 @@ import { useText } from "../../core/utils/text";
 import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 import MaterialButtons from "./material-buttons/MaterialButtons";
+import MaterialButtonsFindOnShelf from "./material-buttons/physical/MaterialButtonsFindOnShelf";
+import { reservationModalId } from "../reservation/reservation-modal";
+import { openModal } from "../../core/modal.slice";
 
 export interface MaterialMainfestationItemProps {
   manifestation: ManifestationsSimpleFieldsFragment;
@@ -38,8 +42,15 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   manifestation
 }) => {
   const t = useText();
+  const dispatch = useDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid as Pid);
+
+  const onClick = () => {
+    if (faustId) {
+      dispatch(openModal({ modalId: reservationModalId(faustId) }));
+    }
+  };
 
   const creatorsText = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -110,13 +110,11 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   return (
     <div className="material-manifestation-item">
       <div className="material-manifestation-item__availability">
-        {faustId && (
-          <AvailabilityLabel
-            manifestText={materialTypes[0]?.specific}
-            url={new URL("/", getCurrentLocation())} // TODO the correct link must be added
-            faustIds={[faustId]}
-          />
-        )}
+        <AvailabilityLabel
+          manifestText={materialTypes[0]?.specific}
+          url={new URL("/", getCurrentLocation())} // TODO the correct link must be added
+          faustIds={[faustId]}
+        />
       </div>
       <div className="material-manifestation-item__cover">
         <Cover pid={pid as Pid} size="small" animate={false} />

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -23,10 +23,6 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({ manifestation, size }) => {
   const faustId = convertPostIdToFaustId(manifestation.pid as Pid);
 
   if (hasPhysicalAccess) {
-    if (!faustId) {
-      // TODO: handle error here once we do that
-      return null;
-    }
     return (
       <>
         <MaterialButtonsPhysical manifestation={manifestation} size={size} />

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -1,13 +1,16 @@
-import * as React from "react";
-import { FC } from "react";
+import React, { FC } from "react";
+import { useDispatch } from "react-redux";
+import { openModal } from "../../../../core/modal.slice";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
+import { FaustId } from "../../../../core/utils/types/ids";
 import { Button } from "../../../Buttons/Button";
+import { reservationModalId } from "../../../reservation/reservation-modal";
 
 export interface MaterialButtonPhysicalProps {
   manifestationMaterialType: string;
-  faustId: string;
   size?: ButtonSize;
+  faustId: FaustId;
 }
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
@@ -16,12 +19,10 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   size
 }) => {
   const t = useText();
+  const dispatch = useDispatch();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onClick = () => {
-    // TODO: open the modal and reserve + remove console.log()
-    // eslint-disable-next-line no-console
-    console.log(faustId);
+    dispatch(openModal({ modalId: reservationModalId(faustId) }));
   };
 
   return (

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -19,7 +19,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   size
 }) => {
   const { pid } = manifestation;
-  const faustId = (convertPostIdToFaustId(pid as Pid) ?? "") as FaustId;
+  const faustId = convertPostIdToFaustId(pid as Pid);
   const { data, isLoading } = useGetAvailabilityV3({
     recordid: [faustId]
   });

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -19,9 +19,9 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   size
 }) => {
   const { pid } = manifestation;
-  const faustId = convertPostIdToFaustId(pid as Pid);
+  const faustId = convertPostIdToFaustId(pid as Pid) ?? "";
   const { data, isLoading } = useGetAvailabilityV3({
-    recordid: [faustId as string]
+    recordid: [faustId]
   });
 
   // TODO: use useGetPatronInformationByPatronIdV2() when we get the correctly

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -3,7 +3,7 @@ import { ManifestationsSimpleFieldsFragment } from "../../../../core/dbc-gateway
 import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { Pid } from "../../../../core/utils/types/ids";
+import { FaustId, Pid } from "../../../../core/utils/types/ids";
 import MaterialButtonCantReserve from "../generic/MaterialButtonCantReserve";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonUserBlocked from "../generic/MaterialButtonUserBlocked";
@@ -19,7 +19,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   size
 }) => {
   const { pid } = manifestation;
-  const faustId = convertPostIdToFaustId(pid as Pid) ?? "";
+  const faustId = (convertPostIdToFaustId(pid as Pid) ?? "") as FaustId;
   const { data, isLoading } = useGetAvailabilityV3({
     recordid: [faustId]
   });
@@ -49,7 +49,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   return (
     <MaterialButtonReservePhysical
       manifestationMaterialType={manifestationMaterialType}
-      faustId={faustId as string}
+      faustId={faustId}
       size={size}
     />
   );

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 
 type ReservationErrorProps = {
@@ -8,11 +9,14 @@ type ReservationErrorProps = {
 const ReservationError: React.FC<ReservationErrorProps> = ({
   setReservationDidSuccess
 }) => {
+  const t = useText();
   return (
     <section className="reservation-modal reservation-modal--confirm">
-      <h2 className="text-header-h3 pb-48">ReservationError</h2>
+      <h2 className="text-header-h3 pb-48">
+        {t("reservationErrorsTitleText")}
+      </h2>
       <p className="text-body-medium-regular pb-48">
-        Vi kunne desværre ikke gennemføre din reservation.
+        {t("reservationErrorsDescriptionText")}
       </p>
       <Button
         classNames="reservation-modal__confirm-button"

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Button } from "../Buttons/Button";
+
+type ReservationErrorProps = {
+  setReservationDidSuccess: (value: boolean | null) => void;
+};
+
+const ReservationError: React.FC<ReservationErrorProps> = ({
+  setReservationDidSuccess
+}) => {
+  return (
+    <section className="reservation-modal reservation-modal--confirm">
+      <h2 className="text-header-h3 pb-48">ReservationError</h2>
+      <p className="text-body-medium-regular pb-48">
+        Vi kunne desværre ikke gennemføre din reservation.
+      </p>
+      <Button
+        classNames="reservation-modal__confirm-button"
+        label={t("tryAginButtonText")}
+        buttonType="none"
+        disabled={false}
+        collapsible={false}
+        size="small"
+        variant="filled"
+        onClick={() => setReservationDidSuccess(null)}
+      />
+    </section>
+  );
+};
+
+export default ReservationError;

--- a/src/components/reservation/ReservationFormListItem.tsx
+++ b/src/components/reservation/ReservationFormListItem.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { useText } from "../../core/utils/text";
+
+interface ReservationFormListItemProps {
+  icon: string;
+  title: string;
+  text: string;
+}
+
+const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
+  icon,
+  title,
+  text
+}) => {
+  const t = useText();
+  return (
+    <div className="reservation-modal-list-item">
+      <img src={icon} alt="" />
+      <div className="reservation-modal-list-item-text">
+        <h3 className="text-header-h5">{title}</h3>
+        <p className="text-small-caption">{text ?? `Mangler data`}</p>
+      </div>
+      {/* <button
+        type="button"
+        className="link-tag text-small-caption cursor-pointer"
+      >
+        {t("shiftText")}
+      </button> */}
+    </div>
+  );
+};
+
+export default ReservationFormListItem;

--- a/src/components/reservation/ReservationFormListItem.tsx
+++ b/src/components/reservation/ReservationFormListItem.tsx
@@ -5,12 +5,14 @@ interface ReservationFormListItemProps {
   icon: string;
   title: string;
   text: string;
+  changeHandler?: () => void;
 }
 
 const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
   icon,
   title,
-  text
+  text,
+  changeHandler
 }) => {
   const t = useText();
   return (
@@ -18,14 +20,17 @@ const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
       <img src={icon} alt="" />
       <div className="reservation-modal-list-item-text">
         <h3 className="text-header-h5">{title}</h3>
-        <p className="text-small-caption">{text ?? `Mangler data`}</p>
+        <p className="text-small-caption">
+          {text.length > 0 ? text : t("missingDataText")}
+        </p>
       </div>
-      {/* <button
+      <button
+        onClick={changeHandler}
         type="button"
         className="link-tag text-small-caption cursor-pointer"
       >
         {t("shiftText")}
-      </button> */}
+      </button>
     </div>
   );
 };

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useDispatch } from "react-redux";
+import { closeModal } from "../../core/modal.slice";
+import { Button } from "../Buttons/Button";
+
+type ReservationSuccesProps = {
+  title: string;
+  preferredPickupBranch: string;
+  modalId: string;
+};
+
+const ReservationSucces: React.FC<ReservationSuccesProps> = ({
+  modalId,
+  title,
+  preferredPickupBranch
+}) => {
+  const dispatch = useDispatch();
+  return (
+    <section className="reservation-modal reservation-modal--confirm">
+      <h2 className="text-header-h3 pb-48">
+        Materialet er hjemme og er nu reserveret til dig!
+      </h2>
+      <p className="text-body-medium-regular pb-24">
+        {title} er reserveret til dig
+      </p>
+      <p className="text-body-medium-regular pb-48">
+        Materialet er hjemme, og du får beksed så snart der ligger klar til dig
+        - afhentning på {preferredPickupBranch}.
+      </p>
+      <Button
+        classNames="reservation-modal__confirm-button"
+        label={t("okButtonText")}
+        buttonType="none"
+        disabled={false}
+        collapsible={false}
+        size="small"
+        variant="filled"
+        onClick={() => {
+          dispatch(closeModal({ modalId }));
+        }}
+      />
+    </section>
+  );
+};
+
+export default ReservationSucces;

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useDispatch } from "react-redux";
 import { closeModal } from "../../core/modal.slice";
+import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 
 type ReservationSuccesProps = {
@@ -15,17 +16,18 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   preferredPickupBranch
 }) => {
   const dispatch = useDispatch();
+  const t = useText();
   return (
     <section className="reservation-modal reservation-modal--confirm">
       <h2 className="text-header-h3 pb-48">
-        Materialet er hjemme og er nu reserveret til dig!
+        {t("reservationSuccesTitleText")}
       </h2>
       <p className="text-body-medium-regular pb-24">
-        {title} er reserveret til dig
+        {title} {t("reservationSuccesIsReservedForYouText")}
       </p>
       <p className="text-body-medium-regular pb-48">
-        Materialet er hjemme, og du får beksed så snart der ligger klar til dig
-        - afhentning på {preferredPickupBranch}.
+        {t("reservationSuccesPreferredPickupBranchText")}
+        {preferredPickupBranch}.
       </p>
       <Button
         classNames="reservation-modal__confirm-button"

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -33,7 +33,7 @@ const UserListItems: FC<UserListItemsProps> = ({
         <ReservationFormListItem
           icon={LoanHistory}
           title={t("haveNoInterestAfterText")}
-          text={getNoInterestAfter(defaultInterestPeriod)}
+          text={getNoInterestAfter(defaultInterestPeriod, t)}
         />
       )}
       {preferredPickupBranch && branchData && (

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import Location from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Location.svg";
+import Subtitles from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Subtitles.svg";
+import Message from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Message.svg";
+import LoanHistory from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/LoanHistory.svg";
+import { FC } from "react";
+import { useText } from "../../core/utils/text";
+import ReservationFormListItem from "./ReservationFormListItem";
+import {
+  getNoInterestAfter,
+  getPreferredLocation
+} from "../../apps/material/helper";
+import { AgencyBranch, PatronV5 } from "../../core/fbs/model";
+
+export interface UserListItemsProps {
+  patron: PatronV5;
+  branchData: AgencyBranch[];
+}
+
+const UserListItems: FC<UserListItemsProps> = ({
+  patron: {
+    defaultInterestPeriod,
+    preferredPickupBranch,
+    phoneNumber,
+    emailAddress
+  },
+  branchData
+}) => {
+  const t = useText();
+  return (
+    <>
+      {defaultInterestPeriod && (
+        <ReservationFormListItem
+          icon={LoanHistory}
+          title={t("haveNoInterestAfterText")}
+          text={getNoInterestAfter(defaultInterestPeriod)}
+        />
+      )}
+      {preferredPickupBranch && branchData && (
+        <ReservationFormListItem
+          icon={Location}
+          title={t("pickupLocationText")}
+          text={getPreferredLocation(preferredPickupBranch, branchData)}
+        />
+      )}
+      {phoneNumber && (
+        <ReservationFormListItem
+          icon={Subtitles}
+          title={t("receiveSmsWhenMaterialReadyText")}
+          text={phoneNumber}
+        />
+      )}
+      {emailAddress && (
+        <ReservationFormListItem
+          icon={Message}
+          title={t("receiveEmailWhenMaterialReadyText")}
+          text={emailAddress}
+        />
+      )}
+    </>
+  );
+};
+
+export default UserListItems;

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -34,6 +34,7 @@ const UserListItems: FC<UserListItemsProps> = ({
           icon={LoanHistory}
           title={t("haveNoInterestAfterText")}
           text={getNoInterestAfter(defaultInterestPeriod, t)}
+          changeHandler={() => {}} // TODO: open modal to switch user data
         />
       )}
       {preferredPickupBranch && branchData && (
@@ -41,6 +42,7 @@ const UserListItems: FC<UserListItemsProps> = ({
           icon={Location}
           title={t("pickupLocationText")}
           text={getPreferredLocation(preferredPickupBranch, branchData)}
+          changeHandler={() => {}} // TODO: open modal to switch user data
         />
       )}
       {phoneNumber && (
@@ -48,6 +50,7 @@ const UserListItems: FC<UserListItemsProps> = ({
           icon={Subtitles}
           title={t("receiveSmsWhenMaterialReadyText")}
           text={phoneNumber}
+          changeHandler={() => {}} // TODO: open modal to switch user data
         />
       )}
       {emailAddress && (
@@ -55,6 +58,7 @@ const UserListItems: FC<UserListItemsProps> = ({
           icon={Message}
           title={t("receiveEmailWhenMaterialReadyText")}
           text={emailAddress}
+          changeHandler={() => {}} // TODO: open modal to switch user data
         />
       )}
     </>

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -1,30 +1,70 @@
 import * as React from "react";
+import Location from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Location.svg";
+import Various from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Various.svg";
+import Subtitles from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Subtitles.svg";
+import Message from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Message.svg";
+import LoanHistory from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/LoanHistory.svg";
 import {
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../core/dbc-gateway/generated/graphql";
-import { useAddReservationsV2 } from "../../core/fbs/fbs";
-import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import {
+  useAddReservationsV2,
+  useGetBranches,
+  useGetHoldingsV3,
+  useGetPatronInformationByPatronIdV2
+} from "../../core/fbs/fbs";
+import {
+  convertPostIdToFaustId,
+  creatorsToString,
+  filterCreators,
+  flattenCreators
+} from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { FaustId, Pid } from "../../core/utils/types/ids";
 import { Button } from "../Buttons/Button";
 import { Cover } from "../cover/cover";
+import ReservationFormListItem from "./ReservationFormListItem";
+import {
+  getNoInterestAfter,
+  getPreferredLocation
+} from "../../apps/material/helper";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;
 
-type ReserVationModalProps = {
+type ReservationModalProps = {
   manifestation: ManifestationsSimpleFieldsFragment;
   work: WorkMediumFragment;
 };
 
-const ReserVationModal = ({
-  manifestation: { pid }
-}: ReserVationModalProps) => {
+const ReservationModal = ({ manifestation }: ReservationModalProps) => {
+  const { pid, materialTypes, creators, titles, publicationYear, edition } =
+    manifestation;
   const t = useText();
   const faustId = convertPostIdToFaustId(pid as Pid);
   const { mutate } = useAddReservationsV2();
+
+  const { data: branchData } = useGetBranches();
+  const { data: userData } = useGetPatronInformationByPatronIdV2();
+  const { data: holdingsData } = useGetHoldingsV3({
+    recordid: [String(faustId)]
+  });
+
+  // TODO move to material/helper.ts because it is used in multiple places (Info text under buttons in the material header)
+  const totalReservations = holdingsData?.[0].reservations;
+  const totalMaterials = holdingsData?.[0].holdings.reduce(
+    (acc, curr) => acc + curr.materials.length,
+    0
+  );
+
+  const author =
+    creatorsToString(
+      flattenCreators(filterCreators(creators, ["Person"])),
+      t
+    ) || t("creatorsAreMissingText");
+
   const onClick = () => {
     if (faustId) {
       const batch = {
@@ -40,7 +80,7 @@ const ReserVationModal = ({
     }
   };
 
-  if (!faustId) {
+  if (!faustId || !userData) {
     return null;
   }
 
@@ -50,26 +90,81 @@ const ReserVationModal = ({
       screenReaderModalDescriptionText={t("screenReaderModalDescriptionText")}
       closeModalAriaLabelText={t("ariaLabelModalTwoText")}
     >
-      <div>
+      <section className="reservation-modal">
+        <header className="reservation-modal-header">
+          <Cover pid={pid as Pid} size="medium" animate />
+          <div className="reservation-modal-description">
+            <div className="reservation-modal-tag">
+              {materialTypes[0].specific}
+            </div>
+            <h2 className="text-header-h2 mt-22 mb-8">{titles.main[0]}</h2>
+            <p className="text-body-medium-regular">
+              {t("materialHeaderAuthorByText")} {author} (
+              {publicationYear.display})
+            </p>
+          </div>
+        </header>
         <div>
-          {" "}
-          <Cover pid={pid as Pid} size="xlarge" animate />
+          <div className="reservation-modal-submit">
+            <p className="text-small-caption">
+              {`${t("weHaveShoppedText")} ${totalMaterials} ${t(
+                "copiesThereIsText"
+              )} ${totalReservations} ${t("reservationsForThisMaterialText")}`}
+            </p>
+            <Button
+              label={t("approveReservationText")}
+              buttonType="none"
+              variant="filled"
+              disabled={false}
+              collapsible={false}
+              size="small"
+              onClick={onClick}
+            />
+          </div>
+          <div className="reservation-modal-list">
+            {edition?.summary && (
+              <ReservationFormListItem
+                icon={Various}
+                title={t("editionText")}
+                text={edition.summary}
+              />
+            )}
+            {userData?.patron?.defaultInterestPeriod && (
+              <ReservationFormListItem
+                icon={LoanHistory}
+                title={t("haveNoInterestAfterText")}
+                text={getNoInterestAfter(userData.patron.defaultInterestPeriod)}
+              />
+            )}
+            {userData?.patron?.preferredPickupBranch && branchData && (
+              <ReservationFormListItem
+                icon={Location}
+                title={t("pickupLocationText")}
+                text={getPreferredLocation(
+                  userData.patron.preferredPickupBranch,
+                  branchData
+                )}
+              />
+            )}
+            {userData?.patron?.phoneNumber && (
+              <ReservationFormListItem
+                icon={Subtitles}
+                title={t("receiveSmsWhenMaterialReadyText")}
+                text={userData.patron.phoneNumber}
+              />
+            )}
+            {userData?.patron?.emailAddress && (
+              <ReservationFormListItem
+                icon={Message}
+                title={t("receiveEmailWhenMaterialReadyText")}
+                text={userData.patron.emailAddress}
+              />
+            )}
+          </div>
         </div>
-        <div>
-          {" "}
-          <Button
-            label={t("reserveText")}
-            buttonType="none"
-            variant="filled"
-            disabled={false}
-            collapsible={false}
-            size="large"
-            onClick={onClick}
-          />
-        </div>
-      </div>
+      </section>
     </Modal>
   );
 };
 
-export default ReserVationModal;
+export default ReservationModal;

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -30,7 +30,10 @@ import {
 import UserListItems from "./UserListItems";
 import ReservationSucces from "./ReservationSucces";
 import ReservationError from "./ReservationError";
-import { getPreferredLocation } from "../../apps/material/helper";
+import {
+  getPreferredLocation,
+  totalMaterials
+} from "../../apps/material/helper";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;
@@ -78,13 +81,6 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
   };
   const { reservations, holdings } = holdingsData[0];
   const { patron } = userData;
-
-  // TODO move to material/helper.ts because it is used in multiple places (Info text under buttons in the material header)
-  const totalReservations = reservations;
-  const totalMaterials = holdings.reduce(
-    (acc, curr) => acc + curr.materials.length,
-    0
-  );
 
   const author =
     creatorsToString(
@@ -147,11 +143,9 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
           <div>
             <div className="reservation-modal-submit">
               <p className="text-small-caption">
-                {`${t("weHaveShoppedText")} ${totalMaterials} ${t(
+                {`${t("weHaveShoppedText")} ${totalMaterials(holdings)} ${t(
                   "copiesThereIsText"
-                )} ${totalReservations} ${t(
-                  "reservationsForThisMaterialText"
-                )}`}
+                )} ${reservations} ${t("reservationsForThisMaterialText")}`}
               </p>
               <Button
                 label={t("approveReservationText")}
@@ -168,6 +162,7 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
                 icon={Various}
                 title={t("editionText")}
                 text={summary}
+                changeHandler={() => {}} // TODO: open modal to switch user data
               />
               {patron && (
                 <UserListItems patron={patron} branchData={branchData} />

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -102,8 +102,10 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
   return (
     <Modal
       modalId={reservationModalId(faustId)}
-      screenReaderModalDescriptionText={t("screenReaderModalDescriptionText")}
-      closeModalAriaLabelText={t("ariaLabelModalTwoText")}
+      screenReaderModalDescriptionText={t(
+        "reservationModalScreenReaderModalDescriptionText"
+      )}
+      closeModalAriaLabelText={t("reservationModalCloseModalAriaLabelText")}
     >
       {reservationDidSuccess && patron && (
         <ReservationSucces

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -62,15 +62,10 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
   const branchResponse = useGetBranches();
   const userResponse = useGetPatronInformationByPatronIdV2();
   const holdingsResponse = useGetHoldingsV3({
-    recordid: [String(faustId)]
+    recordid: [faustId]
   });
 
-  if (
-    !faustId ||
-    !branchResponse.data ||
-    !userResponse.data ||
-    !holdingsResponse.data
-  ) {
+  if (!branchResponse.data || !userResponse.data || !holdingsResponse.data) {
     return null;
   }
 

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import {
+  ManifestationsSimpleFieldsFragment,
+  WorkMediumFragment
+} from "../../core/dbc-gateway/generated/graphql";
+import { useAddReservationsV2 } from "../../core/fbs/fbs";
+import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import Modal from "../../core/utils/modal";
+import { useText } from "../../core/utils/text";
+import { FaustId, Pid } from "../../core/utils/types/ids";
+import { Button } from "../Buttons/Button";
+import { Cover } from "../cover/cover";
+
+export const reservationModalId = (faustId: FaustId) =>
+  `reservation-modal-${faustId}`;
+
+type ReserVationModalProps = {
+  manifestation: ManifestationsSimpleFieldsFragment;
+  work: WorkMediumFragment;
+};
+
+const ReserVationModal = ({
+  manifestation: { pid }
+}: ReserVationModalProps) => {
+  const t = useText();
+  const faustId = convertPostIdToFaustId(pid as Pid);
+  const { mutate } = useAddReservationsV2();
+  const onClick = () => {
+    if (faustId) {
+      const batch = {
+        data: {
+          reservations: [
+            {
+              recordId: faustId
+            }
+          ]
+        }
+      };
+      mutate(batch);
+    }
+  };
+
+  if (!faustId) {
+    return null;
+  }
+
+  return (
+    <Modal
+      modalId={reservationModalId(faustId)}
+      screenReaderModalDescriptionText={t("screenReaderModalDescriptionText")}
+      closeModalAriaLabelText={t("ariaLabelModalTwoText")}
+    >
+      <div>
+        <div>
+          {" "}
+          <Cover pid={pid as Pid} size="xlarge" animate />
+        </div>
+        <div>
+          {" "}
+          <Button
+            label={t("reserveText")}
+            buttonType="none"
+            variant="filled"
+            disabled={false}
+            collapsible={false}
+            size="large"
+            onClick={onClick}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ReserVationModal;

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -109,9 +109,12 @@ export const usePrevious = <Type>(value: Type) => {
   return ref.current;
 };
 
-export const convertPostIdToFaustId = (postId: Pid): FaustId | null => {
+export const convertPostIdToFaustId = (postId: Pid) => {
   const matches = postId.match(/^[0-9]+-[a-z]+:([0-9]+)$/);
-  return matches?.[1] ? (matches?.[1] as FaustId) : null;
+  if (matches?.[1]) {
+    return matches?.[1] as FaustId;
+  }
+  throw new Error(`Unable to extract faust id from post id "${postId}"`);
 };
 
 // Get params if they are defined as props use those

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@^0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609":
-  version "0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-b42865dbbcc6dbc2eee6b5913baa57fc9f8f9609/71df1333bc3d070c691b5c3d0f8aeb2eed74a755#71df1333bc3d070c691b5c3d0f8aeb2eed74a755"
-  integrity sha512-Fu/uaeDpKElq8wY9dvAshyBNRFsj8UYPzz7g9KQFCVulhBOjJ2iIGIh7ZoogBMbuPaBSguK0aDgCNjqUv/YKFw==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca":
+  version "0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca/444207047f073fb5bc41aa67fb255c05c6a63f06#444207047f073fb5bc41aa67fb255c05c6a63f06"
+  integrity sha512-O4TTxk8UOtf+6Bv473OYSYggo8ClLKWmPOGb/MnMt9AfMv5t2DCOfNvA7E1faYgJpi2rf+bN8y2M49ywD1UO/A==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@npm:@reload/dpl-design-system@feature-reservation-succes":
-  version "0.0.0-396bdbc983939d5bbf0554769e3409f788e7cad0"
-  resolved "https://npm.pkg.github.com/download/@reload/dpl-design-system/0.0.0-396bdbc983939d5bbf0554769e3409f788e7cad0/4c6af01e1c120f126073446c3b40e4b7939907c2#4c6af01e1c120f126073446c3b40e4b7939907c2"
-  integrity sha512-/n3YOgZzoHl4RyScjhYlWmDOjMEe7bWXLGeHHgm2ZZVBW3NjLM9JMQiM7Cuq47YCp61KbJvOl0Oog3hF5ULz9A==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-8e89921140308155fa592ee1d305f34b5bba7ccd":
+  version "0.0.0-8e89921140308155fa592ee1d305f34b5bba7ccd"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-8e89921140308155fa592ee1d305f34b5bba7ccd/8347321d218ccc1212d2738a97b555cf32033579#8347321d218ccc1212d2738a97b555cf32033579"
+  integrity sha512-tuFiA0OkXkwTr3GjKnR0o17G7hdfcWTk8CZNeaVUTZwhJ/qGnQzE+H+AOspcQHe7nGqXgcGTl7XGeYH2m8JRaA==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,10 +1721,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca":
-  version "0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-f0a7891288f47e69f92145fe138ccddae7ac86ca/444207047f073fb5bc41aa67fb255c05c6a63f06#444207047f073fb5bc41aa67fb255c05c6a63f06"
-  integrity sha512-O4TTxk8UOtf+6Bv473OYSYggo8ClLKWmPOGb/MnMt9AfMv5t2DCOfNvA7E1faYgJpi2rf+bN8y2M49ywD1UO/A==
+"@danskernesdigitalebibliotek/dpl-design-system@npm:@reload/dpl-design-system@feature-reservation-succes":
+  version "0.0.0-396bdbc983939d5bbf0554769e3409f788e7cad0"
+  resolved "https://npm.pkg.github.com/download/@reload/dpl-design-system/0.0.0-396bdbc983939d5bbf0554769e3409f788e7cad0/4c6af01e1c120f126073446c3b40e4b7939907c2#4c6af01e1c120f126073446c3b40e4b7939907c2"
+  integrity sha512-/n3YOgZzoHl4RyScjhYlWmDOjMEe7bWXLGeHHgm2ZZVBW3NjLM9JMQiM7Cuq47YCp61KbJvOl0Oog3hF5ULz9A==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-203

#### Description

### This PR adds a modal that handles the reservation of a material
The modal is opened after the reservation button has been pressed. Here shows the material and user information.
if the user confirms, and if it is approved it shows ReservationSucces  else is shows ReservationError

Here is added: 
- markup and CSS classes from design-system
- a reusable ReservationFormListItem
- ReservationSucces + ReservationError components 
- add all the translations that are needed

**2 help functions:**
- **getNoInterestAfter**: 
rewrite days into months
- **getPreferredLocation**: 
find branch name with id

#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-09-07 kl  15 24 38" src="https://user-images.githubusercontent.com/49920322/188890877-678ed05c-a318-4eee-a73e-2056f1d82237.png">
<img width="1480" alt="Skærmbillede 2022-09-12 kl  11 14 23" src="https://user-images.githubusercontent.com/49920322/189617112-bd320b5b-eaf1-41bd-8a2d-782d4112f79e.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.