### PR TITLE
MaterialType change to "tidsskrift" instead of "periodikum". + Test split

### DIFF
--- a/cypress/fixtures/material/availability.json
+++ b/cypress/fixtures/material/availability.json
@@ -1,6 +1,6 @@
 [
   {
-    "available": false,
+    "available": true,
     "recordId": "52557240",
     "reservable": true,
     "reservations": 2

--- a/cypress/fixtures/material/periodical-availability.json
+++ b/cypress/fixtures/material/periodical-availability.json
@@ -1,8 +1,0 @@
-[
-  {
-    "recordId": "06373674",
-    "reservable": true,
-    "available": true,
-    "reservations": 64
-  }
-]

--- a/cypress/fixtures/material/periodical-availability.json
+++ b/cypress/fixtures/material/periodical-availability.json
@@ -1,0 +1,8 @@
+[
+  {
+    "recordId": "06373674",
+    "reservable": true,
+    "available": true,
+    "reservations": 64
+  }
+]

--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -20,7 +20,7 @@
               "code": "NONFICTION"
             },
             "publicationYear": { "display": "1946" },
-            "materialTypes": [{ "specific": "periodikum" }],
+            "materialTypes": [{ "specific": "tidsskrift" }],
             "creators": [],
             "hostPublication": null,
             "languages": { "main": [{ "display": "dansk" }] },
@@ -47,7 +47,7 @@
             "code": "NONFICTION"
           },
           "publicationYear": { "display": "1946" },
-          "materialTypes": [{ "specific": "periodikum" }],
+          "materialTypes": [{ "specific": "tidsskrift" }],
           "creators": [],
           "hostPublication": null,
           "languages": { "main": [{ "display": "dansk" }] },

--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -1,80 +1,182 @@
 {
   "data": {
-    "work": {
-      "workId": "work-of:870970-basis:06373674",
-      "titles": { "full": ["Alt for damerne"], "original": [] },
-      "abstract": [],
-      "creators": [],
-      "series": [],
-      "seriesMembers": [],
-      "genreAndForm": [],
-      "manifestations": {
-        "all": [
-          {
-            "pid": "870970-basis:06373674",
-            "genreAndForm": [],
-            "source": ["Bibliotekskatalog"],
-            "titles": { "main": ["Alt for damerne"], "original": [] },
-            "fictionNonfiction": {
-              "display": "FAGLITTERATUR",
-              "code": "NONFICTION"
-            },
-            "publicationYear": { "display": "1946" },
-            "materialTypes": [{ "specific": "tidsskrift" }],
-            "creators": [],
-            "hostPublication": null,
-            "languages": { "main": [{ "display": "dansk" }] },
-            "identifiers": [{ "value": "0002-6506" }],
-            "contributors": [],
-            "edition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "DigitalArticleService", "issn": "00026506" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null
-          }
-        ],
-        "latest": {
-          "pid": "870970-basis:06373674",
-          "genreAndForm": [],
-          "source": ["Bibliotekskatalog"],
-          "titles": { "main": ["Alt for damerne"], "original": [] },
-          "fictionNonfiction": {
-            "display": "FAGLITTERATUR",
-            "code": "NONFICTION"
+      "work": {
+          "workId": "work-of:870970-basis:06373674",
+          "titles": {
+              "full": [
+                  "Alt for damerne"
+              ],
+              "original": []
           },
-          "publicationYear": { "display": "1946" },
-          "materialTypes": [{ "specific": "tidsskrift" }],
+          "abstract": [],
           "creators": [],
-          "hostPublication": null,
-          "languages": { "main": [{ "display": "dansk" }] },
-          "identifiers": [{ "value": "0002-6506" }],
-          "contributors": [],
-          "edition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "00026506" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "series": [],
+          "seriesMembers": [],
+          "genreAndForm": [
+              "tidsskrift",
+              "tíðarrit"
           ],
-          "shelfmark": null
-        }
-      },
-      "materialTypes": [{ "specific": "Tidsskrift" }],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
-      "subjects": {
-        "all": [
-          { "display": "dame- og mandeblade" },
-          { "display": "Viborg amtskommune" }
-        ]
-      },
-      "reviews": [],
-      "fictionNonfiction": { "display": "NONFIKTION", "code": "NONFICTION" },
-      "workYear": null
-    }
+          "manifestations": {
+              "all": [
+                  {
+                      "pid": "870970-basis:06373674",
+                      "genreAndForm": [
+                          "tidsskrift"
+                      ],
+                      "source": [
+                          "Bibliotekskatalog"
+                      ],
+                      "titles": {
+                          "main": [
+                              "Alt for damerne"
+                          ],
+                          "original": []
+                      },
+                      "fictionNonfiction": {
+                          "display": "nonfiktion",
+                          "code": "NONFICTION"
+                      },
+                      "publicationYear": {
+                          "display": "1946- "
+                      },
+                      "materialTypes": [
+                          {
+                              "specific": "tidsskrift"
+                          }
+                      ],
+                      "creators": [],
+                      "hostPublication": null,
+                      "languages": {
+                          "main": [
+                              {
+                                  "display": "dansk"
+                              }
+                          ]
+                      },
+                      "identifiers": [
+                          {
+                              "value": "0002-6506"
+                          }
+                      ],
+                      "contributors": [],
+                      "edition": {
+                          "summary": "1946- "
+                      },
+                      "audience": {
+                          "generalAudience": []
+                      },
+                      "physicalDescriptions": [],
+                      "accessTypes": [
+                          {
+                              "code": "PHYSICAL"
+                          }
+                      ],
+                      "access": [
+                          {
+                              "__typename": "DigitalArticleService",
+                              "issn": "00026506"
+                          },
+                          {
+                              "__typename": "InterLibraryLoan",
+                              "loanIsPossible": true
+                          }
+                      ],
+                      "shelfmark": null
+                  }
+              ],
+              "latest": {
+                  "pid": "870970-basis:06373674",
+                  "genreAndForm": [
+                      "tidsskrift"
+                  ],
+                  "source": [
+                      "Bibliotekskatalog"
+                  ],
+                  "titles": {
+                      "main": [
+                          "Alt for damerne"
+                      ],
+                      "original": []
+                  },
+                  "fictionNonfiction": {
+                      "display": "nonfiktion",
+                      "code": "NONFICTION"
+                  },
+                  "publicationYear": {
+                      "display": "1946- "
+                  },
+                  "materialTypes": [
+                      {
+                          "specific": "tidsskrift"
+                      }
+                  ],
+                  "creators": [],
+                  "hostPublication": null,
+                  "languages": {
+                      "main": [
+                          {
+                              "display": "dansk"
+                          }
+                      ]
+                  },
+                  "identifiers": [
+                      {
+                          "value": "0002-6506"
+                      }
+                  ],
+                  "contributors": [],
+                  "edition": {
+                      "summary": "1946- "
+                  },
+                  "audience": {
+                      "generalAudience": []
+                  },
+                  "physicalDescriptions": [],
+                  "accessTypes": [
+                      {
+                          "code": "PHYSICAL"
+                      }
+                  ],
+                  "access": [
+                      {
+                          "__typename": "DigitalArticleService",
+                          "issn": "00026506"
+                      },
+                      {
+                          "__typename": "InterLibraryLoan",
+                          "loanIsPossible": true
+                      }
+                  ],
+                  "shelfmark": null
+              }
+          },
+          "materialTypes": [
+              {
+                  "specific": "periodikum"
+              }
+          ],
+          "mainLanguages": [
+              {
+                  "display": "dansk",
+                  "isoCode": "dan"
+              }
+          ],
+          "subjects": {
+              "all": [
+                  {
+                      "display": "dame- og mandeblade"
+                  },
+                  {
+                      "display": "Viborg amtskommune"
+                  }
+              ]
+          },
+          "reviews": [],
+          "fictionNonfiction": {
+              "display": "nonfiktion",
+              "code": "NONFICTION"
+          },
+          "workYear": null
+      }
   }
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,5 +1,6 @@
 const task = require("@cypress/code-coverage/task");
 const browserify = require("@cypress/browserify-preprocessor");
+const logsPrinter = require("cypress-terminal-report/src/installLogsPrinter");
 
 // In order to use both babelrc and typescript in browserify
 // we copy the functionality from @cypress/code-coverage/use-babelrc
@@ -10,6 +11,9 @@ const { browserifyOptions } = browserify.defaultOptions;
 browserifyOptions.transform[1][1].babelrc = true;
 
 module.exports = (on, config) => {
+  logsPrinter(on, {
+    printLogsToConsole: "always"
+  });
   task(on, config);
   on(
     "file:preprocessor",

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -2,7 +2,10 @@
 // the namespace is declared like it is done here. Therefore we'll bypass errors about it.
 /* eslint-disable @typescript-eslint/no-namespace */
 import "@cypress/code-coverage/support";
+import installCollector from "cypress-terminal-report/src/installLogsCollector";
 import { hasOperationName } from "../utils/graphql-test-utils";
+
+installCollector();
 
 const TOKEN_USER_KEY = "user";
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "css-loader": "^6.7.1",
     "cssnano": "^5.1.7",
     "cypress": "^9.6.1",
+    "cypress-terminal-report": "^4.1.2",
     "doctoc": "^2.2.0",
     "eslint": "^8.15.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/src/apps/material/infomedia.test.ts
+++ b/src/apps/material/infomedia.test.ts
@@ -1,0 +1,55 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("The infomedia material", () => {
+  it("Render infomedia + Read article + Close modal", () => {
+    cy.contains("button:visible", "Read article").click();
+    cy.contains("h2", "BUTLERENS UTROLIGE HISTORIE");
+    cy.get(`[aria-label="Close infomedia modal"]`).click();
+  });
+
+  beforeEach(() => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/infomedia-fbi-api.json"
+    });
+    cy.interceptGraphql({
+      operationName: "getInfomedia",
+      fixtureFilePath: "material/infomedia-article.json"
+    });
+    cy.interceptRest({
+      aliasName: "holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/holdings.json"
+    });
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
+    cy.interceptRest({
+      aliasName: "user",
+      url: "**/agencyid/patrons/patronid/v2",
+      fixtureFilePath: "material/user.json"
+    });
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+
+    cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story");
+  });
+});
+
+export {};

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -59,7 +59,7 @@ describe("Material", () => {
     });
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
     cy.contains("bog");
-    cy.contains("unavailable");
+    cy.contains("available");
   });
 
   it("Open material details", () => {

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -131,6 +131,12 @@ describe("Material", () => {
     cy.get("#editions").should("have.value", "52");
     cy.contains("button:visible", "Reserve tidsskrift").click();
     cy.contains("h2", "2021, nr. 52");
+    cy.log("periodical Availability");
+    cy.interceptRest({
+      aliasName: "periodical Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/periodical-availability.json"
+    });
     cy.contains("button:visible", "Approve reservation").click();
     cy.contains("Material is available and reserved for you!");
     cy.contains("You are number 3 in queue");

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -125,11 +125,11 @@ describe("Material", () => {
       fixtureFilePath: "material/periodical-fbi-api.json"
     });
     cy.visit(
-      "/iframe.html?id=apps-material--periodical&viewMode=story&type=periodikum"
+      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
     );
     cy.get("#year").select("2021");
     cy.get("#editions").should("have.value", "52");
-    cy.contains("button:visible", "Reserve periodikum").click();
+    cy.contains("button:visible", "Reserve tidsskrift").click();
     cy.contains("h2", "2021, nr. 52");
     cy.contains("button:visible", "Approve reservation").click();
     cy.contains("Material is available and reserved for you!");

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -112,37 +112,6 @@ describe("Material", () => {
     cy.contains("button:visible", "Ok").click();
   });
 
-  //  periodical test.
-  it("Render periodical + change to 2021, nr. 52 + Aprove resevation", () => {
-    cy.interceptRest({
-      aliasName: "periodical holdings",
-      url: "**/agencyid/catalog/holdings/**",
-      fixtureFilePath: "material/periodical-holdings.json"
-    });
-
-    cy.interceptGraphql({
-      operationName: "getMaterial",
-      fixtureFilePath: "material/periodical-fbi-api.json"
-    });
-    cy.visit(
-      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
-    );
-    cy.get("#year").select("2021");
-    cy.get("#editions").should("have.value", "52");
-    cy.contains("button:visible", "Reserve tidsskrift").click();
-    cy.contains("h2", "2021, nr. 52");
-    cy.log("periodical Availability");
-    cy.interceptRest({
-      aliasName: "periodical Availability",
-      url: "**/availability/v3?recordid=**",
-      fixtureFilePath: "material/periodical-availability.json"
-    });
-    cy.contains("button:visible", "Approve reservation").click();
-    cy.contains("Material is available and reserved for you!");
-    cy.contains("You are number 3 in queue");
-    cy.contains("button:visible", "Ok").click();
-  });
-
   //  infomedia test.
   it("Render infomedia + Read article + Close modal", () => {
     cy.interceptGraphql({

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -112,23 +112,6 @@ describe("Material", () => {
     cy.contains("button:visible", "Ok").click();
   });
 
-  //  infomedia test.
-  it("Render infomedia + Read article + Close modal", () => {
-    cy.interceptGraphql({
-      operationName: "getMaterial",
-      fixtureFilePath: "material/infomedia-fbi-api.json"
-    });
-    cy.interceptGraphql({
-      operationName: "getInfomedia",
-      fixtureFilePath: "material/infomedia-article.json"
-    });
-
-    cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story");
-    cy.contains("button:visible", "Read article").click();
-    cy.contains("h2", "BUTLERENS UTROLIGE HISTORIE");
-    cy.get(`[aria-label="Close infomedia modal"]`).click();
-  });
-
   beforeEach(() => {
     cy.interceptRest({
       httpMethod: "POST",

--- a/src/apps/material/periodical.test.ts
+++ b/src/apps/material/periodical.test.ts
@@ -1,0 +1,61 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("The periodical material", () => {
+  it("Render periodical + Change to 2021, nr. 52 + Approve reservation", () => {
+    cy.get("#year").select("2021");
+    cy.get("#editions").should("have.value", "52");
+    cy.contains("button:visible", "Reserve tidsskrift").click();
+    cy.contains("h2", "2021, nr. 52");
+    cy.contains("button:visible", "Approve reservation").click();
+    cy.contains("Material is available and reserved for you!");
+    cy.contains("You are number 3 in queue");
+    cy.contains("button:visible", "Ok").click();
+  });
+
+  beforeEach(() => {
+    cy.interceptRest({
+      aliasName: "Periodical holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/periodical-holdings.json"
+    });
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/periodical-fbi-api.json"
+    });
+    cy.interceptRest({
+      aliasName: "Periodical availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/periodical-availability.json"
+    });
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+    cy.interceptRest({
+      aliasName: "user",
+      url: "**/agencyid/patrons/patronid/v2",
+      fixtureFilePath: "material/user.json"
+    });
+    cy.interceptRest({
+      httpMethod: "POST",
+      aliasName: "reservations",
+      url: "**/patrons/patronid/reservations/**",
+      fixtureFilePath: "material/reservations.json"
+    });
+
+    cy.visit(
+      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
+    );
+  });
+});
+
+export {};

--- a/src/apps/material/periodical.test.ts
+++ b/src/apps/material/periodical.test.ts
@@ -2,10 +2,17 @@ const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
 
 describe("The periodical material", () => {
   it("Render periodical + Change to 2021, nr. 52 + Approve reservation", () => {
+    cy.wait([
+      "@getMaterial GraphQL operation",
+      "@Periodical holdings",
+      "@Periodical availability",
+      "@Cover"
+    ]);
     cy.get("#year").select("2021");
     cy.get("#editions").should("have.value", "52");
     cy.contains("button:visible", "Reserve tidsskrift").click();
     cy.contains("h2", "2021, nr. 52");
+    cy.wait("@user");
     cy.contains("button:visible", "Approve reservation").click();
     cy.contains("Material is available and reserved for you!");
     cy.contains("You are number 3 in queue");

--- a/src/apps/material/periodical.test.ts
+++ b/src/apps/material/periodical.test.ts
@@ -5,7 +5,7 @@ describe("The periodical material", () => {
     cy.wait([
       "@getMaterial GraphQL operation",
       "@Periodical holdings",
-      "@Periodical availability",
+      "@Availability",
       "@Cover"
     ]);
     cy.get("#year").select("2021");
@@ -30,9 +30,9 @@ describe("The periodical material", () => {
       fixtureFilePath: "material/periodical-fbi-api.json"
     });
     cy.interceptRest({
-      aliasName: "Periodical availability",
+      aliasName: "Availability",
       url: "**/availability/v3?recordid=**",
-      fixtureFilePath: "material/periodical-availability.json"
+      fixtureFilePath: "material/availability.json"
     });
     cy.interceptRest({
       aliasName: "Cover",

--- a/src/components/campaign/campaign.test.ts
+++ b/src/components/campaign/campaign.test.ts
@@ -8,6 +8,47 @@ export function isImageLoaded(cy: Cypress.cy & EventEmitter) {
 }
 
 describe("Campaign", () => {
+  it("Shows a full campaign with image, text & link", () => {
+    cy.wait([
+      "@searchFacet GraphQL operation",
+      "@searchWithPagination GraphQL operation",
+      "@Campaign service - full campaign"
+    ]);
+    isImageLoaded(cy);
+    cy.get("img").should("have.attr", "alt");
+    cy.get("section").contains("Harry Potter");
+    cy.get("a")
+      .first()
+      .should(
+        "have.attr",
+        "href",
+        "http://localhost/?path=/story/apps-search-result--search-result"
+      );
+  });
+
+  it.only("Shows a text-only campaign without an image", () => {
+    cy.wait([
+      "@searchFacet GraphQL operation",
+      "@searchWithPagination GraphQL operation",
+      "@Campaign service - text only campaign"
+    ]);
+    cy.get("section").should("contain.text", "Harry Potter");
+    cy.get("section").find("img").should("not.exist");
+  });
+
+  it("Shows an image-only campaign without text", () => {
+    cy.interceptRest({
+      httpMethod: "POST",
+      aliasName: "Campaign service - image only campaign",
+      url: "**/dpl_campaign/match",
+      fixtureFilePath: "search-result/campaign-image-only.json"
+    });
+
+    isImageLoaded(cy);
+    cy.get("img").should("have.attr", "alt");
+    cy.get("section").find("Lorem ipsum Harry Potter").should("not.exist");
+  });
+
   beforeEach(() => {
     // Intercept graphql search query.
     cy.interceptGraphql({
@@ -32,24 +73,18 @@ describe("Campaign", () => {
     ).as("Harry Potter cover");
 
     // Intercept covers.
-    cy.fixture("cover.json")
-      .then((result) => {
-        cy.intercept("GET", "**/covers**", result);
-      })
-      .as("Cover service");
+    cy.interceptRest({
+      aliasName: "Cover service",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
 
     // Intercept availability service.
-    cy.intercept("GET", "**/availability/v3**", {
-      statusCode: 200,
-      body: [
-        {
-          recordId: "99999999",
-          reservable: true,
-          available: true,
-          reservations: 5
-        }
-      ]
-    }).as("Availability service");
+    cy.interceptRest({
+      aliasName: "Availability service",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
 
     // Intercept material list service.
     cy.intercept("HEAD", "**/list/default/**", {
@@ -57,51 +92,22 @@ describe("Campaign", () => {
       body: {}
     }).as("Material list service");
 
+    cy.interceptRest({
+      aliasName: "Campaign service - full campaign",
+      url: "**/dpl_campaign/match",
+      fixtureFilePath: "search-result/campaign.json"
+    });
+
+    cy.interceptRest({
+      httpMethod: "POST",
+      aliasName: "Campaign service - text only campaign",
+      url: "**/dpl_campaign/match",
+      fixtureFilePath: "search-result/campaign-text-only.json"
+    });
+
     cy.visit(
       "/iframe.html?id=apps-search-result--search-result&args=pageSizeDesktop:2;pageSizeMobile:2"
     );
-  });
-
-  it("Shows a full campaign with image, text & link", () => {
-    cy.fixture("search-result/campaign.json")
-      .then((result) => {
-        cy.intercept("**/dpl_campaign/match", result);
-      })
-      .as("Campaign service - full campaign");
-
-    isImageLoaded(cy);
-    cy.get("img").should("have.attr", "alt");
-    cy.get("section").contains("Harry Potter");
-    cy.get("a")
-      .first()
-      .should(
-        "have.attr",
-        "href",
-        "http://localhost/?path=/story/apps-search-result--search-result"
-      );
-  });
-
-  it("Shows a text-only campaign without an image", () => {
-    cy.fixture("search-result/campaign-text-only.json")
-      .then((result) => {
-        cy.intercept("POST", "**/dpl_campaign/match", result);
-      })
-      .as("Campaign service - text only campaign");
-
-    cy.get("section").should("contain.text", "Harry Potter");
-    cy.get("section").find("img").should("not.exist");
-  });
-
-  it("Shows an image-only campaign without text", () => {
-    cy.fixture("search-result/campaign-image-only.json")
-      .then((result) => {
-        cy.intercept("POST", "**/dpl_campaign/match", result);
-      })
-      .as("Campaign service - image only campaign");
-
-    isImageLoaded(cy);
-    cy.get("img").should("have.attr", "alt");
-    cy.get("section").find("Lorem ipsum Harry Potter").should("not.exist");
   });
 });
 

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -64,7 +64,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   );
   const isPeriodical = manifestations.some((manifestation) => {
     return manifestation.materialTypes.some((materialType) => {
-      return materialType.specific.includes("periodikum");
+      return materialType.specific.includes("tidsskrift");
     });
   });
 

--- a/src/components/find-on-shelf/mocked-data.ts
+++ b/src/components/find-on-shelf/mocked-data.ts
@@ -164,7 +164,7 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
     },
     materialTypes: [
       {
-        specific: "periodikum"
+        specific: "tidsskrift"
       }
     ],
     creators: [],

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -63,9 +63,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   );
   const isPeriodical = manifestation.materialTypes.some(
     (materialType: Manifestation["materialTypes"][0]) => {
-      return materialType.specific.includes("periodikum");
+      return materialType.specific.includes("tidsskrift");
     }
   );
+
   const author = creatorsText || t("creatorsAreMissingText");
 
   const containsDanish = mainLanguages.some((language) =>
@@ -96,6 +97,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
             selectManifestationHandler={selectManifestationHandler}
           />
         </div>
+
         {isPeriodical && (
           <MaterialPeriodical
             faustId={convertPostIdToFaustId(pid)}
@@ -103,7 +105,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
             selectPeriodicalHandler={selectPeriodicalHandler}
           />
         )}
-
         {manifestation && (
           <>
             <div className="material-header__button">

--- a/yarn.lock
+++ b/yarn.lock
@@ -8053,6 +8053,16 @@ cyclist@^1.0.1:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-terminal-report@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/cypress-terminal-report/-/cypress-terminal-report-4.1.2.tgz#d5652ebec4d630f24a44fd0907477d394dc3585c"
+  integrity sha512-UyCR7AJXMJYt87JXBAxdZxWC+FXG1S7+ePVACcumUQZq5lH490pXPPg47KY/7J6yyFatT6da+Mb1/J6E7K8sLg==
+  dependencies:
+    chalk "^4.0.0"
+    fs-extra "^10.1.0"
+    semver "^7.3.5"
+    tv4 "^1.3.0"
+
 cypress@^9.6.1:
   version "9.6.1"
   resolved "https://registry.npmjs.org/cypress/-/cypress-9.6.1.tgz"
@@ -10134,7 +10144,7 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^10.0.0, fs-extra@^10.0.1:
+fs-extra@^10.0.0, fs-extra@^10.0.1, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -19033,6 +19043,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+tv4@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
+  integrity sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
#### [DDFSOEG-280](https://reload.atlassian.net/browse/DDFSOEG-280)

#### FBI API has been changed so that materialType is now called "tidsskrift" instead of "periodikum"
 
**Other than that**
in an attempt to find out why the periodical test fails. have we discovered that in cypress you can use wait(alias) to be sure that it does not continue until the fixed data is loaded

in addition, to making it easier to read and debug. The Material test is now divided so that there are separate tests for infomedia and periodicals.

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.