### PR TITLE
Fix/material-buttons - don't show "find on shelf" button twice on work manifestations

### DIFF
--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -155,7 +155,6 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
       </div>
       <div className="material-manifestation-item__buttons">
         <MaterialButtons manifestation={manifestation} size="small" />
-        <MaterialButtonsFindOnShelf faustIds={[faustId as FaustId]} />
       </div>
     </div>
   );

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -9,13 +9,12 @@ import {
   filterCreators,
   flattenCreators
 } from "../../core/utils/helpers/general";
-import { FaustId, Pid } from "../../core/utils/types/ids";
+import { Pid } from "../../core/utils/types/ids";
 import { ManifestationsSimpleFieldsFragment } from "../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../core/utils/text";
 import { getCurrentLocation } from "../../core/utils/helpers/url";
 import MaterialDetailsList, { ListData } from "./MaterialDetailsList";
 import MaterialButtons from "./material-buttons/MaterialButtons";
-import MaterialButtonsFindOnShelf from "./material-buttons/physical/MaterialButtonsFindOnShelf";
 
 export interface MaterialMainfestationItemProps {
   manifestation: ManifestationsSimpleFieldsFragment;


### PR DESCRIPTION
#### Description
This bug was created during merge conflicts when merging in my last PR.

#### Screenshot of the result
Before:
![image](https://user-images.githubusercontent.com/28546954/189343099-5cf1bdb7-a6fc-428f-8925-1bc510b63b07.png)

After:
![image](https://user-images.githubusercontent.com/28546954/189343216-0c16bad6-813b-4881-b678-74bfb5cc55a9.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
