### PR TITLE
Feature/find on shelf/show unavailable branches last

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@storybook/preset-typescript": "^3.0.0",
     "@storybook/react": "^6.5.0-beta.7",
     "@tsconfig/create-react-app": "^1.0.2",
+    "@types/lodash.partition": "^4.6.7",
     "@types/node": "^17.0.31",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.3",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "downshift": "^6.1.7",
     "graphql": "^16.5.0",
     "graphql-tag": "^2.12.6",
+    "lodash.partition": "^4.6.0",
     "orval": "^6.8.1",
     "prop-types": "^15.8.1",
     "react": "^18.1.0",

--- a/src/apps/loan-list/list/list.tsx
+++ b/src/apps/loan-list/list/list.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC, useCallback, useEffect } from "react";
+import React, { FC, useCallback, useEffect } from "react";
 import { GetMaterialManifestationQuery } from "../../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../../core/utils/text";
 import IconList from "../../../components/icon-list/icon-list";

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { FC } from "react";
-import { partition } from "lodash.partition";
+import partition from "lodash.partition";
 import { isAnyManifestationAvailableOnBranch } from "../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -138,7 +138,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
             <div className="text-small-caption modal-find-on-shelf__caption">
               {`${finalData.length} ${t("librariesHaveTheMaterialText")}`}
             </div>
-            {finalDataToShow.map((libraryBranch) => {
+            {finalDataToShow.map((libraryBranch: ManifestationHoldings) => {
               return (
                 <Disclosure
                   key={libraryBranch[0].holding.branch.branchId}

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { FC } from "react";
+import { partition } from "lodash.partition";
 import { isAnyManifestationAvailableOnBranch } from "../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {
@@ -90,16 +91,9 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
       "da-DK"
     );
   }
-  const availableManifestationHoldings = finalData.filter(
-    (manifestationHolding: ManifestationHoldings) => {
-      return isAnyManifestationAvailableOnBranch(manifestationHolding);
-    }
-  );
-  const unavailableManifestationHoldings = finalData.filter(
-    (manifestationHolding: ManifestationHoldings) => {
-      return !isAnyManifestationAvailableOnBranch(manifestationHolding);
-    }
-  );
+  const [availableManifestationHoldings, unavailableManifestationHoldings] =
+    partition(finalData, isAnyManifestationAvailableOnBranch);
+
   const finalDataAlphabetical = availableManifestationHoldings
     .sort((a: ManifestationHoldings, b: ManifestationHoldings) => {
       return orderManifestationHoldingsAlphabetically(a, b);

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -86,7 +86,8 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
       );
     }
   );
-  // "00" is the ending of beanchIds for branches that are considered main.
+  // "00" is the ending of beanchIds for branches that are considered main & should
+  // be shown first independent of whether they're available.
   const finalDataMainBranchFirst = finalDataAlphabetical.sort(
     (manifestationHolding: ManifestationHoldings) => {
       return manifestationHolding[0].holding.branch.branchId.endsWith("00")

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -78,14 +78,36 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   });
 
   // Sorting of the data below to show branches & manifestations in the correct order.
-  const finalDataAlphabetical = finalData.sort(
-    (a: ManifestationHoldings, b: ManifestationHoldings) => {
-      return a[0].holding.branch.title.localeCompare(
-        b[0].holding.branch.title,
-        "da-DK"
-      );
+  function orderManifestationHoldingsAlphabetically(
+    a: ManifestationHoldings,
+    b: ManifestationHoldings
+  ) {
+    return a[0].holding.branch.title.localeCompare(
+      b[0].holding.branch.title,
+      "da-DK"
+    );
+  }
+  const availableManifestationHoldings = finalData.filter(
+    (manifestationHolding: ManifestationHoldings) => {
+      return isAnyManifestationAvailableOnBranch(manifestationHolding);
     }
   );
+  const unavailableManifestationHoldings = finalData.filter(
+    (manifestationHolding: ManifestationHoldings) => {
+      return !isAnyManifestationAvailableOnBranch(manifestationHolding);
+    }
+  );
+  const finalDataAlphabetical = availableManifestationHoldings
+    .sort((a: ManifestationHoldings, b: ManifestationHoldings) => {
+      return orderManifestationHoldingsAlphabetically(a, b);
+    })
+    .concat(
+      unavailableManifestationHoldings.sort(
+        (a: ManifestationHoldings, b: ManifestationHoldings) => {
+          return orderManifestationHoldingsAlphabetically(a, b);
+        }
+      )
+    );
   // "00" is the ending of beanchIds for branches that are considered main & should
   // be shown first independent of whether they're available.
   const finalDataMainBranchFirst = finalDataAlphabetical.sort(

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -77,7 +77,10 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
     );
   });
 
-  // Sorting of the data below to show branches & manifestations in the correct order.
+  // Sorting of the data below to show branches in the correct order:
+  // 1. Main library branch first
+  // 2. Branches with any available speciments sorted alphabetically
+  // 3. Branches without available speciments sorted alphabetically
   function orderManifestationHoldingsAlphabetically(
     a: ManifestationHoldings,
     b: ManifestationHoldings

--- a/yarn.lock
+++ b/yarn.lock
@@ -12923,6 +12923,11 @@ lodash.once@^4.0.0, lodash.once@^4.1.1:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
+lodash.partition@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.partition/-/lodash.partition-4.6.0.tgz#a38e46b73469e0420b0da1212e66d414be364ba4"
+  integrity sha512-35L3dSF3Q6V1w5j6V3NhNlQjzsRDC/pYKCTdYTmwqSib+Q8ponkAmt/PwEOq3EmI38DSCl+SkIVwLd+uSlVdrg==
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,6 +4610,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash.partition@^4.6.7":
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.partition/-/lodash.partition-4.6.7.tgz#7c4bcfa30e2cd945466401855eb5593a848fadff"
+  integrity sha512-tRAQtiQkNfMLPInsv+o/3vXR/YUj8YaqzFh/bdlTdVYvuydU817+dX/dM7N7sQWMQ2PgF4ziHILuvlvW4aHnnw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.185"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.185.tgz#c9843f5a40703a8f5edfd53358a58ae729816908"
+  integrity sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==
+
 "@types/lodash@^4.14.167":
   version "4.14.182"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-225

#### Description
This PR introduces sorting library branches in "find on shelf modal" in **groups** - branches that have at least one available manifestation are shown first and branches without any available specimens are shown last (with the exception of any main branches that are shown on the top regardless).

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/192248425-0dfbe47e-f0b8-4850-8b3b-3203464be799.png)

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
