### PR TITLE
Fix/find on shelf x branches have the material

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,3 +1,4 @@
+import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
 import { HoldingsV3 } from "../../core/fbs/model";
 import {
@@ -8,7 +9,6 @@ import {
 } from "../../core/utils/helpers/general";
 import { UseTextFunction } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 
 export const getManifestationType = (manifestation: Manifestation) =>
   manifestation?.materialTypes?.[0]?.specific;
@@ -138,4 +138,12 @@ export const isAnyManifestationAvailableOnBranch = (
       return material.available;
     });
   });
+};
+
+export const totalBranchesHaveMaterial = (
+  manifestationHoldings: ManifestationHoldings[]
+) => {
+  return manifestationHoldings.filter((branchManifestationHoldings) => {
+    return isAnyManifestationAvailableOnBranch(branchManifestationHoldings);
+  }).length;
 };

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { FC } from "react";
 import partition from "lodash.partition";
-import { isAnyManifestationAvailableOnBranch } from "../../apps/material/helper";
+import {
+  isAnyManifestationAvailableOnBranch,
+  totalBranchesHaveMaterial
+} from "../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {
   convertPostIdToFaustId,
@@ -136,7 +139,9 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
         {!isLoading && (
           <>
             <div className="text-small-caption modal-find-on-shelf__caption">
-              {`${finalData.length} ${t("librariesHaveTheMaterialText")}`}
+              {`${totalBranchesHaveMaterial(finalDataToShow)} ${t(
+                "librariesHaveTheMaterialText"
+              )}`}
             </div>
             {finalDataToShow.map((libraryBranch: ManifestationHoldings) => {
               return (


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-229

#### Description
This PR corrects previously implemented logic where the Find on shelf modal needs to show how many branches in total have a specific material. The data shown previously was incorrect and was showing how many branches have the material regardless its availability. 

#### Screenshot of the result
https://user-images.githubusercontent.com/28546954/193524117-ab708ab3-d2a6-419a-b629-3c06184fecc3.mov


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
