### PR TITLE
Fix/remove "change" from editions & show correct periodical edition - in reservation modal

### DIFF
--- a/src/components/reservation/ReservationFormListItem.tsx
+++ b/src/components/reservation/ReservationFormListItem.tsx
@@ -24,13 +24,15 @@ const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
           {text?.length > 0 ? text : t("missingDataText")}
         </p>
       </div>
-      <button
-        onClick={changeHandler}
-        type="button"
-        className="link-tag text-small-caption cursor-pointer"
-      >
-        {t("shiftText")}
-      </button>
+      {changeHandler && (
+        <button
+          onClick={changeHandler}
+          type="button"
+          className="link-tag text-small-caption cursor-pointer"
+        >
+          {t("shiftText")}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -178,7 +178,6 @@ const ReservationModalBody = ({
                 icon={Various}
                 title={t("editionText")}
                 text={edition?.summary ?? ""}
-                changeHandler={() => {}} // TODO: open modal to switch user data
               />
 
               {patron && (

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -153,7 +153,9 @@ const ReservationModalBody = ({
                 {mainTitle}{" "}
                 {selectedPeriodical && selectedPeriodical.displayText}
               </h2>
-              <p className="text-body-medium-regular">{authorLine}</p>
+              {authorLine && (
+                <p className="text-body-medium-regular">{authorLine}</p>
+              )}
             </div>
           </header>
           <div>

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -177,7 +177,7 @@ const ReservationModalBody = ({
               <ReservationFormListItem
                 icon={Various}
                 title={t("editionText")}
-                text={edition?.summary ?? ""}
+                text={selectedPeriodical?.displayText || edition?.summary || ""}
               />
 
               {patron && (

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -133,7 +133,7 @@ export const getAuthorLine = (
     creatorsToString(
       flattenCreators(filterCreators(creators, ["Person"])),
       t
-    ) || t("creatorsAreMissingText");
+    ) || null;
 
   let year = "";
   if (publicationYear) {
@@ -142,7 +142,9 @@ export const getAuthorLine = (
   if (materialIsFiction(manifestation)) {
     year = `(${t("materialHeaderAllEditionsText")})`;
   }
-  return [t("materialHeaderAuthorByText"), author, year].join(" ");
+  return !author
+    ? null
+    : [t("materialHeaderAuthorByText"), author, year].join(" ");
 };
 
 export const excludeBlacklistedBranches = (


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-265

#### Description
This PR fixes 3 things in the reservation modal:
- removes the "change" button from the "editions beam" as according to the project specs
- shows the correct edition in the "editions beam" for periodicals
- if the given material doesn't have any creators specified, instead of showing "By missing creators", we now don't show the line at all

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/197487964-45287124-2ca8-4af0-a354-bced57448318.png)

No creators shown if there are no creators:
![image](https://user-images.githubusercontent.com/28546954/197493212-7bd60e33-0c6a-4cbf-a216-4ec7f446a399.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
