### PR TITLE
Use Markdownlint problem matcher v2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -113,6 +113,6 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Install problem matcher
-        uses: xt0rted/markdownlint-problem-matcher@v1
+        uses: xt0rted/markdownlint-problem-matcher@v2
       - name: Lint markdown
         run: yarn lint:markdown


### PR DESCRIPTION
#### Description

This updates the runtime from Node 12 to Node 16. Node 12 is being deprecated by GitHub and actions using it cause warnings.

See https://github.com/xt0rted/markdownlint-problem-matcher/issues/527

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.