### PR TITLE
Sort find on shelf modal library branches alphabetically

### DIFF
--- a/src/apps/loan-list/list/list.tsx
+++ b/src/apps/loan-list/list/list.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC, useCallback, useEffect } from "react";
+import React, { FC, useCallback, useEffect } from "react";
 import { GetMaterialManifestationQuery } from "../../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../../core/utils/text";
 import IconList from "../../../components/icon-list/icon-list";

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -78,8 +78,13 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   });
 
   // Sorting of the data below to show branches & manifestations in the correct order.
+  const finalDataAlphabetical = finalData.sort(
+    (a: ManifestationHoldings, b: ManifestationHoldings) => {
+      return a[0].holding.branch.title > b[0].holding.branch.title ? 1 : -1;
+    }
+  );
   // "00" is the ending of beanchIds for branches that are considered main.
-  const finalDataMainBranchFirst = finalData.sort(
+  const finalDataMainBranchFirst = finalDataAlphabetical.sort(
     (manifestationHolding: ManifestationHoldings) => {
       return manifestationHolding[0].holding.branch.branchId.endsWith("00")
         ? -1

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -80,7 +80,10 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   // Sorting of the data below to show branches & manifestations in the correct order.
   const finalDataAlphabetical = finalData.sort(
     (a: ManifestationHoldings, b: ManifestationHoldings) => {
-      return a[0].holding.branch.title > b[0].holding.branch.title ? 1 : -1;
+      return a[0].holding.branch.title.localeCompare(
+        b[0].holding.branch.title,
+        "da-DK"
+      );
     }
   );
   // "00" is the ending of beanchIds for branches that are considered main.


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-226

#### Description
This PR orders find on shelf modal library branches alphabetically (with the exception of the main branch, which is always first).

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/192231829-fe140507-b795-4b2a-a064-6c53d19abd84.png)

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
