### PR TITLE
Add reserve a periodical logic

### DIFF
--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -1,0 +1,80 @@
+{
+  "data": {
+    "work": {
+      "workId": "work-of:870970-basis:06373674",
+      "titles": { "full": ["Alt for damerne"], "original": [] },
+      "abstract": [],
+      "creators": [],
+      "series": [],
+      "seriesMembers": [],
+      "genreAndForm": [],
+      "manifestations": {
+        "all": [
+          {
+            "pid": "870970-basis:06373674",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "titles": { "main": ["Alt for damerne"], "original": [] },
+            "fictionNonfiction": {
+              "display": "FAGLITTERATUR",
+              "code": "NONFICTION"
+            },
+            "publicationYear": { "display": "1946" },
+            "materialTypes": [{ "specific": "periodikum" }],
+            "creators": [],
+            "hostPublication": null,
+            "languages": { "main": [{ "display": "dansk" }] },
+            "identifiers": [{ "value": "0002-6506" }],
+            "contributors": [],
+            "edition": null,
+            "audience": { "generalAudience": [] },
+            "physicalDescriptions": [],
+            "accessTypes": [{ "code": "PHYSICAL" }],
+            "access": [
+              { "__typename": "DigitalArticleService", "issn": "00026506" },
+              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            ],
+            "shelfmark": null
+          }
+        ],
+        "latest": {
+          "pid": "870970-basis:06373674",
+          "genreAndForm": [],
+          "source": ["Bibliotekskatalog"],
+          "titles": { "main": ["Alt for damerne"], "original": [] },
+          "fictionNonfiction": {
+            "display": "FAGLITTERATUR",
+            "code": "NONFICTION"
+          },
+          "publicationYear": { "display": "1946" },
+          "materialTypes": [{ "specific": "periodikum" }],
+          "creators": [],
+          "hostPublication": null,
+          "languages": { "main": [{ "display": "dansk" }] },
+          "identifiers": [{ "value": "0002-6506" }],
+          "contributors": [],
+          "edition": null,
+          "audience": { "generalAudience": [] },
+          "physicalDescriptions": [],
+          "accessTypes": [{ "code": "PHYSICAL" }],
+          "access": [
+            { "__typename": "DigitalArticleService", "issn": "00026506" },
+            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          ],
+          "shelfmark": null
+        }
+      },
+      "materialTypes": [{ "specific": "Tidsskrift" }],
+      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "subjects": {
+        "all": [
+          { "display": "dame- og mandeblade" },
+          { "display": "Viborg amtskommune" }
+        ]
+      },
+      "reviews": [],
+      "fictionNonfiction": { "display": "NONFIKTION", "code": "NONFICTION" },
+      "workYear": null
+    }
+  }
+}

