### PR TITLE
Add Relative CI (release 4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,16 @@ jobs:
         run: yarn install
       - name: Build artifacts
         run: |
+          yarn build:css:prod
           VERSION_FILE_NAME=$GITHUB_REPOSITORY \
           VERSION_FILE_VERSION=$(git describe --tags --exclude=latest) \
-          yarn build
-      - name: Upload
+          yarn build:js:prod --json webpack-stats.json
+      - name: Upload build
         uses: actions/upload-artifact@v1
         with:
           name: dist
           path: dist
+      - name: Upload webpack stats artifact
+        uses: relative-ci/agent-upload-artifact-action@v1
+        with:
+          webpackStatsFile: ./webpack-stats.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build artifacts
+    if: '!github.event.deleted'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Required to fetch all commits and tags
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          registry-url: 'https://npm.pkg.github.com'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Dependencies
+        run: yarn install
+      - name: Build artifacts
+        run: |
+          VERSION_FILE_NAME=$GITHUB_REPOSITORY \
+          VERSION_FILE_VERSION=$(git describe --tags --exclude=latest) \
+          yarn build
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -75,36 +75,6 @@ jobs:
       - name: Lint Javascript
         run: yarn lint:js
 
-  build:
-    name: Build artifacts
-    if: '!github.event.deleted'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Required to fetch all commits and tags
-          fetch-depth: 0
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-          registry-url: 'https://npm.pkg.github.com'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Dependencies
-        run: yarn install
-      - name: Build artifacts
-        run: |
-          VERSION_FILE_NAME=$GITHUB_REPOSITORY \
-          VERSION_FILE_VERSION=$(git describe --tags --exclude=latest) \
-          yarn build
-      - name: Upload
-        uses: actions/upload-artifact@v1
-        with:
-          name: dist
-          path: dist
-
   validate_docs:
     name: Validate documentation
     if: '!github.event.deleted'

--- a/.github/workflows/relative_ci.yml
+++ b/.github/workflows/relative_ci.yml
@@ -1,0 +1,17 @@
+name: RelativeCI
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send webpack stats to RelativeCI
+        uses: relative-ci/agent-action@v2
+        with:
+          key: ${{ secrets.RELATIVE_CI_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/architecture/adr-004-relative-ci.md
+++ b/architecture/adr-004-relative-ci.md
@@ -1,0 +1,55 @@
+# Architecture Decision Record: RelativeCI
+
+## Context
+
+Staying informed about how the size of the JavaScript we require browsers to
+download to use the project plays an important part in ensuring a performant
+solution.
+
+We currently have no awareness of this in this project and the result surfaces
+down the line when the project is integrated with [the CMS](dpl-cms), which is
+tested with Lighthouse.
+
+To address this we want a solution that will help us monitor the changes to the
+size of the bundle we ship for each PR.
+
+## Decision
+
+We add integration to [RelativeCI](https://relative-ci.com/) to the project.
+RelativeCI supports our primary use case and has a number of qualities which we
+value:
+
+- Support for GitHub actions and reporting as GitHub status checks
+- [Support for fork-based development workflows](https://relative-ci.com/documentation/setup/agent/github-action/#workflow_run-event)
+- A free tier for open source projects
+- Other types of analysis e.g. duplicate packages, continual monitoring
+
+## Alternatives considered
+
+### [Bundlewatch](https://github.com/bundlewatch/bundlewatch)
+
+Bundlewatch and its ancestor, [bundlesize](https://github.com/siddharthkp/bundlesize)
+combine a CLI tool and a web app to provide bundle analysis and feedback on
+GitHub as status checks.
+
+These solutions no longer seem to be actively maintained. There are [several](https://github.com/bundlewatch/bundlewatch/issues/423)
+[bugs](https://github.com/bundlewatch/bundlewatch/issues/422) that would affect
+us and fixes remain unmerged. The project relies on a custom secret instead of
+`GITHUB_TOKEN`. This makes supporting our fork-based development workflow
+harder.
+
+### [Bundle comparison](https://github.com/marketplace/actions/bundle-comparison)
+
+This is a GitHub Action which can be used in configurations where statistics
+for two bundles are compared e.g. for the base and head of a pull request. This
+results in a table of changes displayed as a comment in the pull request.
+This is managed using `GITHUB_TOKEN.`
+
+## Status
+
+Accepted.
+
+## Consequences
+
+- We can determine the effect of adding a new JavaScript library to our project
+- We add another dependency to a third party system


### PR DESCRIPTION
#### Description

This PR adds the configuration of Relative CI to the `release/4` branch. This is needed to make PRs from forks report statistics which can be compared with the base repository.

The actual commits should be the same as in #151 which will make it possible to merge `release/4` into `main` without problems eventually.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
