### PR TITLE
Don't show "online material reserve button" if no manifestation have online access

### DIFF
--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -4,6 +4,7 @@ import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
 import { convertPostIdToFaustId } from "../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../core/utils/types/button";
 import { Manifestation } from "../../../core/utils/types/entities";
+import { hasCorrectAccessType } from "./helper";
 import MaterialButtonsOnline from "./online/MaterialButtonsOnline";
 import MaterialButtonsFindOnShelf from "./physical/MaterialButtonsFindOnShelf";
 import MaterialButtonsPhysical from "./physical/MaterialButtonsPhysical";
@@ -18,15 +19,6 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   manifestation: { pid },
   size
 }) => {
-  const hasCorrectAccessType = (
-    desiredAccessType: AccessTypeCode,
-    manifest: Manifestation
-  ) => {
-    return !!manifest.accessTypes.some(
-      (type) => type.code === desiredAccessType
-    );
-  };
-
   const faustId = convertPostIdToFaustId(pid);
 
   return (

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -18,24 +18,26 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   manifestation: { pid },
   size
 }) => {
-  const hasPhysicalAccess = manifestation.accessTypes.some(
-    (type) => type.code === AccessTypeCode.Physical
-  );
-  const hasOnlineAccess = manifestation.accessTypes.some(
-    (type) => type.code === AccessTypeCode.Online
-  );
+  const hasCorrectAccessType = (
+    desiredAccessType: AccessTypeCode,
+    manifest: Manifestation
+  ) => {
+    return !!manifest.accessTypes.some(
+      (type) => type.code === desiredAccessType
+    );
+  };
 
   const faustId = convertPostIdToFaustId(pid);
 
   return (
     <>
-      {hasPhysicalAccess && (
+      {hasCorrectAccessType(AccessTypeCode.Physical, manifestation) && (
         <>
           <MaterialButtonsPhysical manifestation={manifestation} size={size} />
           <MaterialButtonsFindOnShelf size={size} faustIds={[faustId]} />
         </>
       )}
-      {hasOnlineAccess && (
+      {hasCorrectAccessType(AccessTypeCode.Online, manifestation) && (
         <MaterialButtonsOnline manifestation={manifestation} size={size} />
       )}
     </>

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -21,6 +21,9 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   const hasPhysicalAccess = manifestation.accessTypes.some(
     (type) => type.code === AccessTypeCode.Physical
   );
+  const hasOnlineAccess = manifestation.accessTypes.some(
+    (type) => type.code === AccessTypeCode.Online
+  );
 
   const faustId = convertPostIdToFaustId(pid);
 
@@ -32,7 +35,9 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
           <MaterialButtonsFindOnShelf size={size} faustIds={[faustId]} />
         </>
       )}
-      <MaterialButtonsOnline manifestation={manifestation} size={size} />
+      {hasOnlineAccess && (
+        <MaterialButtonsOnline manifestation={manifestation} size={size} />
+      )}
     </>
   );
 };

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -5,7 +5,7 @@ export const hasCorrectAccessType = (
   desiredAccessType: AccessTypeCode,
   manifest: Manifestation
 ) => {
-  return !!manifest.accessTypes.some((type) => type.code === desiredAccessType);
+  return manifest.accessTypes.some((type) => type.code === desiredAccessType);
 };
 
 export default {};

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -1,0 +1,11 @@
+import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
+import { Manifestation } from "../../../core/utils/types/entities";
+
+export const hasCorrectAccessType = (
+  desiredAccessType: AccessTypeCode,
+  manifest: Manifestation
+) => {
+  return !!manifest.accessTypes.some((type) => type.code === desiredAccessType);
+};
+
+export default {};


### PR DESCRIPTION
#### Link to issue
[DDFSOEG-264](https://reload.atlassian.net/browse/DDFSOEG-264)

#### Description
In case none of the material manifestations have online access, we shouldn't show the "online reservation" button on the material page. 

#### Screenshot of the result
n/a

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a