### PR TITLE
Change prop name from additionalClasses to classNames

### DIFF
--- a/src/apps/loan-list/modal/due-date-loans-modal.tsx
+++ b/src/apps/loan-list/modal/due-date-loans-modal.tsx
@@ -25,7 +25,7 @@ const DueDateLoansModal: FC<DueDateLoansModalProps> = ({
   return (
     <Modal
       modalId={dueDate}
-      additionalClasses="modal-loan"
+      classNames="modal-loan"
       closeModalAriaLabelText={t("dueDateRenewLoanCloseModalText")}
       screenReaderModalDescriptionText={t(
         "dueDateRenewLoanModalDescriptionText"

--- a/src/apps/loan-list/modal/material-details-modal.tsx
+++ b/src/apps/loan-list/modal/material-details-modal.tsx
@@ -21,7 +21,7 @@ const MaterialDetailsModal: FC<MaterialDetailsModalProps> = ({
   return (
     <Modal
       modalId={faust}
-      additionalClasses="modal-details"
+      classNames="modal-details"
       closeModalAriaLabelText={t("materialDetailsCloseModalText")}
       screenReaderModalDescriptionText={t(
         "materialDetailsModalDescriptionText"

--- a/src/apps/loan-list/modal/renew-loans-modal.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal.tsx
@@ -19,7 +19,7 @@ const RenewLoansModal: FC<RenewLoansModalProps> = ({
   return (
     <Modal
       modalId={modalIdsConf.allLoansId}
-      additionalClasses="modal-loan"
+      classNames="modal-loan"
       closeModalAriaLabelText={t("renewLoanModalCloseModalText")}
       screenReaderModalDescriptionText={t("renewLoanModalDescriptionText")}
     >

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -51,7 +51,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({ manifestation }) => {
         "findOnShelfModalScreenReaderModalDescriptionText"
       )}
       closeModalAriaLabelText={t("findOnShelfModalCloseModalAriaLabelText")}
-      additionalClasses="modal-details modal-find-on-shelf"
+      classNames="modal-details modal-find-on-shelf"
     >
       <>
         <h2 className="text-header-h2 modal-find-on-shelf__headline">

--- a/src/components/reservation/reservation-modal.tsx
+++ b/src/components/reservation/reservation-modal.tsx
@@ -26,7 +26,6 @@ import {
   getPreferredLocation,
   totalMaterials
 } from "../../apps/material/helper";
-import { ManifestationsSimpleFieldsFragment } from "../../core/dbc-gateway/generated/graphql";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,
@@ -34,7 +33,7 @@ import {
   useGetHoldingsV3,
   useGetPatronInformationByPatronIdV2
 } from "../../core/fbs/fbs";
-import { Manifestation, Work } from "../../core/utils/types/entities";
+import { Manifestation } from "../../core/utils/types/entities";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import CloseIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/CloseLarge.svg";
+import clsx from "clsx";
 import { closeModal, openModal } from "../modal.slice";
 
 type ModalId = string;
@@ -45,9 +46,13 @@ function Modal({
 
   return (
     <div
-      className={`modal ${modalIds.includes(modalId) ? "modal-show" : ""} ${
-        classNames || ""
-      }`}
+      className={clsx(
+        "modal",
+        {
+          "modal-show": modalIds.includes(modalId)
+        },
+        classNames
+      )}
       style={{
         // some elements are designed with z-index which means they pop up over the modal
         // so I add 10 to the z-index of the modal

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -10,7 +10,7 @@ type ModalProps = {
   modalId: ModalId;
   closeModalAriaLabelText: string;
   screenReaderModalDescriptionText: string;
-  additionalClasses?: string;
+  classNames?: string;
 };
 
 export interface ModalIdsProps {
@@ -24,7 +24,7 @@ function Modal({
   closeModalAriaLabelText,
   children,
   screenReaderModalDescriptionText,
-  additionalClasses
+  classNames
 }: ModalProps) {
   const dispatch = useDispatch();
   const { modalIds } = useSelector((s: ModalIdsProps) => s.modal);
@@ -45,9 +45,9 @@ function Modal({
 
   return (
     <div
-      className={`modal ${
-        modalIds.includes(modalId) ? "modal-show" : ""
-      } ${additionalClasses}`}
+      className={`modal ${modalIds.includes(modalId) ? "modal-show" : ""} ${
+        classNames || ""
+      }`}
       style={{
         // some elements are designed with z-index which means they pop up over the modal
         // so I add 10 to the z-index of the modal


### PR DESCRIPTION


#### Description

This PR adds padding to reservation modal + change the  modal prop name from additionalClasses to classNames

#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-09-16 kl  13 53 32" src="https://user-images.githubusercontent.com/49920322/190633235-e3adb675-51ca-485b-9e6c-07fec463f90e.png">
<img width="1728" alt="Skærmbillede 2022-09-16 kl  13 53 14" src="https://user-images.githubusercontent.com/49920322/190633253-e7cccbe2-adbe-4250-8690-058cc24a5564.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

