### PR TITLE
Show only unique periodical editions in periodical dropdowns

### DIFF
--- a/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
+++ b/src/components/find-on-shelf/FindOnShelfPeriodicalDropdowns.tsx
@@ -4,7 +4,8 @@ import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build
 import { HoldingsForBibliographicalRecordV3 } from "../../core/fbs/model";
 import {
   PeriodicalEdition,
-  makePeriodicalEditionsFromHoldings
+  makePeriodicalEditionsFromHoldings,
+  filterAndSortPeriodicalEditions
 } from "../material/periodical/helper";
 import { groupObjectArrayByProperty } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
@@ -24,40 +25,16 @@ const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
   const periodicalEditionsBase = makePeriodicalEditionsFromHoldings(
     manifestationsHoldings[0].holdings
   );
-
-  // Removing duplicate values of editions
   const groupedPeriodicalEditionsBase = groupObjectArrayByProperty(
     periodicalEditionsBase,
     "volumeYear"
   );
-  const periodicalEditions = Object.entries(groupedPeriodicalEditionsBase);
-  const filteredEditions = periodicalEditions.map((yearAndEditions) => {
-    return yearAndEditions[1].reduce((acc, edition) => {
-      if (!edition.volumeNumber) {
-        return acc;
-      }
-      const includesValueAlready = acc.includes(edition.volumeNumber);
-      if (!includesValueAlready) {
-        acc.push(edition.volumeNumber);
-      }
-      return acc;
-    }, [] as string[]);
-  });
-  const allYears = periodicalEditions.map(
-    (yearEditionPair) => yearEditionPair[0]
-  );
-  const filteredPeriodicalEditionsObj = allYears.reduce((acc, curr, index) => {
-    // Sort editions array
-    // eslint-disable-next-line no-param-reassign
-    acc[curr] = filteredEditions[index].sort((a, b) => {
-      return a.localeCompare(b, "da-DK");
-    });
-    return acc;
-  }, {} as { [key: string]: string[] });
 
-  const sortedPeriodicalYears = Object.keys(
-    filteredPeriodicalEditionsObj
-  ).sort();
+  const periodicalEditions = filterAndSortPeriodicalEditions(
+    groupedPeriodicalEditionsBase
+  );
+
+  const sortedPeriodicalYears = Object.keys(periodicalEditions).sort();
 
   const [selectedYear, setSelectedYear] = useState<string>(
     selectedPeriodical.volumeYear
@@ -109,15 +86,13 @@ const FindOnShelfPeriodicalDropdown: FC<FindOnShelfPeriodicalDropdownProps> = ({
               })
             }
           >
-            {filteredPeriodicalEditionsObj[selectedYear].map(
-              (periodicalEdition) => {
-                return (
-                  <option key={periodicalEdition} value={periodicalEdition}>
-                    {periodicalEdition}
-                  </option>
-                );
-              }
-            )}
+            {periodicalEditions[selectedYear].map((periodicalEdition) => {
+              return (
+                <option key={periodicalEdition} value={periodicalEdition}>
+                  {periodicalEdition}
+                </option>
+              );
+            })}
           </select>
           <div className="dropdown__arrows">
             <img className="dropdown__arrow" src={ExpandMoreIcon} alt="" />


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-263

#### Description
This PR fixes an issue with periodical dropdowns. The data is set up in a way where if a library has 5 specimens of e.g. volume 2022 - 29 of Alt for damerne, there would be 5 records with the value 29. This resulted in overpopulating the dropdown with duplicate values. We now filter these out.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/196660885-bfa76b65-c387-4410-99f3-05350ec0505c.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a