### PR TITLE
Add working example of vscode debugging conf (dockerless)

### DIFF
--- a/.vscode.example/launch.json
+++ b/.vscode.example/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Storybook Debug",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "sudo yarn dev",
+      "internalConsoleOptions": "openOnFirstSessionStart",
+      "serverReadyAction": {
+        "pattern": "Local:.+(https?://[^:]+:[0-9]+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Danish public libraries.
   - [Requirements](#requirements)
   - [Development - alternative (no docker)](#development---alternative-no-docker)
     - [Howto](#howto)
+    - [Step Debugging in Visual Studio Code (no docker)](#step-debugging-in-visual-studio-code-no-docker)
     - [Access tokens](#access-tokens)
     - [Library token](#library-token)
   - [Installation](#installation)
@@ -62,6 +63,16 @@ Danish public libraries.
 - (note: if you enter adgangsplatform again after signing it, you will get
   signed out, and need to log in again. This is not a bug, as you stay logged
   in otherwise.)
+
+#### Step Debugging in Visual Studio Code (no docker)
+
+If you want to enable step debugging you need to:
+
+- Copy .vscode.example/launch.json into .vscode/
+- Mark 1 or more breakpoints on a line in the left gutter on an open file
+- In the top menu in VS Code choose:  Run -> Start Debugging
+- Type in your user password if ask to
+- Start debugging 🤖∿💻
 
 #### Access tokens
 


### PR DESCRIPTION
#### Description

Yes!!! Found my way in configuring vs code for step debugging.
Configuration was taken from this article:
https://blog.bruceleeharrison.com/2022/01/26/debug-storybook-from-vscode-2022/

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