--- a/cypress/fixtures/material/periodical-holdings.json
+++ b/cypress/fixtures/material/periodical-holdings.json
@@ -1,0 +1,18341 @@
+[
+  {
+    "recordId": "06373674",
+    "reservable": true,
+    "reservations": 37,
+    "holdings": [
+      {
+        "branch": { "branchId": "DK-775127", "title": "Tranbjerg" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313131426",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313143025",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "A1011223728A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313139591",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128123",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043782195",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 46#Julebag",
+              "volumeNumber": "46#Julebag"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847797850",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848392714",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847880596",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847882092",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3280377626",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2009",
+              "displayText": "2009, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140571433",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703091",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703903",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258747803",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258707070",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258704829",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750049",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750529",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750367",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750685",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752041",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752203",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983194",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963754",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964483",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987017",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688203",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689250",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988285",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987793",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981744",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022112",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982491",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313023941",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022058",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979618",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019774",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968365",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991146",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966729",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968047",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971171",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992142",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993459",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992673",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740787",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258758252",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697091",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258757213",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312974225",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737621",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994838",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994196",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052194",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044116",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957460",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053417",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005730",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006419",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008217",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959161",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027696",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012346",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029230",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031715",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014535",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012958",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033610",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015442",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035516",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978352",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979456",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977496",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960496",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131493",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313143033",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132041",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036911",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050175",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050531",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040145",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048359",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046097",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046501",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775150", "title": "Tilst" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313046488",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046801",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046119",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048332",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046771",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050914",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050558",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050159",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113851",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037330",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036075",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132619",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131515",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313143051",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979472",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978301",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977410",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960518",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016619",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035443",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015469",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033637",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014551",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031731",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012931",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012321",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029222",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008233",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027688",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006435",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005757",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957487",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053883",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053395",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313043969",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052178",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043918712",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140647111",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043922434",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847927029",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 02",
+              "volumeNumber": "2"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847929838",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 03",
+              "volumeNumber": "3"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043744099",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 37#Alt om dit bryllu",
+              "volumeNumber": "37#Alt om dit bryllu"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849711181",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3843462722",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847872550",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848401284",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 04",
+              "volumeNumber": "4"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848462860",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848415331",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848408076",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847179022",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3841240560",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847704471",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848460711",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848446873",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847170203",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140642098",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 08",
+              "volumeNumber": "8"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140631363",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140638910",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140617905",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140626416",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140612539",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140719521",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140567452",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140828558",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313003411",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313002677",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258774711",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258771127",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258765518",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258756861",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258755571",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752068",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750707",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750545",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750383",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750227",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750065",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258707097",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258704845",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703921",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703113",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740760",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258758163",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697113",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258757205",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312974284",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737603",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312995125",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994854",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994171",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993432",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992657",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971099",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992126",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991121",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968357",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968063",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966710",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689277",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688221",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988269",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987645",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987033",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964505",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963770",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983216",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982481",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313023925",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981000",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022090",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979634",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022023",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019782",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130500",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128840",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138633",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223730A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313128050",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127240",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139532",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126007",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128794",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775160", "title": "Risskov" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "rødplade", "title": "Rød plade" },
+        "sublocation": { "sublocationId": "tidssk", "title": "Tidsskrifter" },
+        "materials": [
+          {
+            "itemNumber": "5313131922",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775146", "title": "Harlev" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313138544",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223722A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313019847",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979553",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982546",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981681",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688165",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964424",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963691",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697032",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992738",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966621",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258718676",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703032",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043909721",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 04",
+              "volumeNumber": "4"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052259",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044051",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053964",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053476",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957401",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006354",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005676",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027599",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029291",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959102",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031650",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012400",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013016",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035451",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977437",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142975",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130411",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131434",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131981",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132538",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035982",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036857",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037756",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048413",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113770",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050231",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050477",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050991",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046712",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040080",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046038",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046569",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775130", "title": "Viby" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "rødplade", "title": "Rød plade" },
+        "sublocation": { "sublocationId": "tidssk", "title": "Tidsskrifter" },
+        "materials": [
+          {
+            "itemNumber": "5313131388",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139478",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775162", "title": "Hjortshøj" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313139451",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126023",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048391",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046054",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046704",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127275",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124578",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139486",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313125930",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127283",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966613",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113738",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130373",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046496",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037489",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127364",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124659",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027602",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128824",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053905",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313051058",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046542",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040099",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048383",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046739",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113827",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050213",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313051023",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050493",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142991",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131469",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130462",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132015",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132554",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036008",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036881",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037446",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037731",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052224",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044078",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053931",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053451",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957452",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005692",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006400",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008187",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029311",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959129",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031677",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012389",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979413",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019820",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986983",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688191",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689218",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987750",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991170",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968284",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966648",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992711",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740817",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258758211",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312975620",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697083",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994791",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994234",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258598069",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 27#Sommersmag",
+              "volumeNumber": "27#Sommersmag"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258610123",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258595280",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258593660",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140808360",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140849611",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258590076",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258601612",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140846327",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140806821",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140785761",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140784739",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140844189",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140783538",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140781306",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140840736",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140779522",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140877168",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140875432",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140794327",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140872220",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140871895",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140820816",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140820034",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140720897",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140617360",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847716273",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848446695",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140764150",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140564763",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140760015",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140759246",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140831214",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140559212",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 27#Sommersmag",
+              "volumeNumber": "27#Sommersmag"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140828612",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140567381",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140675220",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 03",
+              "volumeNumber": "3"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140731546",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 04",
+              "volumeNumber": "4"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140671667",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 06",
+              "volumeNumber": "6"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140728189",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 07",
+              "volumeNumber": "7"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140668577",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 08",
+              "volumeNumber": "8"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140686796",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 09",
+              "volumeNumber": "9"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140685390",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140684017",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140714031",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140709028",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140837670",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140766481",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849711600",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043759142",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043722494",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849692101",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043564910",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2014",
+              "displayText": "2014, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849690001",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847173016",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 03",
+              "volumeNumber": "3"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847704445",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2012",
+              "displayText": "2012, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848398119",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 03",
+              "volumeNumber": "3"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3842897512",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2009",
+              "displayText": "2009, nr. 01",
+              "volumeNumber": "1"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3843119319",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2008",
+              "displayText": "2008, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847745265",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847803982",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847799918",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847687532",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847965192",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043918763",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043796676",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043630468",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2014",
+              "displayText": "2014, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849803831",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2014",
+              "displayText": "2014, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847929791",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 03",
+              "volumeNumber": "3"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847923805",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 06",
+              "volumeNumber": "6"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847931824",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 05",
+              "volumeNumber": "5"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847974868",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 07",
+              "volumeNumber": "7"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847926995",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 02",
+              "volumeNumber": "2"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847944098",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847937059",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 09",
+              "volumeNumber": "9"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847787251",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847798415",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847796358",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847797869",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258668776",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258668628",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258667982",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258713216",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258710926",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258736781",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258686847",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258684933",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258618541",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258617799",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258651938",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258632100",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258630922",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258585730",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258718684",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258765453",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258726938",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 40#Strik",
+              "volumeNumber": "40#Strik"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5258774096",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258681950",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258729198",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258608757",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 34#Strik",
+              "volumeNumber": "34#Strik"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5258776781",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752335",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 53",
+              "volumeNumber": "53"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752165",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258755350",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258755512",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258756802",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258769068",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752033",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258722606",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750197",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750324",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750030",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749849",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258747765",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258707038",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703865",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138587",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223724A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313124616",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126058",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258729090",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966583",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012354",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008195",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775164", "title": "Egå" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313036938",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132066",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046577",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046011",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050981",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050485",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050248",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113789",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037772",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037391",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035974",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132521",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131965",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142959",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031669",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013032",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012427",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029273",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959110",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008136",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027572",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006338",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957381",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053980",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053484",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044043",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052275",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140637681",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 05",
+              "volumeNumber": "5"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993521",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138536",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223721A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313037705",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126066",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036083",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037470",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775140", "title": "Åby" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "rødplade", "title": "Rød plade" },
+        "sublocation": { "sublocationId": "tidssk", "title": "Tidsskrifter" },
+        "materials": [
+          {
+            "itemNumber": "5313127224",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "FBS-751031", "title": "Fjernlager 1" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313046631",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048421",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033696",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005651",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689201",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313021957",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046585",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971234",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986940",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313024026",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006443",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027610",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012982",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775130", "title": "Viby" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "læs", "title": "Læsesal" },
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313130446",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775122", "title": "Beder-Malling" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313124675",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142924",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046021",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048431",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040064",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046690",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050973",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050450",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050256",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113754",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037624",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037403",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036830",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035958",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132511",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142967",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131418",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130391",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016716",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960445",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978271",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977429",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015371",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035591",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033548",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014454",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031634",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012419",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013024",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029265",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959080",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008144",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027564",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005668",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006362",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957411",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053972",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044027",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052267",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703016",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703822",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258704772",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258706996",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258747730",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750472",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750316",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749997",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750154",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749806",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258751967",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750634",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752157",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258608722",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 34#Strik",
+              "volumeNumber": "34#Strik"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5258683066",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258726891",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 40#Strik",
+              "volumeNumber": "40#Strik"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "3847750854",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847744536",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968233",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312967970",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966591",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689171",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992215",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991219",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992754",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993531",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994277",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994765",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737700",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312995222",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740851",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258758317",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697016",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312975574",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312974233",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963703",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964432",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983283",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987718",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988358",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688130",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022181",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981663",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982511",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313021965",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979537",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019863",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979375",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128743",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139516",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124683",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223720A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313127259",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130470",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775100", "title": "Hovedbiblioteket" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "rødplade", "title": "Rød plade" },
+        "sublocation": { "sublocationId": "tidssk", "title": "Tidsskrifter" },
+        "materials": [
+          {
+            "itemNumber": "5313037721",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046127",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040013",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046641",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048464",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113721",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050418",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050280",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142908",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130381",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132481",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036016",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036784",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037349",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050930",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052313",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313043993",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313054022",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053522",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957347",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313055614",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006291",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027629",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008081",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014421",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012923",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012311",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029321",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959072",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138137",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "A1011223717A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138511",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124535",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128700",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775147", "title": "Hasle" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "A1011223716A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138501",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124543",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139461",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127232",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128697",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968276",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982554",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847842902",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847166478",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3847845804",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258590009",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140849059",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050922",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044000",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052321",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313054030",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053549",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957355",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313055622",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006303",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008098",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029303",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959056",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013067",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012451",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031601",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142916",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130357",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131371",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132465",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035990",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036806",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037357",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037748",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048472",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113746",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050302",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050426",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040005",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313045971",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046615",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775100", "title": "Hovedbiblioteket" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "læs", "title": "Læsesal" },
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313040072",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139540",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124594",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138226",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775168", "title": "Skødstrup" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313046100",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046798",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048340",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040137",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313051066",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050566",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113861",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037683",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036921",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036059",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132600",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132058",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131507",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012941",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031741",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029206",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012338",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027661",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959196",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005749",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053891",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957495",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053409",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313043977",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052186",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043909731",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 04",
+              "volumeNumber": "4"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140637711",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 05",
+              "volumeNumber": "5"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140579078",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140617344",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258590122",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258598107",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 27#Sommersmag",
+              "volumeNumber": "27#Sommersmag"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5140854060",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258593709",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043714491",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043799969",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043958102",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043975678",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043970171",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043956142",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043589271",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2014",
+              "displayText": "2014, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849612841",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848403910",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 06",
+              "volumeNumber": "6"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3848401683",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 04",
+              "volumeNumber": "4"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "3849720588",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2013",
+              "displayText": "2013, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130497",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126074",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223729A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775167", "title": "Lystrup" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "læs", "title": "Læsesal" },
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313131442",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775167", "title": "Lystrup" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313127372",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050205",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040056",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036024",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037365",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036792",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128042",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128034",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142940",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046607",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313045996",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040048",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046674",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050957",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050434",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050272",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048456",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036814",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036032",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132491",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131949",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016732",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960380",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978395",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977542",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035567",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015345",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033671",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014438",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031618",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013059",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959064",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012443",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029346",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008111",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006311",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027645",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313055630",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957363",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053514",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313054006",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044019",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052291",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740884",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749946",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749784",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750588",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750421",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968314",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966672",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992241",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991251",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993556",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737727",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258696990",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258757167",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963657",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964386",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982449",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983259",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986916",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688122",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988382",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979510",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022211",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981647",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313024042",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019881",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313021991",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979359",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128026",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138641",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223718A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313127291",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313125949",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046666",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127356",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132597",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037659",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046062",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127313",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775100", "title": "Hovedbiblioteket" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313138250",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138242",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5258750162",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036849",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130421",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138201",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138145",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313131361",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037713",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131973",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313125981",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138651",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138171",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138188",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138528",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313125973",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258758309",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750138",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703830",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960429",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130403",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131957",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142932",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312967946",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138161",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138196",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313128761",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258721529",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037411",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050167",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992665",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139605",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138285",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138625",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138153",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313127992",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132589",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313139575",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313138234",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138609",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313138617",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138269",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313124640",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046781",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138218",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313139567",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128085",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128816",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128115",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127331",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313138277",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138595",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036105",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775122", "title": "Beder-Malling" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "læs", "title": "Læsesal" },
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313128077",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126015",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775130", "title": "Viby" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "A1011223725A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138579",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124608",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139559",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127321",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128093",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128786",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979421",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019812",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022031",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979588",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022155",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981698",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313023976",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982503",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983151",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963711",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964440",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986975",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987769",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988323",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688181",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689242",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966737",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968012",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968373",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991189",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992177",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971145",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992703",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993491",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994226",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312995184",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737654",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258757221",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312974276",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697059",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258758228",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740825",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703083",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703891",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258704780",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258747791",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258707062",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749873",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750006",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750359",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750510",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750677",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752009",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752191",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258608765",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 34#Strik",
+              "volumeNumber": "34#Strik"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5258648481",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258667974",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258608013",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052232",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044086",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053441",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053948",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005706",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957428",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006370",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027701",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008179",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029249",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959153",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012370",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012990",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031707",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014500",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033572",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015401",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035478",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016661",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960453",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977453",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978311",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313143009",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130438",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131450",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132007",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132562",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036091",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037640",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113797",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050523",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313051015",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046747",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040102",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046534",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127267",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313125965",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775140", "title": "Åby" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5043906536",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2017",
+              "displayText": "2017, nr. 06",
+              "volumeNumber": "6"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258722630",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752221",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126082",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124527",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128751",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313125991",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139524",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258751924",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124551",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128069",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131914",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128107",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5312995141",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130489",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223727A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5258703911",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703105",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258707089",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258747781",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749891",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750057",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750537",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750219",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750375",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752051",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750669",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258768924",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005102",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258726954",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 40#Strik",
+              "volumeNumber": "40#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258585099",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258585511",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 08#Strik",
+              "volumeNumber": "08#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043918674",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2016",
+              "displayText": "2016, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258608773",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 34#Strik",
+              "volumeNumber": "34#Strik"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5312994218",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312995168",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737638",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697105",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258757231",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740795",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993475",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992681",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992169",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971161",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968039",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968381",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988307",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987785",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689269",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688211",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986991",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964467",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963738",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983178",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019790",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979448",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979601",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022066",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981711",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022120",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982414",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313023968",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012974",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031723",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959171",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029257",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033602",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014519",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015434",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035508",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977471",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978336",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960501",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016651",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027718",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006397",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957444",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005722",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053433",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053913",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044094",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052208",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037632",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037454",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036903",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132570",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132031",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313143017",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131485",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050541",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313051041",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050183",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113819",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046763",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048375",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046070",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046518",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775162", "title": "Hjortshøj" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "rødplade", "title": "Rød plade" },
+        "sublocation": { "sublocationId": "tidssk", "title": "Tidsskrifter" },
+        "materials": [
+          {
+            "itemNumber": "5313125957",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128001",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775120", "title": "Højbjerg" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313128141",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223714A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138560",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313021981",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019901",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313024069",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981612",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979480",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688092",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987661",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986894",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964361",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963649",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992258",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312967938",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043807554",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 45#Jul",
+              "volumeNumber": "45#Jul"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5043818386",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752106",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703792",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740914",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052305",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313043985",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053530",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313054014",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957371",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313055606",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006321",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027637",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008101",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959048",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029338",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012461",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031596",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013075",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035532",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015310",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978387",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960364",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016759",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313130365",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131930",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132473",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048480",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113711",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050299",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050949",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050442",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046658",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040021",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313045988",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046623",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124586",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128832",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113835",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775160", "title": "Risskov" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313037667",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036873",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037438",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128018",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128719",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046682",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037373",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128727",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979405",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046550",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313126031",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139583",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775160", "title": "Risskov" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": { "locationId": "læs", "title": "Læsesal" },
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313046046",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050507",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313051007",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050221",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113800",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037691",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037421",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036865",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036040",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132546",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131991",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313142983",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016686",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312960461",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 47",
+              "volumeNumber": "47"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978298",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977445",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035461",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313015396",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 50",
+              "volumeNumber": "50"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033564",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013008",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012397",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031685",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959137",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029354",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027653",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313005684",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957436",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053468",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053956",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052240",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993505",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312995192",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258757175",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740833",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971129",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992721",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991197",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312967997",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312966680",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 30",
+              "volumeNumber": "30"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968322",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019839",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979561",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313021930",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313023992",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982457",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022163",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981671",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986967",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987742",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988331",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688157",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964459",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963721",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983143",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258585560",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2020",
+              "displayText": "2020, nr. 08#Strik",
+              "volumeNumber": "08#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258666714",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2019",
+              "displayText": "2019, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128778",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313127305",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "A1011223723A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313138552",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775144", "title": "Gellerup" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "A1011223719A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          },
+          {
+            "itemNumber": "5313124561",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139508",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313128735",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979367",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43#Beauty",
+              "volumeNumber": "43#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313019871",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 44",
+              "volumeNumber": "44"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313021973",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42#Strik",
+              "volumeNumber": "42#Strik"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313024034",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312981639",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 41",
+              "volumeNumber": "41"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313022201",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 42",
+              "volumeNumber": "42"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312979529",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 43",
+              "volumeNumber": "43"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312988374",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 33",
+              "volumeNumber": "33"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258688114",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312987701",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312963681",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312983267",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 38",
+              "volumeNumber": "38"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312982538",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 39",
+              "volumeNumber": "39"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312986924",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312964416",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312974373",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312975590",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258697024",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994749",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258737719",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312995230",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994285",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312993548",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312971226",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992762",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991235",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312992231",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258689188",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312968251",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312967954",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258752122",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750618",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258751975",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749814",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258747706",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258749970",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750294",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258750456",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258704756",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258703024",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5258740876",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313052283",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313044035",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053506",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312957398",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313053999",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313055649",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313006346",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313027580",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313008128",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313029281",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313012435",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312959099",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313013040",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313031642",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313014446",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 52",
+              "volumeNumber": "52"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313033688",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 51",
+              "volumeNumber": "51"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035575",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 49",
+              "volumeNumber": "49"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312977550",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 46",
+              "volumeNumber": "46"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312978255",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 45",
+              "volumeNumber": "45"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313016724",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 48",
+              "volumeNumber": "48"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313131401",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313132503",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313035966",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313036822",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037381",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313037764",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313048448",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050264",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313113762",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050469",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313050965",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313040031",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046003",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046593",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313139494",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 36",
+              "volumeNumber": "36"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313124624",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312994811",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5312991162",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2021",
+              "displayText": "2021, nr. 27",
+              "volumeNumber": "27"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          }
+        ]
+      },
+      {
+        "branch": { "branchId": "DK-775126", "title": "Solbjerg" },
+        "department": { "departmentId": "vo", "title": "Voksen" },
+        "location": null,
+        "sublocation": null,
+        "materials": [
+          {
+            "itemNumber": "5313046526",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21#Beauty",
+              "volumeNumber": "21#Beauty"
+            },
+            "materialGroup": {
+              "name": "uindb",
+              "description": "Enkeltnumre, tidsskrifter"
+            }
+          },
+          {
+            "itemNumber": "5313046089",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 22",
+              "volumeNumber": "22"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313048367",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313040110",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 20",
+              "volumeNumber": "20"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313046755",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 21",
+              "volumeNumber": "21"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313050515",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 16",
+              "volumeNumber": "16"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313051031",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 15",
+              "volumeNumber": "15"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313050191",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 17",
+              "volumeNumber": "17"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313113843",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 18",
+              "volumeNumber": "18"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313037675",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 23",
+              "volumeNumber": "23"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313037462",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 24",
+              "volumeNumber": "24"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313036891",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313036067",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313132023",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 28",
+              "volumeNumber": "28"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313131477",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 29",
+              "volumeNumber": "29"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313012966",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 02",
+              "volumeNumber": "02"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313031693",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 01",
+              "volumeNumber": "01"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313029214",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 04",
+              "volumeNumber": "04"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5312959145",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 05",
+              "volumeNumber": "05"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313012362",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 03",
+              "volumeNumber": "03"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313027671",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 07",
+              "volumeNumber": "07"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313008209",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 06",
+              "volumeNumber": "06"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313006427",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 08",
+              "volumeNumber": "08"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313005714",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 09",
+              "volumeNumber": "09"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313053425",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 12",
+              "volumeNumber": "12"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5312957479",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 10",
+              "volumeNumber": "10"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313053921",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 11",
+              "volumeNumber": "11"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313044108",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313052216",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 14",
+              "volumeNumber": "14"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5140766501",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2018",
+              "displayText": "2018, nr. 19",
+              "volumeNumber": "19"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "3847750821",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 25",
+              "volumeNumber": "25"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5043796651",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2015",
+              "displayText": "2015, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "3847950594",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 13",
+              "volumeNumber": "13"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "3847830386",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2011",
+              "displayText": "2011, nr. 26",
+              "volumeNumber": "26"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313130454",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 31",
+              "volumeNumber": "31"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313128808",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 32",
+              "volumeNumber": "32"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313127348",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 34",
+              "volumeNumber": "34"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313126041",
+            "available": true,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 35",
+              "volumeNumber": "35"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "5313124632",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 37",
+              "volumeNumber": "37"
+            },
+            "materialGroup": {
+              "name": "14uin",
+              "description": "Tidsskifter med 14 dages lån i Beder, Egå, Solbjerg, Tilst og Tranbjerg"
+            }
+          },
+          {
+            "itemNumber": "A1011223726A",
+            "available": false,
+            "periodical": {
+              "volume": null,
+              "volumeYear": "2022",
+              "displayText": "2022, nr. 40",
+              "volumeNumber": "40"
+            },
+            "materialGroup": {
+              "name": "nytnr",
+              "description": "Tidsskrifter - nyeste nummer"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -515,6 +515,14 @@ export default {
   }
 } as ComponentMeta<typeof MaterialEntry>;
 
-export const Material: ComponentStory<typeof MaterialEntry> = (
+const Template: ComponentStory<typeof MaterialEntry> = (
   args: MaterialEntryProps
 ) => <MaterialEntry {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Periodical = Template.bind({});
+Periodical.args = {
+  wid: "work-of:870970-basis:06373674"
+};

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -2,14 +2,23 @@ const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
 
 describe("Material", () => {
   it("Does the Material have title?", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.get(".text-header-h1").should("be.visible");
   });
 
   it("Check that cover has a src", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.get("img").should("have.attr", "src").and("match", coverUrlPattern);
   });
 
   it("Does the material have favourite buttons?", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.get(".button-favourite").should(
       "have.attr",
       "aria-label",
@@ -18,28 +27,46 @@ describe("Material", () => {
   });
 
   it("Does the material have horizontal lines?", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.contains("Nr 1 i serien");
     cy.contains("De syv søstre-serien");
   });
 
   it("Does the material have authors?", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.contains("Lucinda Riley");
   });
 
   it("Does a material have a availibility label", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.contains("bog");
     cy.contains("unavailable");
   });
 
   it("Open material details", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.get("details").last().click();
   });
 
   it("Does the material have a editions with a buttton to reserved", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.contains("reserver");
   });
 
   it("Open modal by clicking on reserver button (reserver bog) and close it with the x bottom", () => {
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
+    );
     cy.contains("button:visible", "reserver bog").click();
     cy.contains("Afhentes på");
     cy.contains("Hovedbiblioteket");
@@ -52,7 +79,34 @@ describe("Material", () => {
   });
 
   it("Clicking on Aprove resevation (Godkend reservation and close modal with Ok button)", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("button:visible", "reserver bog").click();
+    cy.contains("button:visible", "Godkend reservation").click();
+    cy.contains("Materialet er hjemme og er nu reserveret til dig!");
+    cy.contains("Du er nummer 3 i køen");
+    cy.contains("button:visible", "Ok").click();
+  });
+
+  //  periodical test.
+  it("Render periodical, change year and Aprove resevation", () => {
+    cy.fixture("material/periodical-fbi-api.json")
+      .then((result) => {
+        cy.intercept("POST", "**/opac/graphql", result);
+      })
+      .as("periodical Graphql query");
+
+    cy.fixture("material/periodical-holdings.json")
+      .then((result) => {
+        cy.intercept("GET", "**/agencyid/catalog/holdings/**", result);
+      })
+      .as("periodical holdings");
+
+    cy.visit(
+      "/iframe.html?id=apps-material--periodical&viewMode=story&type=periodikum"
+    );
+
+    cy.get("#year").select("2021");
+    cy.contains("button:visible", "reserver periodikum").click();
     cy.contains("button:visible", "Godkend reservation").click();
     cy.contains("Materialet er hjemme og er nu reserveret til dig!");
     cy.contains("Du er nummer 3 i køen");
@@ -117,8 +171,6 @@ describe("Material", () => {
     cy.intercept("HEAD", "**/list/default/**", {
       statusCode: 404
     }).as("Favorite list service");
-
-    cy.visit("/iframe.html?args=&id=apps-material--material");
   });
 });
 

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -70,7 +70,7 @@ describe("Material", () => {
   });
 
   //  periodical test.
-  it("Render periodical, change year and Aprove resevation", () => {
+  it("Render periodical + change to 2021, nr. 13 + Aprove resevation", () => {
     cy.fixture("material/periodical-fbi-api.json")
       .then((result) => {
         cy.intercept("POST", "**/opac/graphql", result);
@@ -88,7 +88,9 @@ describe("Material", () => {
     );
 
     cy.get("#year").select("2021");
+    cy.get("#editions").should("have.value", "5258703091");
     cy.contains("button:visible", "reserver periodikum").click();
+    cy.contains("h2", "2021, nr. 13");
     cy.contains("button:visible", "Godkend reservation").click();
     cy.contains("Materialet er hjemme og er nu reserveret til dig!");
     cy.contains("Du er nummer 3 i køen");

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -2,23 +2,17 @@ const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
 
 describe("Material", () => {
   it("Does the Material have title?", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.get(".text-header-h1").should("be.visible");
   });
 
   it("Check that cover has a src", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.get("img").should("have.attr", "src").and("match", coverUrlPattern);
   });
 
   it("Does the material have favourite buttons?", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.get(".button-favourite").should(
       "have.attr",
       "aria-label",
@@ -27,46 +21,34 @@ describe("Material", () => {
   });
 
   it("Does the material have horizontal lines?", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("Nr 1 i serien");
     cy.contains("De syv søstre-serien");
   });
 
   it("Does the material have authors?", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("Lucinda Riley");
   });
 
   it("Does a material have a availibility label", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("bog");
     cy.contains("unavailable");
   });
 
   it("Open material details", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.get("details").last().click();
   });
 
   it("Does the material have a editions with a buttton to reserved", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("reserver");
   });
 
   it("Open modal by clicking on reserver button (reserver bog) and close it with the x bottom", () => {
-    cy.visit(
-      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=bog"
-    );
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("button:visible", "reserver bog").click();
     cy.contains("Afhentes på");
     cy.contains("Hovedbiblioteket");

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -33,6 +33,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import ReservationModal from "../../components/reservation/ReservationModal";
+import { GroupListItem } from "../../components/material/MaterialPeriodicalSelect";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -44,9 +45,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const [currentManifestation, setCurrentManifestation] =
     useState<Manifestation | null>(null);
 
-  // periodicalSelect must be used later to change the UI and reservation when you have chosen a specific periodical
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [periodicalSelect, setPeriodicalSelect] = useState<string | null>(null);
+  const [periodicalSelect, setPeriodicalSelect] =
+    useState<GroupListItem | null>(null);
 
   const { data, isLoading } = useGetMaterialQuery({
     wid
@@ -176,6 +176,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           <ReservationModal
             mainManifestation={currentManifestation}
             parallelManifestations={parallelManifestations}
+            periodicalSelect={periodicalSelect}
           />
         </>
       )}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -45,7 +45,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const [currentManifestation, setCurrentManifestation] =
     useState<Manifestation | null>(null);
 
-  const [periodicalSelect, setPeriodicalSelect] =
+  const [selectedPeriodical, setSelectedPeriodical] =
     useState<GroupListItem | null>(null);
 
   const { data, isLoading } = useGetMaterialQuery({
@@ -114,8 +114,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         work={work}
         manifestation={currentManifestation}
         selectManifestationHandler={setCurrentManifestation}
-        periodicalSelect={periodicalSelect}
-        selectPeriodicalSelect={setPeriodicalSelect}
+        selectedPeriodical={selectedPeriodical}
+        selectPeriodicalHandler={setSelectedPeriodical}
       />
       <MaterialDescription pid={pid} work={work} />
       <Disclosure
@@ -177,7 +177,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           <ReservationModal
             mainManifestation={currentManifestation}
             parallelManifestations={parallelManifestations}
-            periodicalSelect={periodicalSelect}
+            selectedPeriodical={selectedPeriodical}
           />
         </>
       )}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -114,6 +114,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         work={work}
         manifestation={currentManifestation}
         selectManifestationHandler={setCurrentManifestation}
+        periodicalSelect={periodicalSelect}
         selectPeriodicalSelect={setPeriodicalSelect}
       />
       <MaterialDescription pid={pid} work={work} />

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -33,7 +33,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import ReservationModal from "../../components/reservation/ReservationModal";
-import { GroupListItem } from "../../components/material/MaterialPeriodicalSelect";
+import { GroupListItem } from "../../components/material/periodical/helper";
 
 export interface MaterialProps {
   wid: WorkId;

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -21,13 +21,14 @@ import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialButtons from "./material-buttons/MaterialButtons";
 import MaterialPeriodical from "./MaterialPeriodical";
 import { Manifestation, Work } from "../../core/utils/types/entities";
+import { GroupListItem } from "./MaterialPeriodicalSelect";
 
 interface MaterialHeaderProps {
   wid: WorkId;
   work: Work;
   manifestation: Manifestation;
   selectManifestationHandler: (manifestation: Manifestation) => void;
-  selectPeriodicalSelect: (periodicalSelect: string | null) => void;
+  selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -72,6 +73,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const title = containsDanish ? fullTitle : `${fullTitle} (${allLanguages})`;
   const coverPid = pid || getManifestationPid(manifestations);
 
+  const isPeriocial = manifestation?.materialTypes
+    ?.map((i) => i.specific.toLowerCase())
+    .includes("periodikum");
+
   return (
     <header className="material-header">
       <div className="material-header__cover">
@@ -90,7 +95,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           />
         </div>
 
-        {manifestation?.source?.includes("bibliotekskatalog") && (
+        {isPeriocial && (
           <MaterialPeriodical
             faustId={convertPostIdToFaustId(pid)}
             selectPeriodicalSelect={selectPeriodicalSelect}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -28,6 +28,7 @@ interface MaterialHeaderProps {
   work: Work;
   manifestation: Manifestation;
   selectManifestationHandler: (manifestation: Manifestation) => void;
+  periodicalSelect: GroupListItem | null;
   selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
 }
 
@@ -42,6 +43,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   manifestation: { pid },
   manifestation,
   selectManifestationHandler,
+  periodicalSelect,
   selectPeriodicalSelect
 }) => {
   const t = useText();
@@ -98,6 +100,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         {isPeriocial && (
           <MaterialPeriodical
             faustId={convertPostIdToFaustId(pid)}
+            periodicalSelect={periodicalSelect}
             selectPeriodicalSelect={selectPeriodicalSelect}
           />
         )}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -28,8 +28,8 @@ interface MaterialHeaderProps {
   work: Work;
   manifestation: Manifestation;
   selectManifestationHandler: (manifestation: Manifestation) => void;
-  periodicalSelect: GroupListItem | null;
-  selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
+  selectedPeriodical: GroupListItem | null;
+  selectPeriodicalHandler: (selectedPeriodical: GroupListItem) => void;
 }
 
 const MaterialHeader: React.FC<MaterialHeaderProps> = ({
@@ -43,8 +43,8 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   manifestation: { pid },
   manifestation,
   selectManifestationHandler,
-  periodicalSelect,
-  selectPeriodicalSelect
+  selectedPeriodical,
+  selectPeriodicalHandler
 }) => {
   const t = useText();
   const dispatch = useDispatch<TypedDispatch>();
@@ -75,7 +75,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const title = containsDanish ? fullTitle : `${fullTitle} (${allLanguages})`;
   const coverPid = pid || getManifestationPid(manifestations);
 
-  const isPeriocial = manifestation?.materialTypes
+  const isPeriodical = manifestation?.materialTypes
     ?.map((i) => i.specific.toLowerCase())
     .includes("periodikum");
 
@@ -97,11 +97,11 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           />
         </div>
 
-        {isPeriocial && (
+        {isPeriodical && (
           <MaterialPeriodical
             faustId={convertPostIdToFaustId(pid)}
-            periodicalSelect={periodicalSelect}
-            selectPeriodicalSelect={selectPeriodicalSelect}
+            selectedPeriodical={selectedPeriodical}
+            selectPeriodicalHandler={selectPeriodicalHandler}
           />
         )}
 

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -19,9 +19,9 @@ import { Cover } from "../cover/cover";
 import MaterialAvailabilityText from "./MaterialAvailabilityText/MaterialAvailabilityText";
 import MaterialHeaderText from "./MaterialHeaderText";
 import MaterialButtons from "./material-buttons/MaterialButtons";
-import MaterialPeriodical from "./MaterialPeriodical";
+import MaterialPeriodical from "./periodical/MaterialPeriodical";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { GroupListItem } from "./MaterialPeriodicalSelect";
+import { GroupListItem } from "./periodical/helper";
 
 interface MaterialHeaderProps {
   wid: WorkId;

--- a/src/components/material/MaterialPeriodical.tsx
+++ b/src/components/material/MaterialPeriodical.tsx
@@ -3,20 +3,19 @@ import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
 import { FaustId } from "../../core/utils/types/ids";
 import MaterialPeriodicalSelect, {
-  GroupList,
   GroupListItem
 } from "./MaterialPeriodicalSelect";
 
 export interface MaterialPeriodicalProps {
   faustId: FaustId;
-  periodicalSelect: GroupListItem | null;
-  selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
+  selectedPeriodical: GroupListItem | null;
+  selectPeriodicalHandler: (selectedPeriodical: GroupListItem) => void;
 }
 
 const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   faustId,
-  periodicalSelect,
-  selectPeriodicalSelect
+  selectedPeriodical,
+  selectPeriodicalHandler
 }) => {
   const { data, isLoading, isError } = useGetHoldingsV3({
     recordid: [String(faustId)]
@@ -44,8 +43,8 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   return (
     <MaterialPeriodicalSelect
       groupList={groupByVolumeYear as GroupList}
-      periodicalSelect={periodicalSelect}
-      selectPeriodicalSelect={selectPeriodicalSelect}
+      selectedPeriodical={selectedPeriodical}
+      selectPeriodicalHandler={selectPeriodicalHandler}
     />
   );
 };

--- a/src/components/material/MaterialPeriodical.tsx
+++ b/src/components/material/MaterialPeriodical.tsx
@@ -1,13 +1,15 @@
-import * as React from "react";
-import { FC } from "react";
+import React, { FC } from "react";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
 import { FaustId } from "../../core/utils/types/ids";
-import MaterialPeriodicalSelect from "./MaterialPeriodicalSelect";
+import MaterialPeriodicalSelect, {
+  GroupList,
+  GroupListItem
+} from "./MaterialPeriodicalSelect";
 
 export interface MaterialPeriodicalProps {
   faustId: FaustId;
-  selectPeriodicalSelect: (periodicalSelect: string | null) => void;
+  selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
 }
 
 const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
@@ -32,12 +34,16 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
     })
     .flat();
 
+  const groupByVolumeYear = groupObjectArrayByProperty(
+    materialsPeriodical,
+    "volumeYear"
+  );
+
   return (
     <MaterialPeriodicalSelect
-      groupList={groupObjectArrayByProperty(materialsPeriodical, "volumeYear")}
+      groupList={groupByVolumeYear as GroupList}
       selectPeriodicalSelect={selectPeriodicalSelect}
     />
   );
 };
-
 export default MaterialPeriodical;

--- a/src/components/material/MaterialPeriodical.tsx
+++ b/src/components/material/MaterialPeriodical.tsx
@@ -9,11 +9,13 @@ import MaterialPeriodicalSelect, {
 
 export interface MaterialPeriodicalProps {
   faustId: FaustId;
+  periodicalSelect: GroupListItem | null;
   selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
 }
 
 const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   faustId,
+  periodicalSelect,
   selectPeriodicalSelect
 }) => {
   const { data, isLoading, isError } = useGetHoldingsV3({
@@ -42,6 +44,7 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   return (
     <MaterialPeriodicalSelect
       groupList={groupByVolumeYear as GroupList}
+      periodicalSelect={periodicalSelect}
       selectPeriodicalSelect={selectPeriodicalSelect}
     />
   );

--- a/src/components/material/MaterialPeriodical.tsx
+++ b/src/components/material/MaterialPeriodical.tsx
@@ -3,6 +3,7 @@ import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
 import { FaustId } from "../../core/utils/types/ids";
 import MaterialPeriodicalSelect, {
+  GroupList,
   GroupListItem
 } from "./MaterialPeriodicalSelect";
 

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useText } from "../../core/utils/text";
 
 export type GroupListItem = {
@@ -10,29 +10,49 @@ export type GroupListItem = {
 };
 
 export type GroupList = { [key: string]: GroupListItem[] };
+
 interface MaterialPeriodicalSelectProps {
   groupList: GroupList;
-  selectPeriodicalSelect: (periodicalSelect: string | null) => void;
+  selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
 }
 
 const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   groupList,
   selectPeriodicalSelect
 }) => {
-  const last = String(Object.keys(groupList).sort().pop());
+  const lastYear = Object.keys(groupList).sort().pop() || "";
   const t = useText();
-  const [year, setYear] = useState<string>(last);
+  const [year, setYear] = useState<string>(lastYear);
+
+  // Sets periodicalSelect to the last edition on munt and if year changes
+  useEffect(() => {
+    const firstEditions = groupList?.[year]?.[0];
+    if (firstEditions) {
+      selectPeriodicalSelect(firstEditions);
+    }
+  }, [selectPeriodicalSelect, groupList, year]);
+
+  const handleSelectYear = (event: React.ChangeEvent<HTMLSelectElement>) =>
+    setYear(event.target.value);
+
+  const handleSelectEditions = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    const selectedItem = groupList[year].find(
+      (item) => item.itemNumber === event.target.value
+    );
+
+    if (selectedItem) {
+      selectPeriodicalSelect(selectedItem);
+    }
+  };
 
   return (
     <div className="text-small-caption material-periodical ">
       <div className="material-periodical-select">
         <label htmlFor="year">{t("periodicalSelectYearText")}</label>
         <div className="material-periodical-select__border-container">
-          <select
-            id="year"
-            defaultValue={year}
-            onChange={(e) => setYear(e.target.value)}
-          >
+          <select id="year" defaultValue={year} onChange={handleSelectYear}>
             {Object.keys(groupList)
               .sort()
               .map((item) => (
@@ -48,11 +68,8 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
         <div className="material-periodical-select">
           <label htmlFor="editions">{t("periodicalSelectEditionText")}</label>
           <div className="material-periodical-select__border-container">
-            <select
-              id="editions"
-              onChange={(e) => selectPeriodicalSelect(e.target.value)}
-            >
-              {groupList[year]?.map((item) => {
+            <select id="editions" onChange={handleSelectEditions}>
+              {groupList[year].map((item) => {
                 return (
                   <option key={item.itemNumber} value={item.itemNumber}>
                     {item.volumeNumber}

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -13,27 +13,27 @@ export type GroupList = { [key: string]: GroupListItem[] };
 
 interface MaterialPeriodicalSelectProps {
   groupList: GroupList;
-  periodicalSelect: GroupListItem | null;
-  selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
+  selectedPeriodical: GroupListItem | null;
+  selectPeriodicalHandler: (selectedPeriodical: GroupListItem) => void;
 }
 
 const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   groupList,
-  periodicalSelect,
-  selectPeriodicalSelect
+  selectedPeriodical,
+  selectPeriodicalHandler
 }) => {
   const lastYear = Object.keys(groupList).sort().pop() || "";
   const t = useText();
   const [year, setYear] = useState<string>(lastYear);
 
-  // Sets periodicalSelect to the last edition on mount and if year changes
+  // Sets selectedPeriodical to the last edition on mount and if year changes
   useEffect(() => {
-    if (periodicalSelect) return;
+    if (selectedPeriodical) return;
     const firstEditions = groupList?.[year]?.[0];
     if (firstEditions) {
-      selectPeriodicalSelect(firstEditions);
+      selectPeriodicalHandler(firstEditions);
     }
-  }, [selectPeriodicalSelect, groupList, year, periodicalSelect]);
+  }, [selectPeriodicalHandler, groupList, year, selectedPeriodical]);
 
   const handleSelectYear = (event: React.ChangeEvent<HTMLSelectElement>) =>
     setYear(event.target.value);
@@ -46,7 +46,7 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
     );
 
     if (selectedItem) {
-      selectPeriodicalSelect(selectedItem);
+      selectPeriodicalHandler(selectedItem);
     }
   };
 

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -13,24 +13,27 @@ export type GroupList = { [key: string]: GroupListItem[] };
 
 interface MaterialPeriodicalSelectProps {
   groupList: GroupList;
+  periodicalSelect: GroupListItem | null;
   selectPeriodicalSelect: (periodicalSelect: GroupListItem) => void;
 }
 
 const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   groupList,
+  periodicalSelect,
   selectPeriodicalSelect
 }) => {
   const lastYear = Object.keys(groupList).sort().pop() || "";
   const t = useText();
   const [year, setYear] = useState<string>(lastYear);
 
-  // Sets periodicalSelect to the last edition on munt and if year changes
+  // Sets periodicalSelect to the last edition on mount and if year changes
   useEffect(() => {
+    if (periodicalSelect) return;
     const firstEditions = groupList?.[year]?.[0];
     if (firstEditions) {
       selectPeriodicalSelect(firstEditions);
     }
-  }, [selectPeriodicalSelect, groupList, year]);
+  }, [selectPeriodicalSelect, groupList, year, periodicalSelect]);
 
   const handleSelectYear = (event: React.ChangeEvent<HTMLSelectElement>) =>
     setYear(event.target.value);

--- a/src/components/material/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/MaterialPeriodicalSelect.tsx
@@ -22,21 +22,24 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   selectedPeriodical,
   selectPeriodicalHandler
 }) => {
-  const lastYear = Object.keys(groupList).sort().pop() || "";
   const t = useText();
+  const lastYear = Object.keys(groupList).sort().pop() || "";
   const [year, setYear] = useState<string>(lastYear);
+  const firstEdition = groupList?.[year]?.[0];
 
-  // Sets selectedPeriodical to the last edition on mount and if year changes
+  // Sets selectedPeriodical to the last edition
   useEffect(() => {
     if (selectedPeriodical) return;
-    const firstEditions = groupList?.[year]?.[0];
-    if (firstEditions) {
-      selectPeriodicalHandler(firstEditions);
+    if (firstEdition) {
+      selectPeriodicalHandler(firstEdition);
     }
-  }, [selectPeriodicalHandler, groupList, year, selectedPeriodical]);
+  }, [firstEdition, selectPeriodicalHandler, selectedPeriodical]);
 
-  const handleSelectYear = (event: React.ChangeEvent<HTMLSelectElement>) =>
+  const handleSelectYear = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setYear(event.target.value);
+    //  updates the selectedPeriodical to the first edition of the selected year
+    selectPeriodicalHandler(groupList[event.target.value][0]);
+  };
 
   const handleSelectEditions = (
     event: React.ChangeEvent<HTMLSelectElement>

--- a/src/components/material/periodical/MaterialPeriodical.tsx
+++ b/src/components/material/periodical/MaterialPeriodical.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from "react";
-import { useGetHoldingsV3 } from "../../core/fbs/fbs";
-import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
-import { FaustId } from "../../core/utils/types/ids";
+import { useGetHoldingsV3 } from "../../../core/fbs/fbs";
+import { groupObjectArrayByProperty } from "../../../core/utils/helpers/general";
+import { FaustId } from "../../../core/utils/types/ids";
+import { GroupListItem } from "./helper";
 import MaterialPeriodicalSelect, {
-  GroupList,
-  GroupListItem
+  GroupList
 } from "./MaterialPeriodicalSelect";
 
 export interface MaterialPeriodicalProps {

--- a/src/components/material/periodical/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/periodical/MaterialPeriodicalSelect.tsx
@@ -1,13 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { useText } from "../../core/utils/text";
-
-export type GroupListItem = {
-  displayText: string;
-  itemNumber: string;
-  volume: string;
-  volumeNumber: string;
-  volumeYear: string;
-};
+import { useText } from "../../../core/utils/text";
+import { getFirstEditionFromYear, GroupListItem } from "./helper";
 
 export type GroupList = { [key: string]: GroupListItem[] };
 
@@ -25,20 +18,26 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   const t = useText();
   const lastYear = Object.keys(groupList).sort().pop() || "";
   const [year, setYear] = useState<string>(lastYear);
-  const firstEdition = groupList?.[year]?.[0];
 
   // Sets selectedPeriodical to the last edition
   useEffect(() => {
     if (selectedPeriodical) return;
+    const firstEdition = getFirstEditionFromYear(year, groupList);
     if (firstEdition) {
       selectPeriodicalHandler(firstEdition);
     }
-  }, [firstEdition, selectPeriodicalHandler, selectedPeriodical]);
+  }, [groupList, selectPeriodicalHandler, selectedPeriodical, year]);
 
   const handleSelectYear = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setYear(event.target.value);
-    //  updates the selectedPeriodical to the first edition of the selected year
-    selectPeriodicalHandler(groupList[event.target.value][0]);
+    //  Updates the selectedPeriodical to the first edition of the selected year.
+    const changedEdition = getFirstEditionFromYear(
+      event.target.value,
+      groupList
+    );
+    if (changedEdition) {
+      selectPeriodicalHandler(changedEdition);
+    }
   };
 
   const handleSelectEditions = (

--- a/src/components/material/periodical/helper.ts
+++ b/src/components/material/periodical/helper.ts
@@ -1,0 +1,16 @@
+export type GroupListItem = {
+  displayText: string;
+  itemNumber: string;
+  volume: string;
+  volumeNumber: string;
+  volumeYear: string;
+};
+
+export const getFirstEditionFromYear = <T extends string>(
+  year: T,
+  groupList: { [key in T]: GroupListItem[] }
+) => {
+  return groupList[year][0];
+};
+
+export default {};

--- a/src/components/reservation/ReservationFormListItem.tsx
+++ b/src/components/reservation/ReservationFormListItem.tsx
@@ -21,7 +21,7 @@ const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
       <div className="reservation-modal-list-item-text">
         <h3 className="text-header-h5">{title}</h3>
         <p className="text-small-caption">
-          {text.length > 0 ? text : t("missingDataText")}
+          {text?.length > 0 ? text : t("missingDataText")}
         </p>
       </div>
       <button

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -20,7 +20,7 @@ const ReservationModal = ({
   mainManifestation,
   mainManifestation: { pid },
   parallelManifestations,
-  periodicalSelect
+  periodicalSelect = null
 }: ReservationModalProps) => {
   const t = useText();
   return (

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -13,14 +13,14 @@ export const reservationModalId = (faustId: FaustId) =>
 type ReservationModalProps = {
   mainManifestation: Manifestation;
   parallelManifestations?: Manifestation[];
-  periodicalSelect?: GroupListItem | null;
+  selectedPeriodical?: GroupListItem | null;
 };
 
 const ReservationModal = ({
   mainManifestation,
   mainManifestation: { pid },
   parallelManifestations,
-  periodicalSelect = null
+  selectedPeriodical = null
 }: ReservationModalProps) => {
   const t = useText();
   return (
@@ -34,7 +34,7 @@ const ReservationModal = ({
       <ReservationModalBody
         mainManifestation={mainManifestation}
         parallelManifestations={parallelManifestations}
-        periodicalSelect={periodicalSelect}
+        selectedPeriodical={selectedPeriodical}
       />
     </Modal>
   );

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -4,6 +4,7 @@ import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation } from "../../core/utils/types/entities";
 import { FaustId } from "../../core/utils/types/ids";
+import { GroupListItem } from "../material/MaterialPeriodicalSelect";
 import ReservationModalBody from "./ReservationModalBody";
 
 export const reservationModalId = (faustId: FaustId) =>
@@ -12,12 +13,14 @@ export const reservationModalId = (faustId: FaustId) =>
 type ReservationModalProps = {
   mainManifestation: Manifestation;
   parallelManifestations?: Manifestation[];
+  periodicalSelect?: GroupListItem | null;
 };
 
 const ReservationModal = ({
   mainManifestation,
   mainManifestation: { pid },
-  parallelManifestations
+  parallelManifestations,
+  periodicalSelect
 }: ReservationModalProps) => {
   const t = useText();
   return (
@@ -31,6 +34,7 @@ const ReservationModal = ({
       <ReservationModalBody
         mainManifestation={mainManifestation}
         parallelManifestations={parallelManifestations}
+        periodicalSelect={periodicalSelect}
       />
     </Modal>
   );

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -4,7 +4,7 @@ import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation } from "../../core/utils/types/entities";
 import { FaustId } from "../../core/utils/types/ids";
-import { GroupListItem } from "../material/MaterialPeriodicalSelect";
+import { GroupListItem } from "../material/periodical/helper";
 import ReservationModalBody from "./ReservationModalBody";
 
 export const reservationModalId = (faustId: FaustId) =>

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -44,21 +44,18 @@ export const reservationModalId = (faustId: FaustId) =>
 type ReservationModalProps = {
   mainManifestation: Manifestation;
   parallelManifestations?: Manifestation[];
-  periodicalSelect?: GroupListItem | null;
+  selectedPeriodical: GroupListItem | null;
 };
 
 const ReservationModalBody = ({
   mainManifestation,
   mainManifestation: { pid, materialTypes, titles, edition },
   parallelManifestations,
-  periodicalSelect
+  selectedPeriodical
 }: ReservationModalProps) => {
   const mainManifestationType = getManifestationType(mainManifestation);
   const { reservableManifestations } = UseReservableManifestations({
-    manifestations:
-      parallelManifestations && parallelManifestations.length > 0
-        ? parallelManifestations
-        : [mainManifestation],
+    manifestations: parallelManifestations || [mainManifestation],
     type: mainManifestationType
   });
   const queryClient = useQueryClient();
@@ -106,7 +103,7 @@ const ReservationModalBody = ({
           manifestations: reservableManifestations,
           selectedBranch,
           expiryDate,
-          periodical: periodicalSelect
+          periodical: selectedPeriodical
         })
       },
       {
@@ -143,7 +140,7 @@ const ReservationModalBody = ({
               </div>
               <h2 className="text-header-h2 mt-22 mb-8">
                 {titles.main[0]}{" "}
-                {periodicalSelect && periodicalSelect.displayText}
+                {selectedPeriodical && selectedPeriodical.displayText}
               </h2>
               <p className="text-body-medium-regular">{authorLine}</p>
             </div>

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -55,7 +55,10 @@ const ReservationModalBody = ({
 }: ReservationModalProps) => {
   const mainManifestationType = getManifestationType(mainManifestation);
   const { reservableManifestations } = UseReservableManifestations({
-    manifestations: parallelManifestations || [mainManifestation],
+    manifestations:
+      parallelManifestations && parallelManifestations?.length > 0
+        ? parallelManifestations
+        : [mainManifestation],
     type: mainManifestationType
   });
   const queryClient = useQueryClient();

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -36,6 +36,7 @@ import {
   getAuthorLine
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
+import { GroupListItem } from "../material/MaterialPeriodicalSelect";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;
@@ -43,16 +44,21 @@ export const reservationModalId = (faustId: FaustId) =>
 type ReservationModalProps = {
   mainManifestation: Manifestation;
   parallelManifestations?: Manifestation[];
+  periodicalSelect?: GroupListItem | null;
 };
 
 const ReservationModalBody = ({
   mainManifestation,
   mainManifestation: { pid, materialTypes, titles, edition },
-  parallelManifestations
+  parallelManifestations,
+  periodicalSelect
 }: ReservationModalProps) => {
   const mainManifestationType = getManifestationType(mainManifestation);
   const { reservableManifestations } = UseReservableManifestations({
-    manifestations: parallelManifestations ?? [mainManifestation],
+    manifestations:
+      parallelManifestations && parallelManifestations.length > 0
+        ? parallelManifestations
+        : [mainManifestation],
     type: mainManifestationType
   });
   const queryClient = useQueryClient();
@@ -99,7 +105,8 @@ const ReservationModalBody = ({
         data: constructReservationData({
           manifestations: reservableManifestations,
           selectedBranch,
-          expiryDate
+          expiryDate,
+          periodical: periodicalSelect
         })
       },
       {
@@ -134,7 +141,10 @@ const ReservationModalBody = ({
               <div className="reservation-modal-tag">
                 {materialTypes[0].specific}
               </div>
-              <h2 className="text-header-h2 mt-22 mb-8">{titles.main[0]}</h2>
+              <h2 className="text-header-h2 mt-22 mb-8">
+                {titles.main[0]}{" "}
+                {periodicalSelect && periodicalSelect.displayText}
+              </h2>
               <p className="text-body-medium-regular">{authorLine}</p>
             </div>
           </header>

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -61,6 +61,8 @@ const ReservationModalBody = ({
   const mainManifestationType = getManifestationType(mainManifestation);
   const { reservableManifestations } = UseReservableManifestations({
     manifestations:
+      // TODO: We should investigate why we need to check for parallelManifestation length
+      // because it doesn't seem to reflect the possible types.
       parallelManifestations && parallelManifestations.length > 0
         ? parallelManifestations
         : [mainManifestation],

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -49,14 +49,19 @@ type ReservationModalProps = {
 
 const ReservationModalBody = ({
   mainManifestation,
-  mainManifestation: { pid, materialTypes, titles, edition },
+  mainManifestation: {
+    pid,
+    materialTypes,
+    titles: { main: mainTitle },
+    edition
+  },
   parallelManifestations,
   selectedPeriodical
 }: ReservationModalProps) => {
   const mainManifestationType = getManifestationType(mainManifestation);
   const { reservableManifestations } = UseReservableManifestations({
     manifestations:
-      parallelManifestations && parallelManifestations?.length > 0
+      parallelManifestations && parallelManifestations.length > 0
         ? parallelManifestations
         : [mainManifestation],
     type: mainManifestationType
@@ -142,7 +147,7 @@ const ReservationModalBody = ({
                 {materialTypes[0].specific}
               </div>
               <h2 className="text-header-h2 mt-22 mb-8">
-                {titles.main[0]}{" "}
+                {mainTitle}{" "}
                 {selectedPeriodical && selectedPeriodical.displayText}
               </h2>
               <p className="text-body-medium-regular">{authorLine}</p>
@@ -191,7 +196,7 @@ const ReservationModalBody = ({
       {reservationSuccess && reservationDetails && (
         <ReservationSucces
           modalId={reservationModalId(faustId)}
-          title={titles.main[0]}
+          title={mainTitle[0]}
           preferredPickupBranch={getPreferredBranch(
             reservationDetails.pickupBranch,
             branchData

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -36,7 +36,7 @@ import {
   getAuthorLine
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
-import { GroupListItem } from "../material/MaterialPeriodicalSelect";
+import { GroupListItem } from "../material/periodical/helper";
 
 export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -14,6 +14,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { Manifestation } from "../../core/utils/types/entities";
+import { GroupListItem } from "../material/MaterialPeriodicalSelect";
 
 export const smsNotificationsIsEnabled = (config: UseConfigFunction) =>
   config("smsNotificationsForReservationsEnabledConfig") === "1";
@@ -54,48 +55,74 @@ export const getFutureDateString = (num: number) => {
 const constructReservation = ({
   manifestation: { pid },
   pickupBranch,
-  expiryDate
+  expiryDate,
+  periodical
 }: {
   manifestation: Manifestation;
   pickupBranch?: string;
   expiryDate?: string;
+  periodical?: {
+    volumeNumber: string;
+    volumeYear: string;
+  };
 }): CreateReservation => {
   const faustId = convertPostIdToFaustId(pid);
 
   return {
     recordId: faustId,
     ...(pickupBranch ? { pickupBranch } : {}),
-    ...(expiryDate ? { expiryDate } : {})
+    ...(expiryDate ? { expiryDate } : {}),
+    ...(periodical ? { periodical } : {})
   };
 };
 
 const constructReservations = ({
   manifestations,
   pickupBranch,
-  expiryDate
+  expiryDate,
+  periodical
 }: {
   manifestations: Manifestation[];
   pickupBranch?: string;
   expiryDate?: string;
+  periodical?: {
+    volumeNumber: string;
+    volumeYear: string;
+  };
 }): CreateReservation[] =>
   manifestations.map((manifestation) =>
-    constructReservation({ manifestation, pickupBranch, expiryDate })
+    constructReservation({
+      manifestation,
+      pickupBranch,
+      expiryDate,
+      periodical
+    })
   );
 
 export const constructReservationData = ({
   manifestations,
   selectedBranch,
-  expiryDate
+  expiryDate,
+  periodical
 }: {
   manifestations: Manifestation[];
   selectedBranch: string | null;
   expiryDate: string | null;
+  periodical: GroupListItem | null | undefined;
 }): CreateReservationBatchV2 => {
+  const selectedPeriodical = periodical
+    ? {
+        volumeNumber: periodical.volumeNumber,
+        volumeYear: periodical.volumeYear
+      }
+    : null;
+
   return {
     reservations: constructReservations({
       manifestations,
       ...(selectedBranch ? { pickupBranch: selectedBranch } : {}),
-      ...(expiryDate ? { expiryDate } : {})
+      ...(expiryDate ? { expiryDate } : {}),
+      ...(selectedPeriodical ? { periodical: selectedPeriodical } : {})
     }),
     ...(manifestations.length > 1 ? { type: "parallel" } : {})
   };

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -52,6 +52,8 @@ export const getFutureDateString = (num: number) => {
   return futureDate;
 };
 
+type Periodical = Pick<GroupListItem, "volumeNumber" | "volumeYear">;
+
 const constructReservation = ({
   manifestation: { pid },
   pickupBranch,
@@ -61,10 +63,7 @@ const constructReservation = ({
   manifestation: Manifestation;
   pickupBranch?: string;
   expiryDate?: string;
-  periodical?: {
-    volumeNumber: string;
-    volumeYear: string;
-  };
+  periodical?: Periodical;
 }): CreateReservation => {
   const faustId = convertPostIdToFaustId(pid);
 
@@ -85,10 +84,7 @@ const constructReservations = ({
   manifestations: Manifestation[];
   pickupBranch?: string;
   expiryDate?: string;
-  periodical?: {
-    volumeNumber: string;
-    volumeYear: string;
-  };
+  periodical?: Periodical;
 }): CreateReservation[] =>
   manifestations.map((manifestation) =>
     constructReservation({
@@ -108,21 +104,21 @@ export const constructReservationData = ({
   manifestations: Manifestation[];
   selectedBranch: string | null;
   expiryDate: string | null;
-  periodical: GroupListItem | null | undefined;
+  periodical: GroupListItem | null;
 }): CreateReservationBatchV2 => {
-  const selectedPeriodical = periodical
-    ? {
-        volumeNumber: periodical.volumeNumber,
-        volumeYear: periodical.volumeYear
-      }
-    : null;
-
   return {
     reservations: constructReservations({
       manifestations,
       ...(selectedBranch ? { pickupBranch: selectedBranch } : {}),
       ...(expiryDate ? { expiryDate } : {}),
-      ...(selectedPeriodical ? { periodical: selectedPeriodical } : {})
+      ...(periodical
+        ? {
+            periodical: {
+              volumeNumber: periodical.volumeNumber,
+              volumeYear: periodical.volumeYear
+            }
+          }
+        : {})
     }),
     ...(manifestations.length > 1 ? { type: "parallel" } : {})
   };

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -14,7 +14,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { Manifestation } from "../../core/utils/types/entities";
-import { GroupListItem } from "../material/MaterialPeriodicalSelect";
+import { GroupListItem } from "../material/periodical/helper";
 
 export const smsNotificationsIsEnabled = (config: UseConfigFunction) =>
   config("smsNotificationsForReservationsEnabledConfig") === "1";


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-232


#### This PR makes it possible to reserve a periodical material 
To find out if it is a periodical we need to look for manifestation materialTypes and not source as we previously thought

Other changes:
- adds an extra story to be able to display a periodical
- change periodicalSelect (useState) to type GroupListItem instead of string

#### Screenshot of the result
<img width="1728" alt="Skærmbillede 2022-09-26 kl  13 57 01" src="https://user-images.githubusercontent.com/49920322/192270553-7155c427-6e33-4653-bdf3-a68dc3b070f1.png">
<img width="1728" alt="Skærmbillede 2022-09-26 kl  13 57 06" src="https://user-images.githubusercontent.com/49920322/192270573-7473e495-8838-4e4b-81ed-50eebf2315c4.png">
<img width="754" alt="Skærmbillede 2022-09-26 kl  13 57 29" src="https://user-images.githubusercontent.com/49920322/192270596-8faec124-ea20-4a1e-a26b-74a8cc3457c9.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

