### PR TITLE
Confirming the reservation

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -387,6 +387,26 @@ export default {
       name: "Reservation modal aria label modal two",
       defaultValue: "Luk reservation modal",
       control: { type: "text" }
+    },
+    numberInQueueText: {
+      name: "Number in queue text",
+      defaultValue: "Du er nummer",
+      control: { type: "text" }
+    },
+    queueText: {
+      name: "Queue text",
+      defaultValue: "i køen",
+      control: { type: "text" }
+    },
+    alreadyReservedText: {
+      name: "Already reserved text",
+      defaultValue: "Du har allerede reserveret dette materiale",
+      control: { type: "text" }
+    },
+    closeText: {
+      name: "Close text",
+      defaultValue: "Luk",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -79,6 +79,10 @@ interface MaterialEntryTextProps {
   librariesHaveTheMaterialText: string;
   findOnShelfModalScreenReaderModalDescriptionText: string;
   findOnShelfModalCloseModalAriaLabelText: string;
+  numberInQueueText: string;
+  queueText: string;
+  alreadyReservedText: string;
+  closeText: string;
 }
 interface MaterialEntryUrlProps {
   searchUrl: string;

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -12,9 +12,9 @@ export type ButtonProps = {
   size: ButtonSize;
   variant: "outline" | "filled";
   onClick?: () => void;
-  classNames?: string;
+  iconClassNames?: string;
   id?: string;
-  className?: string;
+  classNames?: string;
 };
 
 export const Button: React.FC<ButtonProps> = ({
@@ -25,12 +25,12 @@ export const Button: React.FC<ButtonProps> = ({
   size,
   variant,
   onClick,
-  classNames,
+  iconClassNames,
   id,
-  className
+  classNames
 }) => {
   const iconClassName = `btn-icon ${clsx({ "btn-collapsible": collapsible }, [
-    classNames
+    iconClassNames
   ])}`;
 
   const Icon = React.useCallback(() => {
@@ -57,7 +57,7 @@ export const Button: React.FC<ButtonProps> = ({
     <button
       type="button"
       className={`btn-primary btn-${variant} btn-${size} arrow__hover--right-small ${
-        className ?? ""
+        classNames ?? ""
       }`}
       disabled={disabled}
       onClick={onClick}

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -14,6 +14,7 @@ export type ButtonProps = {
   onClick?: () => void;
   classNames?: string;
   id?: string;
+  className?: string;
 };
 
 export const Button: React.FC<ButtonProps> = ({
@@ -25,7 +26,8 @@ export const Button: React.FC<ButtonProps> = ({
   variant,
   onClick,
   classNames,
-  id
+  id,
+  className
 }) => {
   const iconClassName = `btn-icon ${clsx({ "btn-collapsible": collapsible }, [
     classNames
@@ -54,7 +56,9 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       type="button"
-      className={`btn-primary btn-${variant} btn-${size} arrow__hover--right-small`}
+      className={`btn-primary btn-${variant} btn-${size} arrow__hover--right-small ${
+        className ?? ""
+      }`}
       disabled={disabled}
       onClick={onClick}
       id={id}

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -28,7 +28,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
         disabled={false}
         collapsible={false}
         size={size || "large"}
-        classNames="invert"
+        iconClassNames="invert"
       />
     </LinkNoStyle>
   );

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -3,7 +3,7 @@ import { ManifestationsSimpleFieldsFragment } from "../../../../core/dbc-gateway
 import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { FaustId, Pid } from "../../../../core/utils/types/ids";
+import { Pid } from "../../../../core/utils/types/ids";
 import MaterialButtonCantReserve from "../generic/MaterialButtonCantReserve";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonUserBlocked from "../generic/MaterialButtonUserBlocked";

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -32,7 +32,7 @@ const ReservationError: React.FC<ReservationErrorProps> = ({
         </>
       )}
       <Button
-        className="reservation-modal__confirm-button"
+        classNames="reservation-modal__confirm-button"
         label={buttonText ?? t("tryAginButtonText")}
         buttonType="none"
         disabled={false}

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -4,36 +4,51 @@ import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 
 type ReservationErrorProps = {
-  errorDescription?: string;
-  buttonText?: string;
+  reservationResult: string;
   setReservationResponse: (
     reservationResponse: ReservationResponseV2 | null
   ) => void;
 };
 
 const ReservationError: React.FC<ReservationErrorProps> = ({
-  errorDescription,
-  buttonText,
+  reservationResult,
   setReservationResponse
 }) => {
   const t = useText();
+
+  const handleErrorText: {
+    [key: string]: {
+      title: string;
+      description: string;
+      buttonText: string;
+    };
+  } = {
+    already_reserved: {
+      title: t("alreadyReservedText"),
+      description: "",
+      buttonText: t("closeText")
+    },
+    default: {
+      title: t("reservationErrorsTitleText"),
+      description: t("reservationErrorsDescriptionText"),
+      buttonText: t("tryAginButtonText")
+    }
+  } as const;
+
+  const reservationErrorInfo =
+    handleErrorText[reservationResult] || handleErrorText.default;
+
   return (
     <section className="reservation-modal reservation-modal--confirm">
-      {errorDescription ? (
-        <h2 className="text-header-h3 pb-48">{errorDescription}</h2>
-      ) : (
-        <>
-          <h2 className="text-header-h3 pb-48">
-            {t("reservationErrorsTitleText")}
-          </h2>
-          <p className="text-body-medium-regular pb-48">
-            {t("reservationErrorsDescriptionText")}
-          </p>
-        </>
+      <h2 className="text-header-h3 pb-48">{reservationErrorInfo.title}</h2>
+      {reservationErrorInfo.description && (
+        <p className="text-body-medium-regular pb-48">
+          {reservationErrorInfo.description}
+        </p>
       )}
       <Button
         classNames="reservation-modal__confirm-button"
-        label={buttonText ?? t("tryAginButtonText")}
+        label={reservationErrorInfo.buttonText}
         buttonType="none"
         disabled={false}
         collapsible={false}

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -1,32 +1,45 @@
 import React from "react";
+import { ReservationResponseV2 } from "../../core/fbs/model";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 
 type ReservationErrorProps = {
-  setReservationDidSuccess: (value: boolean | null) => void;
+  errorDescription?: string;
+  buttonText?: string;
+  setReservationResponse: (
+    reservationResponse: ReservationResponseV2 | null
+  ) => void;
 };
 
 const ReservationError: React.FC<ReservationErrorProps> = ({
-  setReservationDidSuccess
+  errorDescription,
+  buttonText,
+  setReservationResponse
 }) => {
   const t = useText();
   return (
     <section className="reservation-modal reservation-modal--confirm">
-      <h2 className="text-header-h3 pb-48">
-        {t("reservationErrorsTitleText")}
-      </h2>
-      <p className="text-body-medium-regular pb-48">
-        {t("reservationErrorsDescriptionText")}
-      </p>
+      {errorDescription ? (
+        <h2 className="text-header-h3 pb-48">{errorDescription}</h2>
+      ) : (
+        <>
+          <h2 className="text-header-h3 pb-48">
+            {t("reservationErrorsTitleText")}
+          </h2>
+          <p className="text-body-medium-regular pb-48">
+            {t("reservationErrorsDescriptionText")}
+          </p>
+        </>
+      )}
       <Button
         classNames="reservation-modal__confirm-button"
-        label={t("tryAginButtonText")}
+        label={buttonText ?? t("tryAginButtonText")}
         buttonType="none"
         disabled={false}
         collapsible={false}
         size="small"
         variant="filled"
-        onClick={() => setReservationDidSuccess(null)}
+        onClick={() => setReservationResponse(null)}
       />
     </section>
   );

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -32,7 +32,7 @@ const ReservationError: React.FC<ReservationErrorProps> = ({
         </>
       )}
       <Button
-        classNames="reservation-modal__confirm-button"
+        className="reservation-modal__confirm-button"
         label={buttonText ?? t("tryAginButtonText")}
         buttonType="none"
         disabled={false}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -8,12 +8,14 @@ type ReservationSuccesProps = {
   title: string;
   preferredPickupBranch: string;
   modalId: string;
+  numberInQueue: string;
 };
 
 const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   modalId,
   title,
-  preferredPickupBranch
+  preferredPickupBranch,
+  numberInQueue
 }) => {
   const dispatch = useDispatch();
   const t = useText();
@@ -24,6 +26,9 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
       </h2>
       <p className="text-body-medium-regular pb-24">
         {title} {t("reservationSuccesIsReservedForYouText")}
+      </p>
+      <p className="text-body-medium-regular pb-24">
+        {t("numberInQueueText")} {numberInQueue} {t("queueText")}
       </p>
       <p className="text-body-medium-regular pb-48">
         {t("reservationSuccesPreferredPickupBranchText")}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -35,7 +35,7 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         {preferredPickupBranch}.
       </p>
       <Button
-        classNames="reservation-modal__confirm-button"
+        className="reservation-modal__confirm-button"
         label={t("okButtonText")}
         buttonType="none"
         disabled={false}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -35,7 +35,7 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         {preferredPickupBranch}.
       </p>
       <Button
-        className="reservation-modal__confirm-button"
+        classNames="reservation-modal__confirm-button"
         label={t("okButtonText")}
         buttonType="none"
         disabled={false}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -8,7 +8,7 @@ type ReservationSuccesProps = {
   title: string;
   preferredPickupBranch: string;
   modalId: string;
-  numberInQueue: string;
+  numberInQueue?: number;
 };
 
 const ReservationSucces: React.FC<ReservationSuccesProps> = ({
@@ -27,9 +27,11 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
       <p className="text-body-medium-regular pb-24">
         {title} {t("reservationSuccesIsReservedForYouText")}
       </p>
-      <p className="text-body-medium-regular pb-24">
-        {t("numberInQueueText")} {numberInQueue} {t("queueText")}
-      </p>
+      {numberInQueue && (
+        <p className="text-body-medium-regular pb-24">
+          {t("numberInQueueText")} {numberInQueue} {t("queueText")}
+        </p>
+      )}
       <p className="text-body-medium-regular pb-48">
         {t("reservationSuccesPreferredPickupBranchText")}
         {preferredPickupBranch}.

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -107,13 +107,10 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
     });
   };
 
-  const reservationResult = reservationResponse?.reservationResults
-    ? reservationResponse.reservationResults[0].result
-    : null;
-
-  const reservationDetails = reservationResponse?.reservationResults
-    ? reservationResponse.reservationResults[0].reservationDetails
-    : null;
+  const reservationSuccess = reservationResponse?.success || false;
+  const reservationResult = reservationResponse?.reservationResults[0]?.result;
+  const reservationDetails =
+    reservationResponse?.reservationResults[0]?.reservationDetails;
 
   return (
     <Modal
@@ -123,73 +120,71 @@ const ReservationModal = ({ manifestation }: ReservationModalProps) => {
       )}
       closeModalAriaLabelText={t("reservationModalCloseModalAriaLabelText")}
     >
-      {reservationResult === "success" && reservationDetails && patron && (
+      {reservationSuccess && reservationDetails && (
         <ReservationSucces
           modalId={reservationModalId(faustId)}
           title={titles.main[0]}
           preferredPickupBranch={getPreferredLocation(
-            patron.preferredPickupBranch,
+            reservationDetails.pickupBranch,
             branchData
           )}
-          numberInQueue={String(reservationDetails.numberInQueue)}
+          numberInQueue={reservationDetails.numberInQueue}
         />
       )}
 
-      {reservationResult === "already_reserved" && (
+      {!reservationSuccess && reservationResult && (
         <ReservationError
+          reservationResult={reservationResult}
           setReservationResponse={setReservationResponse}
-          errorDescription={t("alreadyReservedText")}
-          buttonText={t("closeText")}
         />
       )}
 
-      {reservationResult !== "success" &&
-        reservationResult !== "already_reserved" && (
-          <section className="reservation-modal">
-            <header className="reservation-modal-header">
-              <Cover pid={pid as Pid} size="medium" animate />
-              <div className="reservation-modal-description">
-                <div className="reservation-modal-tag">
-                  {materialTypes[0].specific}
-                </div>
-                <h2 className="text-header-h2 mt-22 mb-8">{titles.main[0]}</h2>
-                <p className="text-body-medium-regular">
-                  {t("materialHeaderAuthorByText")} {author} (
-                  {publicationYear.display})
-                </p>
+      {!reservationResult && (
+        <section className="reservation-modal">
+          <header className="reservation-modal-header">
+            <Cover pid={pid as Pid} size="medium" animate />
+            <div className="reservation-modal-description">
+              <div className="reservation-modal-tag">
+                {materialTypes[0].specific}
               </div>
-            </header>
-            <div>
-              <div className="reservation-modal-submit">
-                <p className="text-small-caption">
-                  {`${t("weHaveShoppedText")} ${totalMaterials(holdings)} ${t(
-                    "copiesThereIsText"
-                  )} ${reservations} ${t("reservationsForThisMaterialText")}`}
-                </p>
-                <Button
-                  label={t("approveReservationText")}
-                  buttonType="none"
-                  variant="filled"
-                  disabled={false}
-                  collapsible={false}
-                  size="small"
-                  onClick={onClick}
-                />
-              </div>
-              <div className="reservation-modal-list">
-                <ReservationFormListItem
-                  icon={Various}
-                  title={t("editionText")}
-                  text={summary}
-                  changeHandler={() => {}} // TODO: open modal to switch user data
-                />
-                {patron && (
-                  <UserListItems patron={patron} branchData={branchData} />
-                )}
-              </div>
+              <h2 className="text-header-h2 mt-22 mb-8">{titles.main[0]}</h2>
+              <p className="text-body-medium-regular">
+                {t("materialHeaderAuthorByText")} {author} (
+                {publicationYear.display})
+              </p>
             </div>
-          </section>
-        )}
+          </header>
+          <div>
+            <div className="reservation-modal-submit">
+              <p className="text-small-caption">
+                {`${t("weHaveShoppedText")} ${totalMaterials(holdings)} ${t(
+                  "copiesThereIsText"
+                )} ${reservations} ${t("reservationsForThisMaterialText")}`}
+              </p>
+              <Button
+                label={t("approveReservationText")}
+                buttonType="none"
+                variant="filled"
+                disabled={false}
+                collapsible={false}
+                size="small"
+                onClick={onClick}
+              />
+            </div>
+            <div className="reservation-modal-list">
+              <ReservationFormListItem
+                icon={Various}
+                title={t("editionText")}
+                text={summary}
+                changeHandler={() => {}} // TODO: open modal to switch user data
+              />
+              {patron && (
+                <UserListItems patron={patron} branchData={branchData} />
+              )}
+            </div>
+          </div>
+        </section>
+      )}
     </Modal>
   );
 };


### PR DESCRIPTION
#### Link to issue  https://reload.atlassian.net/browse/DDFSOEG-207
#### Link to Figma https://www.figma.com/file/ETOZIfmgGS1HUfio57SOh7/S%C3%B8gning?node-id=982%3A13337

#### Description
This PR use response from mutate (useAddReservationsV2) to determine whether to show success or error component after confirming the reservation.

**ReservationSucces**  shows
- title
- numberInQueue
- preferredPickupBranch


#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-09-14 kl  11 37 37" src="https://user-images.githubusercontent.com/49920322/190119384-1b302836-2c33-45fa-a40b-0f6bc0d58106.png">

if reservationResult === "already_reserved"  **ReservationError**  shows
<img width="1728" alt="Skærmbillede 2022-09-14 kl  11 37 50" src="https://user-images.githubusercontent.com/49920322/190119369-28e10489-ac3b-476b-9498-597645a14d21.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
