### PR TITLE
Only render SearchResultHeader + SearchResultList if worksAreLoaded

### DIFF
--- a/.vscode.example/dpl-react.code-snippets
+++ b/.vscode.example/dpl-react.code-snippets
@@ -5,7 +5,7 @@
   // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
   // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
   // Placeholders with the same ids are connected.
-  "Dpl-react functional component": {
+  "Functional component": {
     "scope": "typescriptreact",
     "prefix": "fcdplreact",
     "body": [
@@ -25,5 +25,21 @@
       "export default ${1:component};"
     ],
     "description": "Creates a skeleton for a new functional component in dpl-react style"
-  }
+  },
+  "String literal variable": {
+    "scope": "typescriptreact",
+    "prefix": "slvdplreact",
+    "body": [
+      "${${1:variable}}",
+    ],
+    "description": "Formats a varaible to be used in a string literal"
+  },
+  "Debug": {
+    "scope": "typescriptreact",
+    "prefix": "debugdplreact",
+    "body": [
+      "console.debug(${1:variable});",
+    ],
+    "description": "Writes console.debug();"
+  },
 }

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -65,9 +65,13 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
 
   return (
     <div className="search-result-page">
-      <SearchResultHeader hitcount={String(hitcount)} q={q} />
-      {worksAreLoaded && <SearchResultList resultItems={resultItems} />}
-      {PagerComponent}
+      {worksAreLoaded && (
+        <>
+          <SearchResultHeader hitcount={String(hitcount)} q={q} />
+          <SearchResultList resultItems={resultItems} />
+          {PagerComponent}
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -22,13 +22,13 @@ const usePager = (
     setitemsShown(itemsOnPage);
   };
 
-  const PagerComponent = (
+  const PagerComponent = hitcount ? (
     <ResultPager
       itemsShown={overrideItemsShown ? overrideItemsShown() : itemsShown}
       hitcount={hitcount}
       setPageHandler={pagehandler}
     />
-  );
+  ) : null;
 
   return { itemsShown, PagerComponent, page };
 };


### PR DESCRIPTION
#### Link to issue


#### Description

This PR does 3 things

- Hide pager component if no results
- Only render SearchResultHeader + SearchResultList if worksAreLoaded
This prevents that there will be a flash of a zero result search page before the result are ready
- Adding debug snippet

#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions