### PR TITLE
Fix broken material test

### DIFF
--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -29,7 +29,7 @@ describe("Material", () => {
     cy.contains("unavailable");
   });
   it("Open material details", () => {
-    cy.get("details").click({ multiple: true });
+    cy.get("details").last().click();
   });
   it("Does the material have a editions with a buttton to reserved", () => {
     cy.contains("reserver");
@@ -56,8 +56,6 @@ describe("Material", () => {
   });
 
   beforeEach(() => {
-    cy.visit("/iframe.html?args=&id=apps-material--material");
-
     cy.fixture("material/reservations.json")
       .then((result) => {
         cy.intercept("POST", "**/patrons/patronid/reservations/**", result);
@@ -107,6 +105,8 @@ describe("Material", () => {
     cy.intercept("HEAD", "**/list/default/**", {
       statusCode: 404
     }).as("Favorite list service");
+
+    cy.visit("/iframe.html?args=&id=apps-material--material");
   });
 });
 


### PR DESCRIPTION
#### Fix broken material test
- cy.visit() is moved to the bottom of beforeEach 
- instead of opening all the details, only the last one is now selected, which is the one for the material


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.