### PR TITLE
Fix publication year

### DIFF
--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -3,9 +3,7 @@
     "work": {
       "workId": "work-of:870970-basis:52557240",
       "titles": {
-        "full": [
-          "De syv søstre : Maias historie"
-        ],
+        "full": ["De syv søstre : Maias historie"],
         "original": []
       },
       "abstract": [
@@ -23,9 +21,7 @@
           "isPopular": null,
           "numberInSeries": {
             "display": "1",
-            "number": [
-              1
-            ]
+            "number": [1]
           },
           "readThisFirst": null,
           "readThisWhenever": null
@@ -42,120 +38,76 @@
         {
           "workId": "work-of:870970-basis:52557240",
           "titles": {
-            "main": [
-              "De syv søstre"
-            ],
-            "full": [
-              "De syv søstre : Maias historie"
-            ],
+            "main": ["De syv søstre"],
+            "full": ["De syv søstre : Maias historie"],
             "original": []
           }
         },
         {
           "workId": "work-of:870970-basis:52970628",
           "titles": {
-            "main": [
-              "Stormsøsteren"
-            ],
-            "full": [
-              "Stormsøsteren : Allys historie"
-            ],
+            "main": ["Stormsøsteren"],
+            "full": ["Stormsøsteren : Allys historie"],
             "original": []
           }
         },
         {
           "workId": "work-of:870970-basis:53280749",
           "titles": {
-            "main": [
-              "Skyggesøsteren"
-            ],
-            "full": [
-              "Skyggesøsteren : Stars historie"
-            ],
+            "main": ["Skyggesøsteren"],
+            "full": ["Skyggesøsteren : Stars historie"],
             "original": []
           }
         },
         {
           "workId": "work-of:870970-basis:53802001",
           "titles": {
-            "main": [
-              "Perlesøsteren"
-            ],
-            "full": [
-              "Perlesøsteren : CeCes historie"
-            ],
+            "main": ["Perlesøsteren"],
+            "full": ["Perlesøsteren : CeCes historie"],
             "original": []
           }
         },
         {
           "workId": "work-of:870970-basis:54189141",
           "titles": {
-            "main": [
-              "Månesøsteren"
-            ],
-            "full": [
-              "Månesøsteren : Tiggys historie"
-            ],
+            "main": ["Månesøsteren"],
+            "full": ["Månesøsteren : Tiggys historie"],
             "original": []
           }
         },
         {
           "workId": "work-of:870970-basis:46656172",
           "titles": {
-            "main": [
-              "Solsøsteren"
-            ],
-            "full": [
-              "Solsøsteren : Electras historie"
-            ],
-            "original": [
-              "The sun sister"
-            ]
+            "main": ["Solsøsteren"],
+            "full": ["Solsøsteren : Electras historie"],
+            "original": ["The sun sister"]
           }
         },
         {
           "workId": "work-of:870970-basis:38500775",
           "titles": {
-            "main": [
-              "Den forsvundne søster"
-            ],
-            "full": [
-              "Den forsvundne søster"
-            ],
-            "original": [
-              "The missing sister"
-            ]
+            "main": ["Den forsvundne søster"],
+            "full": ["Den forsvundne søster"],
+            "original": ["The missing sister"]
           }
         }
       ],
-      "genreAndForm": [
-        "slægtsromaner"
-      ],
+      "genreAndForm": ["slægtsromaner"],
       "manifestations": {
         "all": [
           {
             "pid": "870970-basis:46615743",
-            "genreAndForm": [
-              "slægtsromaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["slægtsromaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2019"
-            },
+
             "materialTypes": [
               {
                 "specific": "bog"
@@ -186,7 +138,10 @@
               }
             ],
             "edition": {
-              "summary": "3. udgave, 1. oplag (2019)"
+              "summary": "3. udgave, 1. oplag (2019)",
+              "publicationYear": {
+                "display": "2019"
+              }
             },
             "audience": {
               "generalAudience": []
@@ -211,27 +166,17 @@
           },
           {
             "pid": "870970-basis:52557240",
-            "genreAndForm": [
-              "slægtsromaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["slægtsromaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2016"
-            },
+
             "materialTypes": [
               {
                 "specific": "bog"
@@ -262,7 +207,10 @@
               }
             ],
             "edition": {
-              "summary": "1. udgave, 3. oplag (2018)"
+              "summary": "1. udgave, 3. oplag (2018)",
+              "publicationYear": {
+                "display": "2016"
+              }
             },
             "audience": {
               "generalAudience": []
@@ -287,27 +235,17 @@
           },
           {
             "pid": "870970-basis:52590302",
-            "genreAndForm": [
-              "slægtsromaner"
-            ],
-            "source": [
-              "eReolen"
-            ],
+            "genreAndForm": ["slægtsromaner"],
+            "source": ["eReolen"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2016"
-            },
+
             "materialTypes": [
               {
                 "specific": "ebog"
@@ -341,7 +279,10 @@
               }
             ],
             "edition": {
-              "summary": "1. eBogsudgave"
+              "summary": "1. eBogsudgave",
+              "publicationYear": {
+                "display": "2016"
+              }
             },
             "audience": {
               "generalAudience": []
@@ -367,27 +308,17 @@
           },
           {
             "pid": "870970-basis:52643414",
-            "genreAndForm": [
-              "slægtsromaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["slægtsromaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre (mp3)"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre (mp3)"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2016"
-            },
+
             "materialTypes": [
               {
                 "specific": "lydbog (cd-mp3)"
@@ -421,7 +352,10 @@
               }
             ],
             "edition": {
-              "summary": "1. lydbogsudgave"
+              "summary": "1. lydbogsudgave",
+              "publicationYear": {
+                "display": "2016"
+              }
             },
             "audience": {
               "generalAudience": []
@@ -446,27 +380,17 @@
           },
           {
             "pid": "870970-basis:52643503",
-            "genreAndForm": [
-              "slægtsromaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["slægtsromaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2016"
-            },
+
             "materialTypes": [
               {
                 "specific": "lydbog (net)"
@@ -499,7 +423,11 @@
                 "display": "Ulla Lauridsen"
               }
             ],
-            "edition": null,
+            "edition": {
+              "publicationYear": {
+                "display": "2016"
+              }
+            },
             "audience": {
               "generalAudience": []
             },
@@ -524,24 +452,16 @@
           {
             "pid": "870970-basis:53200346",
             "genreAndForm": [],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2017"
-            },
+
             "materialTypes": [
               {
                 "specific": "bog"
@@ -572,7 +492,10 @@
               }
             ],
             "edition": {
-              "summary": "1. bogklubudgave, 1. oplag (2017)"
+              "summary": "1. bogklubudgave, 1. oplag (2017)",
+              "publicationYear": {
+                "display": "2017"
+              }
             },
             "audience": {
               "generalAudience": []
@@ -597,27 +520,17 @@
           },
           {
             "pid": "870970-basis:53292968",
-            "genreAndForm": [
-              "slægtsromaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["slægtsromaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "SKOENLITTERATUR",
               "code": "FICTION"
             },
-            "publicationYear": {
-              "display": "2017"
-            },
+
             "materialTypes": [
               {
                 "specific": "bog"
@@ -648,7 +561,10 @@
               }
             ],
             "edition": {
-              "summary": "2. udgave, 11. oplag (2021)"
+              "summary": "2. udgave, 11. oplag (2021)",
+              "publicationYear": {
+                "display": "2017"
+              }
             },
             "audience": {
               "generalAudience": []
@@ -674,27 +590,17 @@
         ],
         "latest": {
           "pid": "870970-basis:46615743",
-          "genreAndForm": [
-            "slægtsromaner"
-          ],
-          "source": [
-            "Bibliotekskatalog"
-          ],
+          "genreAndForm": ["slægtsromaner"],
+          "source": ["Bibliotekskatalog"],
           "titles": {
-            "main": [
-              "De syv søstre"
-            ],
-            "original": [
-              "The seven sisters"
-            ]
+            "main": ["De syv søstre"],
+            "original": ["The seven sisters"]
           },
           "fictionNonfiction": {
             "display": "SKOENLITTERATUR",
             "code": "FICTION"
           },
-          "publicationYear": {
-            "display": "2019"
-          },
+
           "materialTypes": [
             {
               "specific": "bog"
@@ -725,7 +631,10 @@
             }
           ],
           "edition": {
-            "summary": "3. udgave, 1. oplag (2019)"
+            "summary": "3. udgave, 1. oplag (2019)",
+            "publicationYear": {
+              "display": "2019"
+            }
           },
           "audience": {
             "generalAudience": []

--- a/cypress/fixtures/material/infomedia-fbi-api.json
+++ b/cypress/fixtures/material/infomedia-fbi-api.json
@@ -27,7 +27,6 @@
               "display": "FAGLITTERATUR",
               "code": "NONFICTION"
             },
-            "publicationYear": { "display": "2013" },
             "materialTypes": [{ "specific": "avisartikel" }],
             "creators": [
               { "display": "Jakob Nielsen", "__typename": "Person" },
@@ -42,7 +41,9 @@
             "languages": { "main": [{ "display": "dansk" }] },
             "identifiers": [],
             "contributors": [],
-            "edition": null,
+            "edition": {
+              "publicationYear": { "display": "2013" }
+            },
             "audience": { "generalAudience": [] },
             "physicalDescriptions": [{ "numberOfPages": null }],
             "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
@@ -62,7 +63,6 @@
             "display": "FAGLITTERATUR",
             "code": "NONFICTION"
           },
-          "publicationYear": { "display": "2013" },
           "materialTypes": [{ "specific": "avisartikel" }],
           "creators": [
             { "display": "Jakob Nielsen", "__typename": "Person" },
@@ -77,7 +77,9 @@
           "languages": { "main": [{ "display": "dansk" }] },
           "identifiers": [],
           "contributors": [],
-          "edition": null,
+          "edition": {
+            "publicationYear": { "display": "2013" }
+          },
           "audience": { "generalAudience": [] },
           "physicalDescriptions": [{ "numberOfPages": null }],
           "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],

--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -19,14 +19,15 @@
               "display": "FAGLITTERATUR",
               "code": "NONFICTION"
             },
-            "publicationYear": { "display": "1946" },
             "materialTypes": [{ "specific": "periodikum" }],
             "creators": [],
             "hostPublication": null,
             "languages": { "main": [{ "display": "dansk" }] },
             "identifiers": [{ "value": "0002-6506" }],
             "contributors": [],
-            "edition": null,
+            "edition": {
+              "publicationYear": { "display": "1946" }
+            },
             "audience": { "generalAudience": [] },
             "physicalDescriptions": [],
             "accessTypes": [{ "code": "PHYSICAL" }],
@@ -46,14 +47,15 @@
             "display": "FAGLITTERATUR",
             "code": "NONFICTION"
           },
-          "publicationYear": { "display": "1946" },
           "materialTypes": [{ "specific": "periodikum" }],
           "creators": [],
           "hostPublication": null,
           "languages": { "main": [{ "display": "dansk" }] },
           "identifiers": [{ "value": "0002-6506" }],
           "contributors": [],
-          "edition": null,
+          "edition": {
+          "publicationYear": { "display": "1946" }
+          },
           "audience": { "generalAudience": [] },
           "physicalDescriptions": [],
           "accessTypes": [{ "code": "PHYSICAL" }],

--- a/cypress/fixtures/search-result/facet-browser/searchWithPagination.json
+++ b/cypress/fixtures/search-result/facet-browser/searchWithPagination.json
@@ -1,10770 +1,11577 @@
 {
   "data": {
-    "search": {
-      "hitcount": 703,
-      "works": [
-        {
-          "workId": "work-of:870970-basis:54129807",
-          "titles": {
-            "full": ["Harry : samtaler med prinsen"],
-            "original": []
-          },
-          "abstract": [
-            "Gennem samtaler gives et portræt af den engelske prins Harry. Der åbnes med forlovelsen mellem Harry (f. 1984) og Meghan Markle (f. 1981). Samtalerne kredser om de store emner i Harrys liv, bl.a. prinsesse Dianas alt for tidlige død"
-          ],
-          "creators": [
-            {
-              "display": "Angela Levin",
-              "__typename": "Person"
-            }
-          ],
-          "series": [],
-          "seriesMembers": [],
-          "genreAndForm": [],
-          "manifestations": {
-            "all": [
+      "search": {
+          "hitcount": 848,
+          "works": [
               {
-                "pid": "870970-basis:54129793",
-                "genreAndForm": ["biografier"],
-                "source": ["eReolen"],
-                "titles": {
-                  "main": ["Harry"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "ebog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Angela Levin",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788793681095"
+                  "workId": "work-of:870970-basis:54129807",
+                  "titles": {
+                      "full": [
+                          "Harry : samtaler med prinsen"
+                      ],
+                      "original": []
                   },
-                  {
-                    "value": "9788793681095"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Birgitte Brix"
-                  }
-                ],
-                "edition": {
-                  "summary": "1. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [],
-                "accessTypes": [
-                  {
-                    "code": "ONLINE"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "AccessUrl",
-                    "origin": "ereolen.dk",
-                    "url": "https://ereolen.dk/ting/object/870970-basis:54129793",
-                    "loginRequired": false
-                  },
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": false
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54129807",
-                "genreAndForm": ["biografier"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Angela Levin",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788793681088"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Birgitte Brix"
-                  }
-                ],
-                "edition": {
-                  "summary": "1. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54168446",
-                "genreAndForm": [],
-                "source": ["Netlydbog"],
-                "titles": {
-                  "main": ["Harry"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (net)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Angela Levin",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788793681132"
-                  },
-                  {
-                    "value": "9788793681132"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Randi Winther"
-                  },
-                  {
-                    "display": "Birgitte Brix"
-                  }
-                ],
-                "edition": {
-                  "summary": "2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "ONLINE"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "AccessUrl",
-                    "origin": "ereolen.dk",
-                    "url": "https://ereolen.dk/ting/object/870970-basis:54168446",
-                    "loginRequired": false
-                  },
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": false
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54175183",
-                "genreAndForm": [],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry (mp3)"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Angela Levin",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788793681231"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Randi Winther"
-                  },
-                  {
-                    "display": "Birgitte Brix"
-                  }
-                ],
-                "edition": {
-                  "summary": "2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:54129793",
-              "genreAndForm": ["biografier"],
-              "source": ["eReolen"],
-              "titles": {
-                "main": ["Harry"],
-                "original": ["Harry (engelsk)"]
-              },
-              "fictionNonfiction": {
-                "display": "faglitteratur",
-                "code": "NONFICTION"
-              },
-              "publicationYear": {
-                "display": "2018"
-              },
-              "materialTypes": [
-                {
-                  "specific": "ebog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Angela Levin",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "9788793681095"
-                },
-                {
-                  "value": "9788793681095"
-                }
-              ],
-              "contributors": [
-                {
-                  "display": "Birgitte Brix"
-                }
-              ],
-              "edition": {
-                "summary": "1. udgave, 2018"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [],
-              "accessTypes": [
-                {
-                  "code": "ONLINE"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "AccessUrl",
-                  "origin": "ereolen.dk",
-                  "url": "https://ereolen.dk/ting/object/870970-basis:54129793",
-                  "loginRequired": false
-                },
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": false
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:22629344",
-          "titles": {
-            "full": ["Harry Potter og de vises sten"],
-            "original": []
-          },
-          "abstract": [
-            "Flot og gennem-illustreret udgave af historien om Harry Potter, der har trolddomsblod i årerne og bliver elev på Hogwarts skole for magi. For både nye og gamle Harry Potter-fans fra 11 til 99 år og egnet til højtlæsning for børn fra ca. 8-9 år"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "1",
-                "number": [1]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": [
-            "roman",
-            "fantasy",
-            "eventyrlige fortællinger",
-            "patent"
-          ],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:22252852",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1998"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-34654-3"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1998"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:22441671",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2002"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-63162-0"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2002"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:22513354",
-                "genreAndForm": [],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-605-8571-4"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:22629344",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788700398368"
-                  },
-                  {
-                    "value": "87-00-39836-5"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23108283",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "punktskrift"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 100029"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23148048",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 13256"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Henrik Emmer"
-                  }
-                ],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23195151",
-                "genreAndForm": [],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten (Ved Henrik Emmer)"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-605-7377-5"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23819104",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2001"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "diskette"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. wp 400037"
-                  },
-                  {
-                    "value": "Best.nr. ascii 500037"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2001"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23862476",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten (2. udgave)"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2001"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "diskette"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. wp 400037"
-                  },
-                  {
-                    "value": "Best.nr. ascii 500037"
-                  },
-                  {
-                    "value": "Best.nr. html 600037"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2001"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:24168638",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og De Vises Sten (Ved Jesper Christensen)"
+                  "abstract": [
+                      "Gennem samtaler gives et portræt af den engelske prins Harry. Der åbnes med forlovelsen mellem Harry (f. 1984) og Meghan Markle (f. 1981). Samtalerne kredser om de store emner i Harrys liv, bl.a. prinsesse Dianas alt for tidlige død"
                   ],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2002"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-01276-6"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2002"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:24343081",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og De Vises Sten (Ved Jesper Christensen)"
+                  "creators": [
+                      {
+                          "display": "Angela Levin",
+                          "__typename": "Person"
+                      }
                   ],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2002"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
+                  "series": [],
+                  "seriesMembers": [],
+                  "genreAndForm": [],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:54129793",
+                              "genreAndForm": [
+                                  "biografier"
+                              ],
+                              "source": [
+                                  "eReolen"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry"
+                                  ],
+                                  "original": [
+                                      "Harry (engelsk)"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "faglitteratur",
+                                  "code": "NONFICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "ebog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Angela Levin",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788793681095"
+                                  },
+                                  {
+                                      "value": "9788793681095"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Birgitte Brix"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [],
+                              "accessTypes": [
+                                  {
+                                      "code": "ONLINE"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "AccessUrl",
+                                      "origin": "ereolen.dk",
+                                      "url": "https://ereolen.dk/ting/object/870970-basis:54129793",
+                                      "loginRequired": false
+                                  },
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": false
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54129807",
+                              "genreAndForm": [
+                                  "biografier"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry"
+                                  ],
+                                  "original": [
+                                      "Harry (engelsk)"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "faglitteratur",
+                                  "code": "NONFICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Angela Levin",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788793681088"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Birgitte Brix"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54168446",
+                              "genreAndForm": [],
+                              "source": [
+                                  "Netlydbog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry"
+                                  ],
+                                  "original": [
+                                      "Harry (engelsk)"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "faglitteratur",
+                                  "code": "NONFICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (net)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Angela Levin",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788793681132"
+                                  },
+                                  {
+                                      "value": "9788793681132"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Randi Winther"
+                                  },
+                                  {
+                                      "display": "Birgitte Brix"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "ONLINE"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "AccessUrl",
+                                      "origin": "ereolen.dk",
+                                      "url": "https://ereolen.dk/ting/object/870970-basis:54168446",
+                                      "loginRequired": false
+                                  },
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": false
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54175183",
+                              "genreAndForm": [],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry (mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry (engelsk)"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "faglitteratur",
+                                  "code": "NONFICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Angela Levin",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788793681231"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Randi Winther"
+                                  },
+                                  {
+                                      "display": "Birgitte Brix"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:54129793",
+                          "genreAndForm": [
+                              "biografier"
+                          ],
+                          "source": [
+                              "eReolen"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry"
+                              ],
+                              "original": [
+                                  "Harry (engelsk)"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "faglitteratur",
+                              "code": "NONFICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "ebog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Angela Levin",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "9788793681095"
+                              },
+                              {
+                                  "value": "9788793681095"
+                              }
+                          ],
+                          "contributors": [
+                              {
+                                  "display": "Birgitte Brix"
+                              }
+                          ],
+                          "edition": {
+                              "summary": "1. udgave, 2018",
+                              "publicationYear": {
+                                  "display": "2018"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [],
+                          "accessTypes": [
+                              {
+                                  "code": "ONLINE"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "AccessUrl",
+                                  "origin": "ereolen.dk",
+                                  "url": "https://ereolen.dk/ting/object/870970-basis:54129793",
+                                  "loginRequired": false
+                              },
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": false
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-69610-2"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "Bogklubudgave, 2002"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
               },
               {
-                "pid": "870970-basis:25194853",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-02769-0"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "3. udgave, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26178533",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788703011714"
+                  "workId": "work-of:870970-basis:22629344",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og de vises sten"
+                      ],
+                      "original": []
                   },
-                  {
-                    "value": "87-03-01171-2"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. bogklubudgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27638708",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og De Vises Sten (Ved Jesper Christensen, mp3)"
+                  "abstract": [
+                      "Flot og gennem-illustreret udgave af historien om Harry Potter, der har trolddomsblod i årerne og bliver elev på Hogwarts skole for magi. For både nye og gamle Harry Potter-fans fra 11 til 99 år og egnet til højtlæsning for børn fra ca. 8-9 år"
                   ],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075380"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29317038",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702113990"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:38289977",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og de vises sten (ill. MinaLima)"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2020"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702301588"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  },
-                  {
-                    "display": "MinaLima firma"
-                  }
-                ],
-                "edition": {
-                  "summary": "9. udgave, 2020"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:46018869",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2008"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788700774636"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Særudgave, 2008"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51980247",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og De Vises Sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173222"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6 udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51989252",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og de vises sten (ill. Jim Kay)"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702179859"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jim Kay"
-                  },
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "1. illustrerede udgave, 7. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54871910",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og de vises sten"],
-                  "original": ["Harry Potter and the philosopher's stone"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272451"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "8. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:22252852",
-              "genreAndForm": ["roman", "fantasy"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og De Vises Sten"],
-                "original": ["Harry Potter and the philosopher's stone"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "1998"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "87-00-34654-3"
-                }
-              ],
-              "contributors": [],
-              "edition": {
-                "summary": "1998"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:22995154",
-          "titles": {
-            "full": ["Harry Potter og fangen fra Azkaban"],
-            "original": []
-          },
-          "abstract": [
-            "Fantasy. Harry Potter er elev på trolddomsskolen på tredje år. Han får at vide, at hans forældres morder er flygtet fra Azkabanfængslet og nu også vil dræbe ham"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten.",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "3",
-                "number": [3]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "fantasy", "eventyrlige fortællinger"],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:22639862",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-39628-1"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "3. oplag, 2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:22843737",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-65233-4"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:22995154",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788700470460"
-                  },
-                  {
-                    "value": "87-00-47046-5"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23189151",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "punktskrift"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 100031"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23208903",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "diskette"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. wp 400039"
-                  },
-                  {
-                    "value": "Best.nr. ascii 500039"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23227932",
-                "genreAndForm": [],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban (I 1 mappe)"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-605-7334-1"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Torben Sekov"
-                  }
-                ],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23240769",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og fangen fra Azkaban (Ved Thomas Gulstad)"
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
                   ],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 13322"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Thomas Gulstad"
-                  }
-                ],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25197879",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-02771-2"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "3. udgave, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26178509",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788703011738"
-                  },
-                  {
-                    "value": "87-03-01173-9"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. bogklubudgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26239699",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og fangen fra Azkaban (Ved Jesper Christensen)"
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "1",
+                              "number": [
+                                  1
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
                   ],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-04791-8"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27639151",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og fangen fra Azkaban (Ved Jesper Christensen, mp3)"
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
                   ],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075403"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29317003",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702114348"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51980220",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173246"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:53516033",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban (ill. Jim Kay)"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2017"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702227888"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jim Kay"
-                  },
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2017"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54871945",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og fangen fra Azkaban"],
-                  "original": ["Harry Potter and the prisoner of Azkaban"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272468"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "8. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:22639862",
-              "genreAndForm": ["roman", "fantasy"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2000"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "87-00-39628-1"
-                }
-              ],
-              "contributors": [],
-              "edition": {
-                "summary": "3. oplag, 2000"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:25807995",
-          "titles": {
-            "full": ["Harry Potter og halvblodsprinsen"],
-            "original": []
-          },
-          "abstract": [
-            "Fantasy. Endnu en gang skal Harry Potter tilbage til troldmandsskolen Hogwart efter at have tilbragt nogle kedelige uger hos sin plejefamilie i Ligustervænget. Han glæder sig, men han ved heller ikke, hvilke uhyggelige oplevelser han har i vente"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten.",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "6",
-                "number": [6]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "eventyrlige fortællinger", "fantasy"],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:25771893",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2005"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-04498-6"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2005"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25807995",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2005"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-04122-7"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. udgave, 2005"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25998960",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2005"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "ebog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Masternr. 705275"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2005"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [],
-                "accessTypes": [
-                  {
-                    "code": "ONLINE"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "AccessUrl",
-                    "origin": "www.e17.dk",
-                    "url": "http://www.e17.dk/portalen/laeserum/findogbestil.aspx?pid=infoxml.e17&xml=705275",
-                    "loginRequired": false
-                  },
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": false
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26056829",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2005"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "punktskrift"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 105096"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2005"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26068053",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2005"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 16105"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Janek Lesniak"
-                  }
-                ],
-                "edition": {
-                  "summary": "2005"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26137276",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-03-01122-4"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26285240",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702048513"
-                  },
-                  {
-                    "value": "87-02-04851-5"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27639674",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen (mp3)"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075434"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29317100",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702114423"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "4. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51980212",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173277"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "1., i.e 5. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54872003",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og halvblodsprinsen"],
-                  "original": ["Harry Potter and the half-blood prince"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272499"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:25771893",
-              "genreAndForm": ["roman"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "original": ["Harry Potter and the half-blood prince"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2005"
-              },
-              "materialTypes": [
-                {
-                  "specific": "lydbog (cd)"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "87-02-04498-6"
-                }
-              ],
-              "contributors": [
-                {
-                  "display": "Jesper Christensen (f. 1948)"
-                }
-              ],
-              "edition": {
-                "summary": "2005"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:25245784",
-          "titles": {
-            "full": ["Harry Potter og Fønixordenen"],
-            "original": []
-          },
-          "abstract": [
-            "Fantasy. Da Harry Potter vender tilbage til Hogwarts er meget ændret. Man tror, at han lyver angående Voldemort, og ministeriet sender en repræsentant til skolen, der snart er delt i to fjendtlige lejre"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten.",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "5",
-                "number": [5]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "fantasy", "eventyrlige fortællinger"],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:134693959",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen (Ill. Jim Kay)"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2022"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702307566"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jim Kay"
-                  },
-                  {
-                    "display": "Neil Packer"
-                  },
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2022"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:24880605",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-02222-2"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:24973670",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 14948"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Mikkel Schou"
-                  }
-                ],
-                "edition": {
-                  "summary": "2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25040007",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "diskette"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. ascii 503142"
-                  },
-                  {
-                    "value": "Best.nr. html 603142"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25082427",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-03-00004-4"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25096517",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "punktskrift"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 103081"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25245784",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702029444"
-                  },
-                  {
-                    "value": "87-02-02944-8"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26167663",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-04746-2"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26470498",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788703014807"
-                  },
-                  {
-                    "value": "87-03-01480-0"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. bogklubudgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27639534",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen (mp3)"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075427"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29368872",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702114393"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "4. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51980204",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173260"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54871996",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272482"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:134693959",
-              "genreAndForm": ["roman", "fantasy"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen (Ill. Jim Kay)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2022"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "9788702307566"
-                }
-              ],
-              "contributors": [
-                {
-                  "display": "Jim Kay"
-                },
-                {
-                  "display": "Neil Packer"
-                },
-                {
-                  "display": "Hanna Lützen"
-                }
-              ],
-              "edition": {
-                "summary": "Illustreret udgave, 7. udgave, 2022"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:23540703",
-          "titles": {
-            "full": ["Harry Potter og Flammernes Pokal"],
-            "original": []
-          },
-          "abstract": [
-            "Fantasy. På mystisk vis er Harry Potter blevet udvalgt til at deltage i en magisk trekamp mellem de forskellige troldmandsskoler. Samtidig er hans dødsfjende troldmanden Voldemort ved at genvinde sin magt"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "4",
-                "number": [4]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "fantasy", "eventyrlige fortællinger"],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:23154382",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-00127-6"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23299453",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 13355"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Peter Krag"
-                  }
-                ],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23299976",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "punktskrift"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 100117"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23340682",
-                "genreAndForm": ["eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "diskette"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. wp 400183"
-                  },
-                  {
-                    "value": "Best.nr. ascii 501174"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23358875",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-67297-1"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23540703",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2001"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702002805"
-                  },
-                  {
-                    "value": "87-02-00280-9"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 2001"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25197909",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-02772-0"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "3. udgave, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26178487",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788703011745"
-                  },
-                  {
-                    "value": "87-03-01174-7"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. bogklubudgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26239710",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-04789-6"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27639240",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal (mp3)"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075410"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29317070",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702114362"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:47092183",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal (Ill. Jim Kay)"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702284799"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  },
-                  {
-                    "display": "Jim Kay"
-                  }
-                ],
-                "edition": {
-                  "summary": "Illustreret udgave, 8. udgave, 2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51980190",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173253"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54871953",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Flammernes Pokal"],
-                  "original": ["Harry Potter and the goblet of fire"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272475"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "7. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:23154382",
-              "genreAndForm": ["roman", "fantasy"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "original": ["Harry Potter and the goblet of fire"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2000"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "87-02-00127-6"
-                }
-              ],
-              "contributors": [],
-              "edition": {
-                "summary": "2000"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:27267912",
-          "titles": {
-            "full": ["Harry Potter og dødsregalierne"],
-            "original": []
-          },
-          "abstract": [
-            "Fantasy. Harry Potter er sammen med sine gode venner Ron og Hermione taget ud på en farlig færd. De skal finde den onde troldmand Voldemorts Horcruxer og ødelægge dem. Deres søgen bringer dem mange steder hen og ofte er de i livsfare. Men Voldemort og hans kumpaner er også på jagt efter de forsvundne Horcruxer"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten.",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "7",
-                "number": [7]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "fantasy", "eventyrlige fortællinger"],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:26917921",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2007"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702062281"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2007"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26931215",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2007"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702062311"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2007"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27267912",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2007"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702069990"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 2007"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27639798",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne (mp3)"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075441"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29316910",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702114430"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "4. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51979591",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173284"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54872186",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og dødsregalierne"],
-                  "original": ["Harry Potter and the deathly hallows"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272420"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:26917921",
-              "genreAndForm": ["roman", "fantasy"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "original": ["Harry Potter and the deathly hallows"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2007"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "9788702062281"
-                }
-              ],
-              "contributors": [],
-              "edition": {
-                "summary": "2007"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:22677780",
-          "titles": {
-            "full": ["Harry Potter og Hemmelighedernes Kammer"],
-            "original": []
-          },
-          "abstract": [
-            "Den 12-årige Harry Potter har trolddomsevner. Derfor er han blevet optaget på troldmandsskolen Hogwarts, som ligger i en parallelverden. Men nu indtræffer der uhyggelige og mystiske hændelser på troldmandsskolen"
-          ],
-          "creators": [
-            {
-              "display": "Joanne K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Harry Potter og De Vises Sten",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "2",
-                "number": [2]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864416",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22864459",
-              "titles": {
-                "main": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og Hemmelighedernes Kammer. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937766",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 2 (cd 5-8)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937774",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 3 (cd 9-11)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22937758",
-              "titles": {
-                "main": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "full": [
-                  "Harry Potter og fangen fra Azkaban. Mappe 1 (cd 1-4)"
-                ],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041308",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 1 (cd 1-12)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44041316",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "full": ["Harry Potter og Fønixordenen. Mappe 2 (cd 13-25)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065503",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 2 (cd 11-20)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27065325",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "full": ["Harry Potter og dødsregalierne. Mappe 1 (cd 1-10)"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "genreAndForm": [
-            "roman",
-            "fantasy",
-            "eventyrlige fortællinger",
-            "fra 11 år"
-          ],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:22375733",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-37264-1"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:22677780",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788700459946"
-                  },
-                  {
-                    "value": "87-00-45994-1"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23227886",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og Hemmelighedernes Kammer (I 1 mappe)"
+                  "genreAndForm": [
+                      "roman",
+                      "fantasy",
+                      "eventyrlige fortællinger",
+                      "patent"
                   ],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:22252852",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-34654-3"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1998",
+                                  "publicationYear": {
+                                      "display": "1998"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:22441671",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-63162-0"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. bogklubudgave, 2002",
+                                  "publicationYear": {
+                                      "display": "2002"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:22513354",
+                              "genreAndForm": [],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-605-8571-4"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:22629344",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788700398368"
+                                  },
+                                  {
+                                      "value": "87-00-39836-5"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23108283",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "punktskrift"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 100029"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23148048",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 13256"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Henrik Emmer"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23195151",
+                              "genreAndForm": [],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten (Ved Henrik Emmer)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-605-7377-5"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23819104",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "diskette"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. wp 400037"
+                                  },
+                                  {
+                                      "value": "Best.nr. ascii 500037"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2001",
+                                  "publicationYear": {
+                                      "display": "2001"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23862476",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten (2. udgave)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "diskette"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. wp 400037"
+                                  },
+                                  {
+                                      "value": "Best.nr. ascii 500037"
+                                  },
+                                  {
+                                      "value": "Best.nr. html 600037"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2001",
+                                  "publicationYear": {
+                                      "display": "2001"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:24168638",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten (Ved Jesper Christensen)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-01276-6"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2002",
+                                  "publicationYear": {
+                                      "display": "2002"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:24343081",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten (Ved Jesper Christensen)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-69610-2"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "Bogklubudgave, 2002",
+                                  "publicationYear": {
+                                      "display": "2002"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25194853",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-02769-0"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "3. udgave, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26178533",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788703011714"
+                                  },
+                                  {
+                                      "value": "87-03-01171-2"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. bogklubudgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27638708",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten (Ved Jesper Christensen, mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075380"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29317038",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702113990"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "5. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:38289977",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og de vises sten (ill. MinaLima)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702301588"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  },
+                                  {
+                                      "display": "MinaLima firma"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "9. udgave, 2020",
+                                  "publicationYear": {
+                                      "display": "2020"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:46018869",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788700774636"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "Særudgave, 2008",
+                                  "publicationYear": {
+                                      "display": "2008"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51980247",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og De Vises Sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173222"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6 udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51989252",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og de vises sten (ill. Jim Kay)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702179859"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jim Kay"
+                                  },
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1. illustrerede udgave, 7. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54871910",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og de vises sten"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272451"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "8. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:22252852",
+                          "genreAndForm": [
+                              "roman",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og De Vises Sten"
+                              ],
+                              "original": [
+                                  "Harry Potter and the philosopher's stone"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "87-00-34654-3"
+                              }
+                          ],
+                          "contributors": [],
+                          "edition": {
+                              "summary": "1998",
+                              "publicationYear": {
+                                  "display": "1998"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-605-8673-7"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Torben Sekov"
-                  }
-                ],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
               },
               {
-                "pid": "870970-basis:23257874",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2003"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-00-63796-3"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2003"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23264919",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "punktskrift"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 100030"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23368889",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2001"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "diskette"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. wp 400038"
+                  "workId": "work-of:870970-basis:22995154",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og fangen fra Azkaban"
+                      ],
+                      "original": []
                   },
-                  {
-                    "value": "Best.nr. ascii 500038"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2001"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:23403277",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2001"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 13321"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Ole Boesen"
-                  }
-                ],
-                "edition": {
-                  "summary": "2001"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25197887",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-02770-4"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "3. udgave, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25254031",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og Hemmelighedernes Kammer (Ved Jesper Christensen)"
+                  "abstract": [
+                      "Fantasy. Harry Potter er elev på trolddomsskolen på tredje år. Han får at vide, at hans forældres morder er flygtet fra Azkabanfængslet og nu også vil dræbe ham"
                   ],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "87-02-02780-1"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:26178479",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2006"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788703011721"
-                  },
-                  {
-                    "value": "87-03-01172-0"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. bogklubudgave, 2006"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:27639097",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og Hemmelighedernes Kammer (Ved Jesper Christensen, mp3)"
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
                   ],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2009"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702075397"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jesper Christensen (f. 1948)"
-                  }
-                ],
-                "edition": {
-                  "summary": "2009"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:29316945",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2012"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702114331"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2012"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51980239",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702173239"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "6. udgave, 2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:52652219",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og Hemmelighedernes Kammer (ill. Jim Kay)"
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten.",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "3",
+                              "number": [
+                                  3
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
                   ],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2016"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702204681"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jim Kay"
-                  },
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2016"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:54871929",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2018"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702272444"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  }
-                ],
-                "edition": {
-                  "summary": "8. udgave, 2018"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:61636935",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter og Hemmelighedernes Kammer (Ill. MinaLima)"
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
                   ],
-                  "original": ["Harry Potter and the Chamber of Secrets"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2021"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788702319361"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Hanna Lützen"
-                  },
-                  {
-                    "display": "MinaLima firma"
-                  }
-                ],
-                "edition": {
-                  "summary": "9. udgave, 2021"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:22375733",
-              "genreAndForm": ["roman", "fantasy"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "1999"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "87-00-37264-1"
-                }
-              ],
-              "contributors": [],
-              "edition": {
-                "summary": "1999"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:42042455",
-          "titles": {
-            "full": ["Harry Potter and the Philosopher's Stone: Ill. Jim Kay"],
-            "original": []
-          },
-          "abstract": [],
-          "creators": [
-            {
-              "display": "J.K. Rowling",
-              "__typename": "Person"
-            }
-          ],
-          "series": [],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:61587659",
-              "titles": {
-                "main": ["Harry Potter and the half-blood prince"],
-                "full": ["Harry Potter and the half-blood prince"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45481050",
-              "titles": {
-                "main": ["Harry Potter & the philosopher's stone"],
-                "full": ["Harry Potter & the philosopher's stone"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:42042455",
-              "titles": {
-                "main": [
-                  "Harry Potter and the Philosopher's Stone: Ill. Jim Kay"
-                ],
-                "full": [
-                  "Harry Potter and the Philosopher's Stone: Ill. Jim Kay"
-                ],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:61429204",
-              "titles": {
-                "main": ["Harry Potter and the chamber of secrets"],
-                "full": ["Harry Potter and the chamber of secrets"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45483924",
-              "titles": {
-                "main": ["Harry Potter & the chamber of secrets"],
-                "full": ["Harry Potter & the chamber of secrets"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:43078607",
-              "titles": {
-                "main": ["Harry Potter and the Chamber of Secrets"],
-                "full": ["Harry Potter and the Chamber of Secrets"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45483916",
-              "titles": {
-                "main": ["Harry Potter & the prisoner of Azkaban"],
-                "full": ["Harry Potter & the prisoner of Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23346346",
-              "titles": {
-                "main": ["Harry Potter and the prisoner of Azkaban"],
-                "full": ["Harry Potter and the prisoner of Azkaban"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:42242098",
-              "titles": {
-                "main": ["Harry Potter and the goblet of fire"],
-                "full": ["Harry Potter and the goblet of fire"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45481042",
-              "titles": {
-                "main": ["Harry Potter & the goblet of fire"],
-                "full": ["Harry Potter & the goblet of fire"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44124653",
-              "titles": {
-                "main": [
-                  "Harry Potter and the Order of the Phoenix. Mappe 1 (cd 1-12)"
-                ],
-                "full": [
-                  "Harry Potter and the Order of the Phoenix. Mappe 1 (cd 1-12)"
-                ],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45481026",
-              "titles": {
-                "main": ["Harry Potter & the order of the Phoenix"],
-                "full": ["Harry Potter & the order of the Phoenix"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:43167669",
-              "titles": {
-                "main": ["Harry Potter and the order of the Phoenix"],
-                "full": ["Harry Potter and the order of the Phoenix"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:44124661",
-              "titles": {
-                "main": [
-                  "Harry Potter and the Order of the Phoenix. Mappe 2 (cd 13-24)"
-                ],
-                "full": [
-                  "Harry Potter and the Order of the Phoenix. Mappe 2 (cd 13-24)"
-                ],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25602560",
-              "titles": {
-                "main": ["Harry Potter and the half-blood prince"],
-                "full": ["Harry Potter and the half-blood prince"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45481085",
-              "titles": {
-                "main": ["Harry Potter & the half-blood prince"],
-                "full": ["Harry Potter & the half-blood prince"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:45483932",
-              "titles": {
-                "main": ["Harry Potter & the deathly hallows"],
-                "full": ["Harry Potter & the deathly hallows"],
-                "original": []
-              }
-            },
-            {
-              "workId": "work-of:776000-katalog:110342519",
-              "titles": {
-                "main": ["Harry Potter and the deathly hallows"],
-                "full": ["Harry Potter and the deathly hallows"],
-                "original": []
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "eventyrlige fortællinger", "fantasy"],
-          "manifestations": {
-            "all": [
-              {
-                "pid": "870970-basis:23353873",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-4572-3"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Special edition, 1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:24047520",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2002"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "1-85549-860-X"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Stephen Fry"
-                  }
-                ],
-                "edition": {
-                  "summary": "DBC (dist.), 2002"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:25699815",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2005"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Best.nr. 15613"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Stephen Fry"
-                  }
-                ],
-                "edition": {
-                  "summary": "2005"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:28090757",
-                "genreAndForm": ["eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-7447-2"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Paperback edition, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:42042455",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1997"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-5362-9"
-                  },
-                  {
-                    "value": "0-7475-3269-9"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1997"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:42118982",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (bånd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "1-85549-860-X"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Stephen Fry"
-                  }
-                ],
-                "edition": {
-                  "summary": "1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:42235504",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "1-85549-670-4"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Stephen Fry"
-                  }
-                ],
-                "edition": {
-                  "summary": "1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:42388173",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1997"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-3274-5"
-                  },
-                  {
-                    "value": "0-7475-5701-2"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Bloomsbury, New pbk. edition 1997, 1997"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:42793825",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2001"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-5819-1"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Bloomsbury, New edition 2001, 2001"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:42810215",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-4955-9"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:43072994",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1998"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-6000-5"
-                  },
-                  {
-                    "value": "0-7475-4298-8"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "1998"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:43903977",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter and the philosopher's stone (Ved Stephen Fry)"
+                  "genreAndForm": [
+                      "roman",
+                      "fantasy",
+                      "eventyrlige fortællinger"
                   ],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:22639862",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-39628-1"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "3. oplag, 2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:22843737",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-65233-4"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. bogklubudgave, 2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:22995154",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788700470460"
+                                  },
+                                  {
+                                      "value": "87-00-47046-5"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23189151",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "punktskrift"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 100031"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23208903",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "diskette"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. wp 400039"
+                                  },
+                                  {
+                                      "value": "Best.nr. ascii 500039"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23227932",
+                              "genreAndForm": [],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban (I 1 mappe)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-605-7334-1"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Torben Sekov"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23240769",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban (Ved Thomas Gulstad)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 13322"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Thomas Gulstad"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25197879",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-02771-2"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "3. udgave, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26178509",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788703011738"
+                                  },
+                                  {
+                                      "value": "87-03-01173-9"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. bogklubudgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26239699",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban (Ved Jesper Christensen)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-04791-8"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27639151",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban (Ved Jesper Christensen, mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075403"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29317003",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702114348"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "5. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51980220",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173246"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:53516033",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban (ill. Jim Kay)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702227888"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jim Kay"
+                                  },
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "Illustreret udgave, 7. udgave, 2017",
+                                  "publicationYear": {
+                                      "display": "2017"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54871945",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og fangen fra Azkaban"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the prisoner of Azkaban"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272468"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "8. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:22639862",
+                          "genreAndForm": [
+                              "roman",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": [
+                                  "Harry Potter and the prisoner of Azkaban"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "87-00-39628-1"
+                              }
+                          ],
+                          "contributors": [],
+                          "edition": {
+                              "summary": "3. oplag, 2000",
+                              "publicationYear": {
+                                  "display": "2000"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "1-85549-631-3"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Stephen Fry"
-                  }
-                ],
-                "edition": {
-                  "summary": "2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
               },
               {
-                "pid": "870970-basis:44227843",
-                "genreAndForm": [
-                  "roman",
-                  "eventyrlige fortællinger",
-                  "fantasy"
-                ],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2000"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9780747532699"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Bloomsbury, New edition 2000, 2000"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:44513323",
-                "genreAndForm": ["eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "0-7475-7360-3"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Adult edition, 2004"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:44815702",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter and the philosopher's stone (Ved Stephen Fry)"
+                  "workId": "work-of:870970-basis:25245784",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og Fønixordenen"
+                      ],
+                      "original": []
+                  },
+                  "abstract": [
+                      "Fantasy. Da Harry Potter vender tilbage til Hogwarts er meget ændret. Man tror, at han lyver angående Voldemort, og ministeriet sender en repræsentant til skolen, der snart er delt i to fjendtlige lejre"
                   ],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9781907545016"
-                  },
-                  {
-                    "value": "9781907545009"
-                  },
-                  {
-                    "value": "9781408882221"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Stephen Fry"
-                  }
-                ],
-                "edition": {
-                  "summary": "HNP, 1999"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:44931885",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2010"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9781408810545"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Signature edition, 2010"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:45654222",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Harry Potter and the philosopher's stone"],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2014"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9781408855652"
-                  },
-                  {
-                    "value": "9781408855898"
-                  }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "Bloomsbury, new edition 2014, 2014"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:51811925",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": [
-                    "Harry Potter and the Philosopher's Stone (Ill. Jim Kay)"
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
                   ],
-                  "original": []
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2015"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten.",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "5",
+                              "number": [
+                                  5
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
+                  ],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "roman",
+                      "fantasy",
+                      "eventyrlige fortællinger"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:134693959",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen (Ill. Jim Kay)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702307566"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jim Kay"
+                                  },
+                                  {
+                                      "display": "Neil Packer"
+                                  },
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "Illustreret udgave, 7. udgave, 2022",
+                                  "publicationYear": {
+                                      "display": "2022"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:24880605",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-02222-2"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:24973670",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 14948"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Mikkel Schou"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25040007",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "diskette"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. ascii 503142"
+                                  },
+                                  {
+                                      "value": "Best.nr. html 603142"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25082427",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-03-00004-4"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. bogklubudgave, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25096517",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "punktskrift"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 103081"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25245784",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702029444"
+                                  },
+                                  {
+                                      "value": "87-02-02944-8"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26167663",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-04746-2"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26470498",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788703014807"
+                                  },
+                                  {
+                                      "value": "87-03-01480-0"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. bogklubudgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27639534",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen (mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075427"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29368872",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702114393"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "4. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51980204",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173260"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "5. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54871996",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Fønixordenen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Order of the Phoenix"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272482"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:134693959",
+                          "genreAndForm": [
+                              "roman",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen (Ill. Jim Kay)"
+                              ],
+                              "original": [
+                                  "Harry Potter and the Order of the Phoenix"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "9788702307566"
+                              }
+                          ],
+                          "contributors": [
+                              {
+                                  "display": "Jim Kay"
+                              },
+                              {
+                                  "display": "Neil Packer"
+                              },
+                              {
+                                  "display": "Hanna Lützen"
+                              }
+                          ],
+                          "edition": {
+                              "summary": "Illustreret udgave, 7. udgave, 2022",
+                              "publicationYear": {
+                                  "display": "2022"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "creators": [
-                  {
-                    "display": "Joanne K. Rowling",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "engelsk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9781408845646"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Jim Kay"
-                  }
-                ],
-                "edition": {
-                  "summary": "2015"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              }
-            ],
-            "latest": {
-              "pid": "870970-basis:23353873",
-              "genreAndForm": ["roman"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Harry Potter and the philosopher's stone"],
-                "original": []
               },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "1999"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Joanne K. Rowling",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "engelsk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "0-7475-4572-3"
-                }
-              ],
-              "contributors": [],
-              "edition": {
-                "summary": "Special edition, 1999"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        },
-        {
-          "workId": "work-of:870970-basis:46510534",
-          "titles": {
-            "full": ["Kniv"],
-            "original": ["Kniv (norsk)"]
-          },
-          "abstract": [
-            "I Oslo vågner den karismatiske politimand Harry Hole op efter en brandert med blod på tøjet. Et medlem af hans nærmeste familie er blevet knivdræbt, men kan Harry have noget med det at gøre? Selv husker han intet."
-          ],
-          "creators": [
-            {
-              "display": "Jo Nesbø",
-              "__typename": "Person"
-            }
-          ],
-          "series": [
-            {
-              "title": "Krimiserien med Harry Hole",
-              "isPopular": null,
-              "numberInSeries": {
-                "display": "12",
-                "number": [12]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:46510534",
-              "titles": {
-                "main": ["Kniv"],
-                "full": ["Kniv"],
-                "original": ["Kniv (norsk)"]
-              }
-            }
-          ],
-          "genreAndForm": ["roman", "krimi"],
-          "manifestations": {
-            "all": [
               {
-                "pid": "870970-basis:38519395",
-                "genreAndForm": ["roman", "krimi", "romaner"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2020"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770073851"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Allan Hilton Andersen"
-                  }
-                ],
-                "edition": {
-                  "summary": "5. udgave, 2020"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:38519883",
-                "genreAndForm": ["roman", "krimi", "romaner"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2020"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770073844"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Allan Hilton Andersen"
-                  }
-                ],
-                "edition": {
-                  "summary": "4. udgave, 2020"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:46510534",
-                "genreAndForm": ["roman", "krimi"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770071529"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Allan Hilton Andersen"
-                  }
-                ],
-                "edition": {
-                  "summary": "1. udgave, 2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:46551931",
-                "genreAndForm": ["roman", "krimi"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "ebog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770071987"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Allan Hilton Andersen"
-                  }
-                ],
-                "edition": {
-                  "summary": "1. udgave, 2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [],
-                "accessTypes": [
-                  {
-                    "code": "ONLINE"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": false
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:46821939",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv (mp3)"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd-mp3)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770071710"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Bent Otto Hansen"
+                  "workId": "work-of:870970-basis:25807995",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og halvblodsprinsen"
+                      ],
+                      "original": []
                   },
-                  {
-                    "display": "Allan Hilton Andersen"
+                  "abstract": [
+                      "Fantasy. Endnu en gang skal Harry Potter tilbage til troldmandsskolen Hogwart efter at have tilbragt nogle kedelige uger hos sin plejefamilie i Ligustervænget. Han glæder sig, men han ved heller ikke, hvilke uhyggelige oplevelser han har i vente"
+                  ],
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten.",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "6",
+                              "number": [
+                                  6
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
+                  ],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "roman",
+                      "eventyrlige fortællinger",
+                      "fantasy"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:25771893",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-04498-6"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2005",
+                                  "publicationYear": {
+                                      "display": "2005"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25807995",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-04122-7"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. udgave, 2005",
+                                  "publicationYear": {
+                                      "display": "2005"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25998960",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "ebog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Masternr. 705275"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2005",
+                                  "publicationYear": {
+                                      "display": "2005"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [],
+                              "accessTypes": [
+                                  {
+                                      "code": "ONLINE"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "AccessUrl",
+                                      "origin": "www.e17.dk",
+                                      "url": "http://www.e17.dk/portalen/laeserum/findogbestil.aspx?pid=infoxml.e17&xml=705275",
+                                      "loginRequired": false
+                                  },
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": false
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26056829",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "punktskrift"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 105096"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2005",
+                                  "publicationYear": {
+                                      "display": "2005"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26068053",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 16105"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Janek Lesniak"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2005",
+                                  "publicationYear": {
+                                      "display": "2005"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26137276",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-03-01122-4"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. bogklubudgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26285240",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702048513"
+                                  },
+                                  {
+                                      "value": "87-02-04851-5"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27639674",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen (mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075434"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29317100",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702114423"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "4. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51980212",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173277"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1., i.e 5. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54872003",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og halvblodsprinsen"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the half-blood prince"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272499"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:25771893",
+                          "genreAndForm": [
+                              "roman"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": [
+                                  "Harry Potter and the half-blood prince"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "lydbog (cd)"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "87-02-04498-6"
+                              }
+                          ],
+                          "contributors": [
+                              {
+                                  "display": "Jesper Christensen (f. 1948)"
+                              }
+                          ],
+                          "edition": {
+                              "summary": "2005",
+                              "publicationYear": {
+                                  "display": "2005"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "edition": {
-                  "summary": "2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
               },
               {
-                "pid": "870970-basis:46822161",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (cd)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770071703"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Bent Otto Hansen"
+                  "workId": "work-of:870970-basis:22677780",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og Hemmelighedernes Kammer"
+                      ],
+                      "original": []
                   },
-                  {
-                    "display": "Allan Hilton Andersen"
+                  "abstract": [
+                      "Den 12-årige Harry Potter har trolddomsevner. Derfor er han blevet optaget på troldmandsskolen Hogwarts, som ligger i en parallelverden. Men nu indtræffer der uhyggelige og mystiske hændelser på troldmandsskolen"
+                  ],
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "2",
+                              "number": [
+                                  2
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
+                  ],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "roman",
+                      "fantasy",
+                      "eventyrlige fortællinger",
+                      "fra 11 år"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:22375733",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-37264-1"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:22677780",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788700459946"
+                                  },
+                                  {
+                                      "value": "87-00-45994-1"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23227886",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer (I 1 mappe)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-605-8673-7"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Torben Sekov"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23257874",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-63796-3"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. bogklubudgave, 2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23264919",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "punktskrift"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 100030"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23368889",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "diskette"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. wp 400038"
+                                  },
+                                  {
+                                      "value": "Best.nr. ascii 500038"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2001",
+                                  "publicationYear": {
+                                      "display": "2001"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23403277",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 13321"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Ole Boesen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2001",
+                                  "publicationYear": {
+                                      "display": "2001"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25197887",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-02770-4"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "3. udgave, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25254031",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer (Ved Jesper Christensen)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-02780-1"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26178479",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788703011721"
+                                  },
+                                  {
+                                      "value": "87-03-01172-0"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. bogklubudgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27639097",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer (Ved Jesper Christensen, mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075397"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29316945",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702114331"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "5. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51980239",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173239"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:52652219",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer (ill. Jim Kay)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702204681"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jim Kay"
+                                  },
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "Illustreret udgave, 7. udgave, 2016",
+                                  "publicationYear": {
+                                      "display": "2016"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54871929",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272444"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "8. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:61636935",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Hemmelighedernes Kammer (Ill. MinaLima)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the Chamber of Secrets"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702319361"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  },
+                                  {
+                                      "display": "MinaLima firma"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "9. udgave, 2021",
+                                  "publicationYear": {
+                                      "display": "2021"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:22375733",
+                          "genreAndForm": [
+                              "roman",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": [
+                                  "Harry Potter and the Chamber of Secrets"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "87-00-37264-1"
+                              }
+                          ],
+                          "contributors": [],
+                          "edition": {
+                              "summary": "1999",
+                              "publicationYear": {
+                                  "display": "1999"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "edition": {
-                  "summary": "2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
               },
               {
-                "pid": "870970-basis:47090377",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788703090955"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Allan Hilton Andersen"
-                  }
-                ],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "PHYSICAL"
-                  }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": true
-                  }
-                ],
-                "shelfmark": null
-              },
-              {
-                "pid": "870970-basis:48026656",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "titles": {
-                  "main": ["Kniv"],
-                  "original": ["Kniv (norsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2019"
-                },
-                "materialTypes": [
-                  {
-                    "specific": "lydbog (net)"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Jo Nesbø",
-                    "__typename": "Person"
-                  }
-                ],
-                "hostPublication": null,
-                "languages": {
-                  "main": [
-                    {
-                      "display": "dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "9788770071697"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Bent Otto Hansen"
+                  "workId": "work-of:870970-basis:23540703",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og Flammernes Pokal"
+                      ],
+                      "original": []
                   },
-                  {
-                    "display": "Allan Hilton Andersen"
+                  "abstract": [
+                      "Fantasy. På mystisk vis er Harry Potter blevet udvalgt til at deltage i en magisk trekamp mellem de forskellige troldmandsskoler. Samtidig er hans dødsfjende troldmanden Voldemort ved at genvinde sin magt"
+                  ],
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "4",
+                              "number": [
+                                  4
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
+                  ],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "roman",
+                      "fantasy",
+                      "eventyrlige fortællinger"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:23154382",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-00127-6"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23299453",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 13355"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Peter Krag"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23299976",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "punktskrift"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 100117"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23340682",
+                              "genreAndForm": [
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "diskette"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. wp 400183"
+                                  },
+                                  {
+                                      "value": "Best.nr. ascii 501174"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23358875",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-00-67297-1"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1. bogklubudgave, 2003",
+                                  "publicationYear": {
+                                      "display": "2003"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23540703",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702002805"
+                                  },
+                                  {
+                                      "value": "87-02-00280-9"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 2001",
+                                  "publicationYear": {
+                                      "display": "2001"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25197909",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-02772-0"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "3. udgave, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26178487",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788703011745"
+                                  },
+                                  {
+                                      "value": "87-03-01174-7"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. bogklubudgave, 2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26239710",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "87-02-04789-6"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2006",
+                                  "publicationYear": {
+                                      "display": "2006"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27639240",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal (mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075410"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29317070",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702114362"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "5. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:47092183",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal (Ill. Jim Kay)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702284799"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  },
+                                  {
+                                      "display": "Jim Kay"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "Illustreret udgave, 8. udgave, 2019",
+                                  "publicationYear": {
+                                      "display": "2019"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51980190",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173253"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54871953",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og Flammernes Pokal"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the goblet of fire"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272475"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "7. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:23154382",
+                          "genreAndForm": [
+                              "roman",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": [
+                                  "Harry Potter and the goblet of fire"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "87-02-00127-6"
+                              }
+                          ],
+                          "contributors": [],
+                          "edition": {
+                              "summary": "2000",
+                              "publicationYear": {
+                                  "display": "2000"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "edition": {
-                  "summary": "2019"
-                },
-                "audience": {
-                  "generalAudience": []
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
+              },
+              {
+                  "workId": "work-of:870970-basis:27267912",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og dødsregalierne"
+                      ],
+                      "original": []
+                  },
+                  "abstract": [
+                      "Fantasy. Harry Potter er sammen med sine gode venner Ron og Hermione taget ud på en farlig færd. De skal finde den onde troldmand Voldemorts Horcruxer og ødelægge dem. Deres søgen bringer dem mange steder hen og ofte er de i livsfare. Men Voldemort og hans kumpaner er også på jagt efter de forsvundne Horcruxer"
+                  ],
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten.",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "7",
+                              "number": [
+                                  7
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
+                  ],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "roman",
+                      "fantasy",
+                      "eventyrlige fortællinger"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:26917921",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702062281"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2007",
+                                  "publicationYear": {
+                                      "display": "2007"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:26931215",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702062311"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2007",
+                                  "publicationYear": {
+                                      "display": "2007"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27267912",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702069990"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2. udgave, 2007",
+                                  "publicationYear": {
+                                      "display": "2007"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:27639798",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne (mp3)"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd-mp3)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702075441"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jesper Christensen (f. 1948)"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2009",
+                                  "publicationYear": {
+                                      "display": "2009"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:29316910",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702114430"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "4. udgave, 2012",
+                                  "publicationYear": {
+                                      "display": "2012"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51979591",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702173284"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "5. udgave, 2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:54872186",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og dødsregalierne"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the deathly hallows"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702272420"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "6. udgave, 2018",
+                                  "publicationYear": {
+                                      "display": "2018"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:26917921",
+                          "genreAndForm": [
+                              "roman",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": [
+                                  "Harry Potter and the deathly hallows"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "9788702062281"
+                              }
+                          ],
+                          "contributors": [],
+                          "edition": {
+                              "summary": "2007",
+                              "publicationYear": {
+                                  "display": "2007"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "accessTypes": [
-                  {
-                    "code": "ONLINE"
+              },
+              {
+                  "workId": "work-of:870970-basis:52646251",
+                  "titles": {
+                      "full": [
+                          "Harry Potter og det forbandede barn : del et & to"
+                      ],
+                      "original": [
+                          "Harry Potter and the cursed child"
+                      ]
+                  },
+                  "abstract": [
+                      "Fantasy. 19 år er gået siden slaget om Hogwarts. Harry Potter er blevet voksen og far til 3 børn. Ved hjælp af en forbudt Tidsvender, rejser Harrys søn Albus og Albus' bedste ven Scorpius Malfoy, ud på en farlig tidsrejse. En rejse der får fortid og nutid til at smelte ildevarslende sammen"
+                  ],
+                  "creators": [
+                      {
+                          "display": "Joanne K. Rowling",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "series": [
+                      {
+                          "title": "Harry Potter og De Vises Sten",
+                          "isPopular": null,
+                          "numberInSeries": {
+                              "display": "8",
+                              "number": [
+                                  8
+                              ]
+                          },
+                          "readThisFirst": null,
+                          "readThisWhenever": null
+                      }
+                  ],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:22629344",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "full": [
+                                  "Harry Potter og de vises sten"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22677780",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "full": [
+                                  "Harry Potter og Hemmelighedernes Kammer"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:22995154",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter og fangen fra Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23540703",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "full": [
+                                  "Harry Potter og Flammernes Pokal"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25245784",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "full": [
+                                  "Harry Potter og Fønixordenen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25807995",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "full": [
+                                  "Harry Potter og halvblodsprinsen"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:27267912",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "full": [
+                                  "Harry Potter og dødsregalierne"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52646251",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "full": [
+                                  "Harry Potter og det forbandede barn : del et & to"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796199",
+                          "titles": {
+                              "main": [
+                                  "Hermione Granger"
+                              ],
+                              "full": [
+                                  "Hermione Granger : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796202",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter"
+                              ],
+                              "full": [
+                                  "Harry Potter : Harry Potter"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:52796180",
+                          "titles": {
+                              "main": [
+                                  "Ron Weasley"
+                              ],
+                              "full": [
+                                  "Ron Weasley : filmguide"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:53232590",
+                          "titles": {
+                              "main": [
+                                  "Hogwarts"
+                              ],
+                              "full": [
+                                  "Hogwarts : de fire kollegier : filmguide"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "dramatik",
+                      "fantasy"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:52646251",
+                              "genreAndForm": [
+                                  "dramatik",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter og det forbandede barn"
+                                  ],
+                                  "original": [
+                                      "Harry Potter and the cursed child"
+                                  ]
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "dansk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9788702215694"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Hanna Lützen"
+                                  },
+                                  {
+                                      "display": "Mette Nejmann"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1. udgave af manuskriptbogen, 2016",
+                                  "publicationYear": {
+                                      "display": "2016"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:52646251",
+                          "genreAndForm": [
+                              "dramatik",
+                              "fantasy"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter og det forbandede barn"
+                              ],
+                              "original": [
+                                  "Harry Potter and the cursed child"
+                              ]
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "dansk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "9788702215694"
+                              }
+                          ],
+                          "contributors": [
+                              {
+                                  "display": "Hanna Lützen"
+                              },
+                              {
+                                  "display": "Mette Nejmann"
+                              }
+                          ],
+                          "edition": {
+                              "summary": "1. udgave af manuskriptbogen, 2016",
+                              "publicationYear": {
+                                  "display": "2016"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "access": [
-                  {
-                    "__typename": "InterLibraryLoan",
-                    "loanIsPossible": false
+              },
+              {
+                  "workId": "work-of:870970-basis:42042455",
+                  "titles": {
+                      "full": [
+                          "Harry Potter and the Philosopher's Stone: Ill. Jim Kay"
+                      ],
+                      "original": []
+                  },
+                  "abstract": [],
+                  "creators": [
+                      {
+                          "display": "J.K. Rowling",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "series": [],
+                  "seriesMembers": [
+                      {
+                          "workId": "work-of:870970-basis:61587659",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the half-blood prince"
+                              ],
+                              "full": [
+                                  "Harry Potter and the half-blood prince"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45481050",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the philosopher's stone"
+                              ],
+                              "full": [
+                                  "Harry Potter & the philosopher's stone"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:42042455",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the Philosopher's Stone: Ill. Jim Kay"
+                              ],
+                              "full": [
+                                  "Harry Potter and the Philosopher's Stone: Ill. Jim Kay"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:61429204",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the chamber of secrets"
+                              ],
+                              "full": [
+                                  "Harry Potter and the chamber of secrets"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45483924",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the chamber of secrets"
+                              ],
+                              "full": [
+                                  "Harry Potter & the chamber of secrets"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:43078607",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the Chamber of Secrets"
+                              ],
+                              "full": [
+                                  "Harry Potter and the Chamber of Secrets"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45483916",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the prisoner of Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter & the prisoner of Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:23346346",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the prisoner of Azkaban"
+                              ],
+                              "full": [
+                                  "Harry Potter and the prisoner of Azkaban"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:42242098",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the goblet of fire"
+                              ],
+                              "full": [
+                                  "Harry Potter and the goblet of fire"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45481042",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the goblet of fire"
+                              ],
+                              "full": [
+                                  "Harry Potter & the goblet of fire"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:44124653",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the Order of the Phoenix. Mappe 1 (cd 1-12)"
+                              ],
+                              "full": [
+                                  "Harry Potter and the Order of the Phoenix. Mappe 1 (cd 1-12)"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45481026",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the order of the Phoenix"
+                              ],
+                              "full": [
+                                  "Harry Potter & the order of the Phoenix"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:43167669",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the order of the Phoenix"
+                              ],
+                              "full": [
+                                  "Harry Potter and the order of the Phoenix"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:44124661",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the Order of the Phoenix. Mappe 2 (cd 13-24)"
+                              ],
+                              "full": [
+                                  "Harry Potter and the Order of the Phoenix. Mappe 2 (cd 13-24)"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:25602560",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the half-blood prince"
+                              ],
+                              "full": [
+                                  "Harry Potter and the half-blood prince"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45481085",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the half-blood prince"
+                              ],
+                              "full": [
+                                  "Harry Potter & the half-blood prince"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:870970-basis:45483932",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter & the deathly hallows"
+                              ],
+                              "full": [
+                                  "Harry Potter & the deathly hallows"
+                              ],
+                              "original": []
+                          }
+                      },
+                      {
+                          "workId": "work-of:776000-katalog:110342519",
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the deathly hallows"
+                              ],
+                              "full": [
+                                  "Harry Potter and the deathly hallows"
+                              ],
+                              "original": []
+                          }
+                      }
+                  ],
+                  "genreAndForm": [
+                      "roman",
+                      "eventyrlige fortællinger",
+                      "fantasy"
+                  ],
+                  "manifestations": {
+                      "all": [
+                          {
+                              "pid": "870970-basis:134987766",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9781526646651"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2022",
+                                  "publicationYear": {
+                                      "display": "2022"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:23353873",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-4572-3"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Special edition, 1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:24047520",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "1-85549-860-X"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Stephen Fry"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "DBC (dist.), 2002",
+                                  "publicationYear": {
+                                      "display": "2002"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:25699815",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "Best.nr. 15613"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Stephen Fry"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2005",
+                                  "publicationYear": {
+                                      "display": "2005"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:28090757",
+                              "genreAndForm": [
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-7447-2"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Paperback edition, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:42042455",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-5362-9"
+                                  },
+                                  {
+                                      "value": "0-7475-3269-9"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1997",
+                                  "publicationYear": {
+                                      "display": "1997"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:42118982",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (bånd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "1-85549-860-X"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Stephen Fry"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:42235504",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "1-85549-670-4"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Stephen Fry"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:42388173",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-3274-5"
+                                  },
+                                  {
+                                      "value": "0-7475-5701-2"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Bloomsbury, New pbk. edition 1997, 1997",
+                                  "publicationYear": {
+                                      "display": "1997"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:42793825",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-5819-1"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Bloomsbury, New edition 2001, 2001",
+                                  "publicationYear": {
+                                      "display": "2001"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:42810215",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-4955-9"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:43072994",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-6000-5"
+                                  },
+                                  {
+                                      "value": "0-7475-4298-8"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "1998",
+                                  "publicationYear": {
+                                      "display": "1998"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:43903977",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone (Ved Stephen Fry)"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "1-85549-631-3"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Stephen Fry"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:44227843",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9780747532699"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Bloomsbury, New edition 2000, 2000",
+                                  "publicationYear": {
+                                      "display": "2000"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:44513323",
+                              "genreAndForm": [
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "0-7475-7360-3"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Adult edition, 2004",
+                                  "publicationYear": {
+                                      "display": "2004"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:44815702",
+                              "genreAndForm": [
+                                  "roman"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone (Ved Stephen Fry)"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "lydbog (cd)"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9781907545016"
+                                  },
+                                  {
+                                      "value": "9781907545009"
+                                  },
+                                  {
+                                      "value": "9781408882221"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Stephen Fry"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "HNP, 1999",
+                                  "publicationYear": {
+                                      "display": "1999"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:44931885",
+                              "genreAndForm": [
+                                  "roman",
+                                  "eventyrlige fortællinger"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9781408810545"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Signature edition, 2010",
+                                  "publicationYear": {
+                                      "display": "2010"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:45654222",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the philosopher's stone"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9781408855652"
+                                  },
+                                  {
+                                      "value": "9781408855898"
+                                  }
+                              ],
+                              "contributors": [],
+                              "edition": {
+                                  "summary": "Bloomsbury, new edition 2014, 2014",
+                                  "publicationYear": {
+                                      "display": "2014"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          },
+                          {
+                              "pid": "870970-basis:51811925",
+                              "genreAndForm": [
+                                  "roman",
+                                  "fantasy"
+                              ],
+                              "source": [
+                                  "Bibliotekskatalog"
+                              ],
+                              "titles": {
+                                  "main": [
+                                      "Harry Potter and the Philosopher's Stone (Ill. Jim Kay)"
+                                  ],
+                                  "original": []
+                              },
+                              "fictionNonfiction": {
+                                  "display": "skønlitteratur",
+                                  "code": "FICTION"
+                              },
+                              "materialTypes": [
+                                  {
+                                      "specific": "bog"
+                                  }
+                              ],
+                              "creators": [
+                                  {
+                                      "display": "Joanne K. Rowling",
+                                      "__typename": "Person"
+                                  }
+                              ],
+                              "hostPublication": null,
+                              "languages": {
+                                  "main": [
+                                      {
+                                          "display": "engelsk"
+                                      }
+                                  ]
+                              },
+                              "identifiers": [
+                                  {
+                                      "value": "9781408845646"
+                                  }
+                              ],
+                              "contributors": [
+                                  {
+                                      "display": "Jim Kay"
+                                  }
+                              ],
+                              "edition": {
+                                  "summary": "2015",
+                                  "publicationYear": {
+                                      "display": "2015"
+                                  }
+                              },
+                              "audience": {
+                                  "generalAudience": []
+                              },
+                              "physicalDescriptions": [
+                                  {
+                                      "numberOfPages": null
+                                  }
+                              ],
+                              "accessTypes": [
+                                  {
+                                      "code": "PHYSICAL"
+                                  }
+                              ],
+                              "access": [
+                                  {
+                                      "__typename": "InterLibraryLoan",
+                                      "loanIsPossible": true
+                                  }
+                              ],
+                              "shelfmark": null
+                          }
+                      ],
+                      "latest": {
+                          "pid": "870970-basis:134987766",
+                          "genreAndForm": [
+                              "roman"
+                          ],
+                          "source": [
+                              "Bibliotekskatalog"
+                          ],
+                          "titles": {
+                              "main": [
+                                  "Harry Potter and the philosopher's stone"
+                              ],
+                              "original": []
+                          },
+                          "fictionNonfiction": {
+                              "display": "skønlitteratur",
+                              "code": "FICTION"
+                          },
+                          "materialTypes": [
+                              {
+                                  "specific": "bog"
+                              }
+                          ],
+                          "creators": [
+                              {
+                                  "display": "Joanne K. Rowling",
+                                  "__typename": "Person"
+                              }
+                          ],
+                          "hostPublication": null,
+                          "languages": {
+                              "main": [
+                                  {
+                                      "display": "engelsk"
+                                  }
+                              ]
+                          },
+                          "identifiers": [
+                              {
+                                  "value": "9781526646651"
+                              }
+                          ],
+                          "contributors": [],
+                          "edition": {
+                              "summary": "2022",
+                              "publicationYear": {
+                                  "display": "2022"
+                              }
+                          },
+                          "audience": {
+                              "generalAudience": []
+                          },
+                          "physicalDescriptions": [
+                              {
+                                  "numberOfPages": null
+                              }
+                          ],
+                          "accessTypes": [
+                              {
+                                  "code": "PHYSICAL"
+                              }
+                          ],
+                          "access": [
+                              {
+                                  "__typename": "InterLibraryLoan",
+                                  "loanIsPossible": true
+                              }
+                          ],
+                          "shelfmark": null
+                      }
                   }
-                ],
-                "shelfmark": null
               }
-            ],
-            "latest": {
-              "pid": "870970-basis:38519395",
-              "genreAndForm": ["roman", "krimi", "romaner"],
-              "source": ["Bibliotekskatalog"],
-              "titles": {
-                "main": ["Kniv"],
-                "original": ["Kniv (norsk)"]
-              },
-              "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2020"
-              },
-              "materialTypes": [
-                {
-                  "specific": "bog"
-                }
-              ],
-              "creators": [
-                {
-                  "display": "Jo Nesbø",
-                  "__typename": "Person"
-                }
-              ],
-              "hostPublication": null,
-              "languages": {
-                "main": [
-                  {
-                    "display": "dansk"
-                  }
-                ]
-              },
-              "identifiers": [
-                {
-                  "value": "9788770073851"
-                }
-              ],
-              "contributors": [
-                {
-                  "display": "Allan Hilton Andersen"
-                }
-              ],
-              "edition": {
-                "summary": "5. udgave, 2020"
-              },
-              "audience": {
-                "generalAudience": []
-              },
-              "physicalDescriptions": [
-                {
-                  "numberOfPages": null
-                }
-              ],
-              "accessTypes": [
-                {
-                  "code": "PHYSICAL"
-                }
-              ],
-              "access": [
-                {
-                  "__typename": "InterLibraryLoan",
-                  "loanIsPossible": true
-                }
-              ],
-              "shelfmark": null
-            }
-          }
-        }
-      ]
-    }
+          ]
+      }
   }
 }

--- a/cypress/fixtures/search-result/facet-browser/searchWithPagination_terms_joanne-k-rowling.json
+++ b/cypress/fixtures/search-result/facet-browser/searchWithPagination_terms_joanne-k-rowling.json
@@ -208,9 +208,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1998"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -237,7 +234,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1998"
+                  "summary": "1998",
+                  "publicationYear": {
+                    "display": "1998"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -272,9 +272,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -301,7 +298,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. bogklubudgave, 2002"
+                  "summary": "1. bogklubudgave, 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -336,9 +336,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -365,7 +362,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -400,9 +400,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -432,7 +429,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 1999"
+                  "summary": "2. udgave, 1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -467,9 +467,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "punktskrift"
@@ -496,7 +493,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -531,9 +531,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -564,7 +561,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -599,9 +599,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -628,7 +625,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -663,9 +663,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2001"
-                },
                 "materialTypes": [
                   {
                     "specific": "diskette"
@@ -695,7 +692,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2001"
+                  "summary": "2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -730,9 +730,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2001"
-                },
                 "materialTypes": [
                   {
                     "specific": "diskette"
@@ -765,7 +762,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2001"
+                  "summary": "2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -802,9 +802,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -835,7 +832,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2002"
+                  "summary": "2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -872,9 +872,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -905,7 +902,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Bogklubudgave, 2002"
+                  "summary": "Bogklubudgave, 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -940,9 +940,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -969,7 +966,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "3. udgave, 2004"
+                  "summary": "3. udgave, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1004,9 +1004,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1036,7 +1033,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. bogklubudgave, 2006"
+                  "summary": "2. bogklubudgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1073,9 +1073,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -1106,7 +1103,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1141,9 +1141,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1174,7 +1171,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "5. udgave, 2012"
+                  "summary": "5. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1209,9 +1209,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2020"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1245,7 +1242,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "9. udgave, 2020"
+                  "summary": "9. udgave, 2020",
+                  "publicationYear": {
+                    "display": "2020"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1280,9 +1280,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2008"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1313,7 +1310,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Særudgave, 2008"
+                  "summary": "Særudgave, 2008",
+                  "publicationYear": {
+                    "display": "2008"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1348,9 +1348,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1381,7 +1378,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6 udgave, 2015"
+                  "summary": "6 udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1416,9 +1416,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1452,7 +1449,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "1. illustrerede udgave, 7. udgave, 2015"
+                  "summary": "1. illustrerede udgave, 7. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1487,9 +1487,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1520,7 +1517,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "8. udgave, 2018"
+                  "summary": "8. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1556,9 +1556,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "1998"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -1585,7 +1582,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "1998"
+                "summary": "1998",
+                "publicationYear": {
+                  "display": "1998"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -1810,9 +1810,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1839,7 +1836,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "3. oplag, 2000"
+                  "summary": "3. oplag, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1874,9 +1874,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1903,7 +1900,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. bogklubudgave, 2003"
+                  "summary": "1. bogklubudgave, 2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -1938,9 +1938,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -1970,7 +1967,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 2000"
+                  "summary": "2. udgave, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2005,9 +2005,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "punktskrift"
@@ -2034,7 +2031,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2069,9 +2069,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "diskette"
@@ -2101,7 +2098,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2136,9 +2136,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -2169,7 +2166,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2206,9 +2206,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -2239,7 +2236,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2274,9 +2274,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -2303,7 +2300,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "3. udgave, 2004"
+                  "summary": "3. udgave, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2338,9 +2338,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -2370,7 +2367,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. bogklubudgave, 2006"
+                  "summary": "2. bogklubudgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2407,9 +2407,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -2440,7 +2437,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2006"
+                  "summary": "2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2477,9 +2477,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -2510,7 +2507,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2545,9 +2545,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -2578,7 +2575,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "5. udgave, 2012"
+                  "summary": "5. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2613,9 +2613,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -2646,7 +2643,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6. udgave, 2015"
+                  "summary": "6. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2681,9 +2681,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2017"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -2717,7 +2714,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2017"
+                  "summary": "Illustreret udgave, 7. udgave, 2017",
+                  "publicationYear": {
+                    "display": "2017"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2752,9 +2752,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -2785,7 +2782,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "8. udgave, 2018"
+                  "summary": "8. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -2821,9 +2821,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "2000"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -2850,7 +2847,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "3. oplag, 2000"
+                "summary": "3. oplag, 2000",
+                "publicationYear": {
+                  "display": "2000"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -3075,9 +3075,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -3108,7 +3105,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3143,9 +3143,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -3172,7 +3169,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. udgave, 2005"
+                  "summary": "1. udgave, 2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3207,9 +3207,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "ebog"
@@ -3236,7 +3233,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3273,9 +3273,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "punktskrift"
@@ -3302,7 +3299,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3337,9 +3337,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -3370,7 +3367,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3405,9 +3405,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -3434,7 +3431,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. bogklubudgave, 2006"
+                  "summary": "1. bogklubudgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3469,9 +3469,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -3501,7 +3498,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 2006"
+                  "summary": "2. udgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3536,9 +3536,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -3569,7 +3566,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3604,9 +3604,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -3637,7 +3634,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "4. udgave, 2012"
+                  "summary": "4. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3672,9 +3672,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -3705,7 +3702,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "1., i.e 5. udgave, 2015"
+                  "summary": "1., i.e 5. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3740,9 +3740,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -3773,7 +3770,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6. udgave, 2018"
+                  "summary": "6. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -3809,9 +3809,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "2005"
-              },
               "materialTypes": [
                 {
                   "specific": "lydbog (cd)"
@@ -3842,7 +3839,10 @@
                 }
               ],
               "edition": {
-                "summary": "2005"
+                "summary": "2005",
+                "publicationYear": {
+                  "display": "2005"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -4067,9 +4067,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4096,7 +4093,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4131,9 +4131,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -4164,7 +4161,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4199,9 +4199,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "punktskrift"
@@ -4228,7 +4225,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4263,9 +4263,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "diskette"
@@ -4295,7 +4292,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4330,9 +4330,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4359,7 +4356,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. bogklubudgave, 2003"
+                  "summary": "1. bogklubudgave, 2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4394,9 +4394,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2001"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4426,7 +4423,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 2001"
+                  "summary": "2. udgave, 2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4461,9 +4461,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4490,7 +4487,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "3. udgave, 2004"
+                  "summary": "3. udgave, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4525,9 +4525,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4557,7 +4554,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. bogklubudgave, 2006"
+                  "summary": "2. bogklubudgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4592,9 +4592,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -4625,7 +4622,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2006"
+                  "summary": "2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4660,9 +4660,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -4693,7 +4690,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4728,9 +4728,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4761,7 +4758,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "5. udgave, 2012"
+                  "summary": "5. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4796,9 +4796,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2019"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4832,7 +4829,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Illustreret udgave, 8. udgave, 2019"
+                  "summary": "Illustreret udgave, 8. udgave, 2019",
+                  "publicationYear": {
+                    "display": "2019"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4867,9 +4867,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4900,7 +4897,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6. udgave, 2015"
+                  "summary": "6. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -4935,9 +4935,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -4968,7 +4965,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "7. udgave, 2018"
+                  "summary": "7. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5004,9 +5004,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "2000"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -5033,7 +5030,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "2000"
+                "summary": "2000",
+                "publicationYear": {
+                  "display": "2000"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -5258,9 +5258,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2022"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -5297,7 +5294,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2022"
+                  "summary": "Illustreret udgave, 7. udgave, 2022",
+                  "publicationYear": {
+                    "display": "2022"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5332,9 +5332,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -5361,7 +5358,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2003"
+                  "summary": "2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5396,9 +5396,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -5429,7 +5426,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2003"
+                  "summary": "2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5464,9 +5464,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "diskette"
@@ -5496,7 +5493,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2003"
+                  "summary": "2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5531,9 +5531,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -5560,7 +5557,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. bogklubudgave, 2004"
+                  "summary": "1. bogklubudgave, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5595,9 +5595,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "punktskrift"
@@ -5624,7 +5621,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2003"
+                  "summary": "2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5659,9 +5659,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -5691,7 +5688,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 2004"
+                  "summary": "2. udgave, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5726,9 +5726,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -5759,7 +5756,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2006"
+                  "summary": "2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5794,9 +5794,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -5826,7 +5823,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. bogklubudgave, 2006"
+                  "summary": "2. bogklubudgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5861,9 +5861,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -5894,7 +5891,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5929,9 +5929,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -5962,7 +5959,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "4. udgave, 2012"
+                  "summary": "4. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -5997,9 +5997,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -6030,7 +6027,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "5. udgave, 2015"
+                  "summary": "5. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6065,9 +6065,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -6098,7 +6095,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6. udgave, 2018"
+                  "summary": "6. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6133,9 +6133,6 @@
               "fictionNonfiction": {
                 "display": "skønlitteratur",
                 "code": "FICTION"
-              },
-              "publicationYear": {
-                "display": "2022"
               },
               "materialTypes": [
                 {
@@ -6173,7 +6170,10 @@
                 }
               ],
               "edition": {
-                "summary": "Illustreret udgave, 7. udgave, 2022"
+                "summary": "Illustreret udgave, 7. udgave, 2022",
+                "publicationYear": {
+                  "display": "2022"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -6403,9 +6403,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -6432,7 +6429,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6467,9 +6467,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -6499,7 +6496,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 1999"
+                  "summary": "2. udgave, 1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6536,9 +6536,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -6569,7 +6566,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6604,9 +6604,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2003"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -6633,7 +6630,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1. bogklubudgave, 2003"
+                  "summary": "1. bogklubudgave, 2003",
+                  "publicationYear": {
+                    "display": "2003"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6668,9 +6668,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "punktskrift"
@@ -6697,7 +6694,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6732,9 +6732,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2001"
-                },
                 "materialTypes": [
                   {
                     "specific": "diskette"
@@ -6764,7 +6761,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2001"
+                  "summary": "2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6799,9 +6799,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2001"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -6832,7 +6829,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2001"
+                  "summary": "2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6867,9 +6867,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -6896,7 +6893,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "3. udgave, 2004"
+                  "summary": "3. udgave, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -6933,9 +6933,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -6966,7 +6963,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2004"
+                  "summary": "2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7001,9 +7001,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2006"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7033,7 +7030,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. bogklubudgave, 2006"
+                  "summary": "2. bogklubudgave, 2006",
+                  "publicationYear": {
+                    "display": "2006"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7070,9 +7070,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -7103,7 +7100,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7138,9 +7138,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7171,7 +7168,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "5. udgave, 2012"
+                  "summary": "5. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7206,9 +7206,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7239,7 +7236,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6. udgave, 2015"
+                  "summary": "6. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7276,9 +7276,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2016"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7312,7 +7309,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2016"
+                  "summary": "Illustreret udgave, 7. udgave, 2016",
+                  "publicationYear": {
+                    "display": "2016"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7347,9 +7347,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7380,7 +7377,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "8. udgave, 2018"
+                  "summary": "8. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7417,9 +7417,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2021"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7453,7 +7450,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "9. udgave, 2021"
+                  "summary": "9. udgave, 2021",
+                  "publicationYear": {
+                    "display": "2021"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7489,9 +7489,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "1999"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -7518,7 +7515,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "1999"
+                "summary": "1999",
+                "publicationYear": {
+                  "display": "1999"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -7743,9 +7743,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2007"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7772,7 +7769,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2007"
+                  "summary": "2007",
+                  "publicationYear": {
+                    "display": "2007"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7807,9 +7807,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2007"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -7840,7 +7837,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2007"
+                  "summary": "2007",
+                  "publicationYear": {
+                    "display": "2007"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7875,9 +7875,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2007"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -7904,7 +7901,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. udgave, 2007"
+                  "summary": "2. udgave, 2007",
+                  "publicationYear": {
+                    "display": "2007"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -7939,9 +7939,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2009"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd-mp3)"
@@ -7972,7 +7969,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2009"
+                  "summary": "2009",
+                  "publicationYear": {
+                    "display": "2009"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8007,9 +8007,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2012"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8040,7 +8037,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "4. udgave, 2012"
+                  "summary": "4. udgave, 2012",
+                  "publicationYear": {
+                    "display": "2012"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8075,9 +8075,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8108,7 +8105,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "5. udgave, 2015"
+                  "summary": "5. udgave, 2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8143,9 +8143,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2018"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8176,7 +8173,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "6. udgave, 2018"
+                  "summary": "6. udgave, 2018",
+                  "publicationYear": {
+                    "display": "2018"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8212,9 +8212,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "2007"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -8241,7 +8238,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "2007"
+                "summary": "2007",
+                "publicationYear": {
+                  "display": "2007"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -8453,9 +8453,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8482,7 +8479,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Special edition, 1999"
+                  "summary": "Special edition, 1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8517,9 +8517,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -8550,7 +8547,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "DBC (dist.), 2002"
+                  "summary": "DBC (dist.), 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8585,9 +8585,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -8618,7 +8615,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8653,9 +8653,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8682,7 +8679,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Paperback edition, 2004"
+                  "summary": "Paperback edition, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8717,9 +8717,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1997"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8749,7 +8746,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1997"
+                  "summary": "1997",
+                  "publicationYear": {
+                    "display": "1997"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8784,9 +8784,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -8817,7 +8814,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8852,9 +8852,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -8885,7 +8882,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8920,9 +8920,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1997"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -8952,7 +8949,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, New pbk. edition 1997, 1997"
+                  "summary": "Bloomsbury, New pbk. edition 1997, 1997",
+                  "publicationYear": {
+                    "display": "1997"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -8987,9 +8987,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2001"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9016,7 +9013,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, New edition 2001, 2001"
+                  "summary": "Bloomsbury, New edition 2001, 2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9051,9 +9051,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9080,7 +9077,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9115,9 +9115,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1998"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9147,7 +9144,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1998"
+                  "summary": "1998",
+                  "publicationYear": {
+                    "display": "1998"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9184,9 +9184,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -9217,7 +9214,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9256,9 +9256,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9285,7 +9282,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, New edition 2000, 2000"
+                  "summary": "Bloomsbury, New edition 2000, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9320,9 +9320,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9349,7 +9346,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Adult edition, 2004"
+                  "summary": "Adult edition, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9385,9 +9385,6 @@
                 "fictionNonfiction": {
                   "display": "skønlitteratur",
                   "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "1999"
                 },
                 "materialTypes": [
                   {
@@ -9425,7 +9422,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "HNP, 1999"
+                  "summary": "HNP, 1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9460,9 +9460,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2010"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9489,7 +9486,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Signature edition, 2010"
+                  "summary": "Signature edition, 2010",
+                  "publicationYear": {
+                    "display": "2010"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9524,9 +9524,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2014"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9556,7 +9553,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, new edition 2014, 2014"
+                  "summary": "Bloomsbury, new edition 2014, 2014",
+                  "publicationYear": {
+                    "display": "2014"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9593,9 +9593,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2015"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -9626,7 +9623,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2015"
+                  "summary": "2015",
+                  "publicationYear": {
+                    "display": "2015"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9662,9 +9662,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "1999"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -9691,7 +9688,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "Special edition, 1999"
+                "summary": "Special edition, 1999",
+                "publicationYear": {
+                  "display": "1999"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -9926,9 +9926,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -9959,7 +9956,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "DBC (dist.), 2002"
+                  "summary": "DBC (dist.), 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -9994,9 +9994,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -10027,7 +10024,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10062,9 +10062,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10091,7 +10088,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Paperback edition, 2004"
+                  "summary": "Paperback edition, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10130,9 +10130,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10162,7 +10159,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10197,9 +10197,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "ca. 2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10232,7 +10229,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "ca. 2002"
+                  "summary": "ca. 2002",
+                  "publicationYear": {
+                    "display": "ca. 2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10267,9 +10267,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10299,7 +10296,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10334,9 +10334,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -10367,7 +10364,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10402,9 +10402,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -10435,7 +10432,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10470,9 +10470,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10499,7 +10496,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10534,9 +10534,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10566,7 +10563,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, New pbk. edition 1998, 2002"
+                  "summary": "Bloomsbury, New pbk. edition 1998, 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10603,9 +10603,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -10636,7 +10633,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10671,9 +10671,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -10704,7 +10701,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Bloomsbury, 2000"
+                  "summary": "Bloomsbury, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10741,9 +10741,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -10774,7 +10771,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "New edition 2004, 2004"
+                  "summary": "New edition 2004, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10811,9 +10811,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -10844,7 +10841,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10881,9 +10881,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -10910,7 +10907,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Complete & unabridged, 2000"
+                  "summary": "Complete & unabridged, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -10945,9 +10945,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -10974,7 +10971,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Adult edition, 2004"
+                  "summary": "Adult edition, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11009,9 +11009,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2010"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11038,7 +11035,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Signature edition, 2010"
+                  "summary": "Signature edition, 2010",
+                  "publicationYear": {
+                    "display": "2010"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11073,9 +11073,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11102,7 +11099,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, new pbk. edition 2002, 2002"
+                  "summary": "Bloomsbury, new pbk. edition 2002, 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11137,9 +11137,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2014"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11169,7 +11166,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, Pbk. edition 2014, 2014"
+                  "summary": "Bloomsbury, Pbk. edition 2014, 2014",
+                  "publicationYear": {
+                    "display": "2014"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11206,9 +11206,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "201-"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -11242,7 +11239,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "HNP, Bloomsbury, New edition 201?, 201-"
+                  "summary": "HNP, Bloomsbury, New edition 201?, 201-",
+                  "publicationYear": {
+                    "display": "201-"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11279,9 +11279,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2016"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11312,7 +11309,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2016"
+                  "summary": "2016",
+                  "publicationYear": {
+                    "display": "2016"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11348,9 +11348,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "2002"
-              },
               "materialTypes": [
                 {
                   "specific": "lydbog (bånd)"
@@ -11381,7 +11378,10 @@
                 }
               ],
               "edition": {
-                "summary": "DBC (dist.), 2002"
+                "summary": "DBC (dist.), 2002",
+                "publicationYear": {
+                  "display": "2002"
+                }
               },
               "audience": {
                 "generalAudience": []
@@ -11616,9 +11616,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11645,7 +11642,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, 1999"
+                  "summary": "Bloomsbury, 1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11680,9 +11680,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2005"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -11713,7 +11710,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2005"
+                  "summary": "2005",
+                  "publicationYear": {
+                    "display": "2005"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11748,9 +11748,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11780,7 +11777,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11815,9 +11815,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11847,7 +11844,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11882,9 +11882,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -11911,7 +11908,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -11946,9 +11946,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -11979,7 +11976,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12014,9 +12014,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12046,7 +12043,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury New pbk. edition 1999, 1999"
+                  "summary": "Bloomsbury New pbk. edition 1999, 1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12081,9 +12081,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2002"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -12114,7 +12111,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2002"
+                  "summary": "2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12149,9 +12149,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -12182,7 +12179,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12221,9 +12221,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "1999"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12253,7 +12250,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "1999"
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12288,9 +12288,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12317,7 +12314,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, New pbk. edition 2004, 2004"
+                  "summary": "Bloomsbury, New pbk. edition 2004, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12354,9 +12354,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -12387,7 +12384,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12422,9 +12422,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -12451,7 +12448,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, 2000"
+                  "summary": "Bloomsbury, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12486,9 +12486,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12515,7 +12512,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "New edition 2004, 2004"
+                  "summary": "New edition 2004, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12552,9 +12552,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -12585,7 +12582,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2000"
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12624,9 +12624,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12653,7 +12650,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "New edition 2000, 2000"
+                  "summary": "New edition 2000, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12690,9 +12690,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (bånd)"
@@ -12719,7 +12716,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Complete & unabridged, 2000"
+                  "summary": "Complete & unabridged, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12755,9 +12755,6 @@
                 "fictionNonfiction": {
                   "display": "skønlitteratur",
                   "code": "FICTION"
-                },
-                "publicationYear": {
-                  "display": "2004"
                 },
                 "materialTypes": [
                   {
@@ -12795,7 +12792,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Bloomsbury, HNP, 2004"
+                  "summary": "Bloomsbury, HNP, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12830,9 +12830,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2010"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12859,7 +12856,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Signature edition, 2010"
+                  "summary": "Signature edition, 2010",
+                  "publicationYear": {
+                    "display": "2010"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12894,9 +12894,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2004"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12923,7 +12920,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, new pbk. edition 2004, 2004"
+                  "summary": "Bloomsbury, new pbk. edition 2004, 2004",
+                  "publicationYear": {
+                    "display": "2004"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -12958,9 +12958,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2014"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -12990,7 +12987,10 @@
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "Bloomsbury, Pbk. edition 2014, 2014"
+                  "summary": "Bloomsbury, Pbk. edition 2014, 2014",
+                  "publicationYear": {
+                    "display": "2014"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -13025,9 +13025,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2000"
-                },
                 "materialTypes": [
                   {
                     "specific": "lydbog (cd)"
@@ -13061,7 +13058,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "HNP, Bloomsbury, 2000"
+                  "summary": "HNP, Bloomsbury, 2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -13098,9 +13098,6 @@
                   "display": "skønlitteratur",
                   "code": "FICTION"
                 },
-                "publicationYear": {
-                  "display": "2017"
-                },
                 "materialTypes": [
                   {
                     "specific": "bog"
@@ -13131,7 +13128,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "2017"
+                  "summary": "2017",
+                  "publicationYear": {
+                    "display": "2017"
+                  }
                 },
                 "audience": {
                   "generalAudience": []
@@ -13167,9 +13167,6 @@
                 "display": "skønlitteratur",
                 "code": "FICTION"
               },
-              "publicationYear": {
-                "display": "1999"
-              },
               "materialTypes": [
                 {
                   "specific": "bog"
@@ -13196,7 +13193,10 @@
               ],
               "contributors": [],
               "edition": {
-                "summary": "Bloomsbury, 1999"
+                "summary": "Bloomsbury, 1999",
+                "publicationYear": {
+                  "display": "1999"
+                }
               },
               "audience": {
                 "generalAudience": []

--- a/cypress/fixtures/search-result/fbi-api.json
+++ b/cypress/fixtures/search-result/fbi-api.json
@@ -300,9 +300,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -344,7 +341,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -367,9 +367,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -411,7 +408,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -434,9 +434,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -478,7 +475,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -501,9 +501,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -545,7 +542,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -568,9 +568,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -612,7 +609,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -635,9 +635,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -679,7 +676,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -702,9 +702,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -746,7 +743,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -769,9 +769,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -813,7 +810,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -836,9 +836,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -880,7 +877,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -903,9 +903,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -947,7 +944,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -970,9 +970,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1014,7 +1011,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1037,9 +1037,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1081,7 +1078,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1104,9 +1104,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1148,7 +1145,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1171,9 +1171,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1215,7 +1212,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1238,9 +1238,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1282,7 +1279,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1305,9 +1305,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1349,7 +1346,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1372,9 +1372,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1416,7 +1413,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1439,9 +1439,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1483,7 +1480,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1506,9 +1506,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1550,7 +1547,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1573,9 +1573,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1617,7 +1614,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1930,9 +1930,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -1974,7 +1971,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -1997,9 +1997,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2041,7 +2038,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2064,9 +2064,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2108,7 +2105,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2131,9 +2131,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2175,7 +2172,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2198,9 +2198,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2242,7 +2239,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2265,9 +2265,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2309,7 +2306,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2332,9 +2332,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2376,7 +2373,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2399,9 +2399,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2443,7 +2440,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2466,9 +2466,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2510,7 +2507,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2533,9 +2533,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2577,7 +2574,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [
@@ -2600,9 +2600,6 @@
                     "Dummy Some Title: Original"
                   ]
                 },
-                "publicationYear": {
-                  "display": "Dummy 1839"
-                },
                 "materialTypes": [
                   {
                     "specific": "Dummy bog"
@@ -2644,7 +2641,10 @@
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005"
+                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "publicationYear": {
+                    "display": "Dummy 1839"
+                  }
                 },
                 "audience": {
                   "generalAudience": [

--- a/src/apps/search-result/facet-browser.test.ts
+++ b/src/apps/search-result/facet-browser.test.ts
@@ -29,7 +29,7 @@ describe("The Facet Browser", () => {
 
   it("renders the logic of selected terms and open facets", () => {
     cy.log("renders all results");
-    cy.contains("h1", "“harry” (703)");
+    cy.contains("h1", "“harry” (848)");
 
     cy.log("updates result after it select Joanne K. Rowling inside Creators");
 
@@ -84,7 +84,7 @@ describe("The Facet Browser", () => {
 
     cy.get(`[aria-label="Close facet browser modal"]`).click();
 
-    cy.contains("h1", "“harry” (703)");
+    cy.contains("h1", "“harry” (848)");
   });
 
   beforeEach(() => {

--- a/src/components/find-on-shelf/FindOnShelfManifestationList.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationList.tsx
@@ -34,7 +34,7 @@ const FindOnShelfManifestationList: FC<FindOnShelfManifestationListProps> = ({
             sublocation={branchHolding.holding.sublocation?.title}
             title={branchHolding.manifestation.titles.main.join(", ")}
             publicationYear={
-              branchHolding.manifestation.publicationYear.display
+              branchHolding.manifestation.edition?.publicationYear?.display
             }
             numberAvailable={totalAvailableMaterials(
               branchHolding.holding.materials

--- a/src/components/find-on-shelf/FindOnShelfManifestationList.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationList.tsx
@@ -4,6 +4,7 @@ import { totalAvailableMaterials } from "../../apps/material/helper";
 import { useText } from "../../core/utils/text";
 import { ManifestationHoldings } from "./types";
 import FindOnShelfManifestationListItem from "./FindOnShelfManifestationListItem";
+import { getManifestationPublicationYear } from "../../core/utils/helpers/general";
 
 export interface FindOnShelfManifestationListProps {
   libraryBranchHoldings: ManifestationHoldings;
@@ -33,9 +34,9 @@ const FindOnShelfManifestationList: FC<FindOnShelfManifestationListProps> = ({
             location={branchHolding.holding.location?.title}
             sublocation={branchHolding.holding.sublocation?.title}
             title={branchHolding.manifestation.titles.main.join(", ")}
-            publicationYear={
-              branchHolding.manifestation.edition?.publicationYear?.display
-            }
+            publicationYear={getManifestationPublicationYear(
+              branchHolding.manifestation
+            )}
             numberAvailable={totalAvailableMaterials(
               branchHolding.holding.materials
             )}

--- a/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
@@ -9,7 +9,7 @@ export interface FindOnShelfManifestationListItemProps {
   location: string | undefined;
   sublocation: string | undefined;
   title: string;
-  publicationYear: string;
+  publicationYear?: string;
   numberAvailable: number;
 }
 
@@ -41,7 +41,7 @@ const FindOnShelfManifestationListItem: FC<
     <li className="find-on-shelf__row text-body-medium-regular">
       <span className="find-on-shelf__material-text">
         {title}
-        {publicationYear ? `, ${publicationYear}` : ""}
+        {publicationYear ?? ""}
       </span>
       <span>
         {locationArray.length

--- a/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
@@ -9,7 +9,7 @@ export interface FindOnShelfManifestationListItemProps {
   location: string | undefined;
   sublocation: string | undefined;
   title: string;
-  publicationYear?: string;
+  publicationYear: string | null;
   numberAvailable: number;
 }
 

--- a/src/components/find-on-shelf/mocked-data.ts
+++ b/src/components/find-on-shelf/mocked-data.ts
@@ -17,9 +17,6 @@ export const mockedManifestationData: Manifestation[] = [
       display: "SKOENLITTERATUR",
       code: "FICTION" as FictionNonfictionCode
     },
-    publicationYear: {
-      display: "2016"
-    },
     materialTypes: [
       {
         specific: "bog"
@@ -50,7 +47,10 @@ export const mockedManifestationData: Manifestation[] = [
       }
     ],
     edition: {
-      summary: "1. udgave, 3. oplag (2018)"
+      summary: "1. udgave, 3. oplag (2018)",
+      publicationYear: {
+        display: "2016"
+      }
     },
     audience: {
       generalAudience: []
@@ -85,9 +85,6 @@ export const mockedManifestationData: Manifestation[] = [
       display: "SKOENLITTERATUR",
       code: "FICTION" as FictionNonfictionCode
     },
-    publicationYear: {
-      display: "2016"
-    },
     materialTypes: [
       {
         specific: "lydbog (cd-mp3)"
@@ -121,7 +118,10 @@ export const mockedManifestationData: Manifestation[] = [
       }
     ],
     edition: {
-      summary: "1. lydbogsudgave"
+      summary: "1. lydbogsudgave",
+      publicationYear: {
+        display: "2016"
+      }
     },
     audience: {
       generalAudience: []
@@ -159,9 +159,6 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
       display: "FAGLITTERATUR",
       code: "NONFICTION" as FictionNonfictionCode
     },
-    publicationYear: {
-      display: "1946"
-    },
     materialTypes: [
       {
         specific: "periodikum"
@@ -182,7 +179,12 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
       }
     ],
     contributors: [],
-    edition: null,
+    edition: {
+      summary: "",
+      publicationYear: {
+        display: "1946"
+      }
+    },
     audience: {
       generalAudience: []
     },

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -10,6 +10,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
+  getManifestationPublicationYear,
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { Manifestation } from "../../core/utils/types/entities";
@@ -128,7 +129,8 @@ export const getAuthorLine = (
   manifestation: Manifestation,
   t: UseTextFunction
 ) => {
-  const { creators, edition } = manifestation;
+  const { creators } = manifestation;
+  const publicationYear = getManifestationPublicationYear(manifestation);
   const author =
     creatorsToString(
       flattenCreators(filterCreators(creators, ["Person"])),
@@ -136,8 +138,8 @@ export const getAuthorLine = (
     ) || null;
 
   let year = "";
-  if (edition?.publicationYear) {
-    year = `(${edition.publicationYear.display})`;
+  if (publicationYear) {
+    year = publicationYear;
   }
   if (materialIsFiction(manifestation)) {
     year = `(${t("materialHeaderAllEditionsText")})`;

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -128,7 +128,7 @@ export const getAuthorLine = (
   manifestation: Manifestation,
   t: UseTextFunction
 ) => {
-  const { creators, publicationYear } = manifestation;
+  const { creators, edition } = manifestation;
   const author =
     creatorsToString(
       flattenCreators(filterCreators(creators, ["Person"])),
@@ -136,8 +136,8 @@ export const getAuthorLine = (
     ) || null;
 
   let year = "";
-  if (publicationYear) {
-    year = `(${publicationYear.display})`;
+  if (edition?.publicationYear) {
+    year = `(${edition.publicationYear.display})`;
   }
   if (materialIsFiction(manifestation)) {
     year = `(${t("materialHeaderAllEditionsText")})`;

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -19,9 +19,6 @@ fragment ManifestationsSimpleFields on Manifestation {
     display
     code
   }
-  publicationYear {
-    display
-  }
   materialTypes {
     specific
   }
@@ -50,6 +47,9 @@ fragment ManifestationsSimpleFields on Manifestation {
   }
   edition {
     summary
+    publicationYear {
+      display
+    }
   }
   audience {
     generalAudience

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -372,57 +372,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "CatalogueCodes",
-        "description": null,
-        "fields": [
-          {
-            "name": "nationalBibliography",
-            "description": "Catalogue codes for the national bibliography ",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "otherCatalogues",
-            "description": "other catalogue codes ",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "ChildOrAdult",
         "description": null,
         "fields": [
@@ -2933,18 +2882,6 @@
             "deprecationReason": null
           },
           {
-            "name": "catalogueCodes",
-            "description": "CatalogueCodes for nationalBibliography and others",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "CatalogueCodes",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "classifications",
             "description": "Classification codes for this manifestation from any classification system",
             "args": [],
@@ -3287,22 +3224,6 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "publicationYear",
-            "description": "The publication year of the manifestation - OBS! was datePublished",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PublicationYear",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "use edition.publicationYear instead."
           },
           {
             "name": "publisher",
@@ -6788,13 +6709,9 @@
             "description": "A postfix to the shelfmark, eg. 99.4 Christensen, Inger. f. 1935",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -76,14 +76,6 @@ export type Audience = {
   schoolUse: Array<SchoolUse>;
 };
 
-export type CatalogueCodes = {
-  __typename?: "CatalogueCodes";
-  /** Catalogue codes for the national bibliography  */
-  nationalBibliography: Array<Maybe<Scalars["String"]>>;
-  /** other catalogue codes  */
-  otherCatalogues: Array<Maybe<Scalars["String"]>>;
-};
-
 export type ChildOrAdult = {
   __typename?: "ChildOrAdult";
   code: ChildOrAdultCode;
@@ -473,8 +465,6 @@ export type Manifestation = {
   accessTypes: Array<AccessType>;
   /** Different kinds of definitions of appropriate audience for this manifestation */
   audience?: Maybe<Audience>;
-  /** CatalogueCodes for nationalBibliography and others */
-  catalogueCodes?: Maybe<CatalogueCodes>;
   /** Classification codes for this manifestation from any classification system */
   classifications: Array<Classification>;
   /** Contributors to the manifestation, actors, illustrators etc */
@@ -511,11 +501,6 @@ export type Manifestation = {
   physicalDescriptions: Array<PhysicalDescription>;
   /** Unique identification of the manifestation e.g 870970-basis:54029519 */
   pid: Scalars["String"];
-  /**
-   * The publication year of the manifestation - OBS! was datePublished
-   * @deprecated use edition.publicationYear instead.
-   */
-  publicationYear: PublicationYear;
   /** Publisher of this manifestion */
   publisher: Array<Scalars["String"]>;
   /** The creation date of the record describing this manifestation in the format YYYYMMDD */
@@ -990,7 +975,7 @@ export type Series = {
 export type Shelfmark = {
   __typename?: "Shelfmark";
   /** A postfix to the shelfmark, eg. 99.4 Christensen, Inger. f. 1935 */
-  postfix: Scalars["String"];
+  postfix?: Maybe<Scalars["String"]>;
   /** The actual shelfmark - e.g. information about on which shelf in the library this manifestation can be found, e.g. 99.4 */
   shelfmark: Scalars["String"];
 };
@@ -1300,7 +1285,6 @@ export type GetMaterialQuery = {
           display: string;
           code: FictionNonfictionCode;
         } | null;
-        publicationYear: { __typename?: "PublicationYear"; display: string };
         materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
         creators: Array<
           | { __typename: "Corporation"; display: string }
@@ -1325,7 +1309,14 @@ export type GetMaterialQuery = {
           | { __typename?: "Corporation"; display: string }
           | { __typename?: "Person"; display: string }
         >;
-        edition?: { __typename?: "Edition"; summary: string } | null;
+        edition?: {
+          __typename?: "Edition";
+          summary: string;
+          publicationYear?: {
+            __typename?: "PublicationYear";
+            display: string;
+          } | null;
+        } | null;
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
@@ -1354,7 +1345,7 @@ export type GetMaterialQuery = {
         >;
         shelfmark?: {
           __typename?: "Shelfmark";
-          postfix: string;
+          postfix?: string | null;
           shelfmark: string;
         } | null;
       }>;
@@ -1373,7 +1364,6 @@ export type GetMaterialQuery = {
           display: string;
           code: FictionNonfictionCode;
         } | null;
-        publicationYear: { __typename?: "PublicationYear"; display: string };
         materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
         creators: Array<
           | { __typename: "Corporation"; display: string }
@@ -1398,7 +1388,14 @@ export type GetMaterialQuery = {
           | { __typename?: "Corporation"; display: string }
           | { __typename?: "Person"; display: string }
         >;
-        edition?: { __typename?: "Edition"; summary: string } | null;
+        edition?: {
+          __typename?: "Edition";
+          summary: string;
+          publicationYear?: {
+            __typename?: "PublicationYear";
+            display: string;
+          } | null;
+        } | null;
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
@@ -1427,7 +1424,7 @@ export type GetMaterialQuery = {
         >;
         shelfmark?: {
           __typename?: "Shelfmark";
-          postfix: string;
+          postfix?: string | null;
           shelfmark: string;
         } | null;
       };
@@ -1517,7 +1514,6 @@ export type SearchWithPaginationQuery = {
             display: string;
             code: FictionNonfictionCode;
           } | null;
-          publicationYear: { __typename?: "PublicationYear"; display: string };
           materialTypes: Array<{
             __typename?: "MaterialType";
             specific: string;
@@ -1545,7 +1541,14 @@ export type SearchWithPaginationQuery = {
             | { __typename?: "Corporation"; display: string }
             | { __typename?: "Person"; display: string }
           >;
-          edition?: { __typename?: "Edition"; summary: string } | null;
+          edition?: {
+            __typename?: "Edition";
+            summary: string;
+            publicationYear?: {
+              __typename?: "PublicationYear";
+              display: string;
+            } | null;
+          } | null;
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
@@ -1577,7 +1580,7 @@ export type SearchWithPaginationQuery = {
           >;
           shelfmark?: {
             __typename?: "Shelfmark";
-            postfix: string;
+            postfix?: string | null;
             shelfmark: string;
           } | null;
         }>;
@@ -1596,7 +1599,6 @@ export type SearchWithPaginationQuery = {
             display: string;
             code: FictionNonfictionCode;
           } | null;
-          publicationYear: { __typename?: "PublicationYear"; display: string };
           materialTypes: Array<{
             __typename?: "MaterialType";
             specific: string;
@@ -1624,7 +1626,14 @@ export type SearchWithPaginationQuery = {
             | { __typename?: "Corporation"; display: string }
             | { __typename?: "Person"; display: string }
           >;
-          edition?: { __typename?: "Edition"; summary: string } | null;
+          edition?: {
+            __typename?: "Edition";
+            summary: string;
+            publicationYear?: {
+              __typename?: "PublicationYear";
+              display: string;
+            } | null;
+          } | null;
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
@@ -1656,7 +1665,7 @@ export type SearchWithPaginationQuery = {
           >;
           shelfmark?: {
             __typename?: "Shelfmark";
-            postfix: string;
+            postfix?: string | null;
             shelfmark: string;
           } | null;
         };
@@ -1735,7 +1744,6 @@ export type ManifestationsSimpleFragment = {
       display: string;
       code: FictionNonfictionCode;
     } | null;
-    publicationYear: { __typename?: "PublicationYear"; display: string };
     materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
     creators: Array<
       | { __typename: "Corporation"; display: string }
@@ -1757,7 +1765,14 @@ export type ManifestationsSimpleFragment = {
       | { __typename?: "Corporation"; display: string }
       | { __typename?: "Person"; display: string }
     >;
-    edition?: { __typename?: "Edition"; summary: string } | null;
+    edition?: {
+      __typename?: "Edition";
+      summary: string;
+      publicationYear?: {
+        __typename?: "PublicationYear";
+        display: string;
+      } | null;
+    } | null;
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
@@ -1786,7 +1801,7 @@ export type ManifestationsSimpleFragment = {
     >;
     shelfmark?: {
       __typename?: "Shelfmark";
-      postfix: string;
+      postfix?: string | null;
       shelfmark: string;
     } | null;
   }>;
@@ -1805,7 +1820,6 @@ export type ManifestationsSimpleFragment = {
       display: string;
       code: FictionNonfictionCode;
     } | null;
-    publicationYear: { __typename?: "PublicationYear"; display: string };
     materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
     creators: Array<
       | { __typename: "Corporation"; display: string }
@@ -1827,7 +1841,14 @@ export type ManifestationsSimpleFragment = {
       | { __typename?: "Corporation"; display: string }
       | { __typename?: "Person"; display: string }
     >;
-    edition?: { __typename?: "Edition"; summary: string } | null;
+    edition?: {
+      __typename?: "Edition";
+      summary: string;
+      publicationYear?: {
+        __typename?: "PublicationYear";
+        display: string;
+      } | null;
+    } | null;
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
@@ -1856,7 +1877,7 @@ export type ManifestationsSimpleFragment = {
     >;
     shelfmark?: {
       __typename?: "Shelfmark";
-      postfix: string;
+      postfix?: string | null;
       shelfmark: string;
     } | null;
   };
@@ -1877,7 +1898,6 @@ export type ManifestationsSimpleFieldsFragment = {
     display: string;
     code: FictionNonfictionCode;
   } | null;
-  publicationYear: { __typename?: "PublicationYear"; display: string };
   materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
   creators: Array<
     | { __typename: "Corporation"; display: string }
@@ -1899,7 +1919,14 @@ export type ManifestationsSimpleFieldsFragment = {
     | { __typename?: "Corporation"; display: string }
     | { __typename?: "Person"; display: string }
   >;
-  edition?: { __typename?: "Edition"; summary: string } | null;
+  edition?: {
+    __typename?: "Edition";
+    summary: string;
+    publicationYear?: {
+      __typename?: "PublicationYear";
+      display: string;
+    } | null;
+  } | null;
   audience?: { __typename?: "Audience"; generalAudience: Array<string> } | null;
   physicalDescriptions: Array<{
     __typename?: "PhysicalDescription";
@@ -1925,7 +1952,7 @@ export type ManifestationsSimpleFieldsFragment = {
   >;
   shelfmark?: {
     __typename?: "Shelfmark";
-    postfix: string;
+    postfix?: string | null;
     shelfmark: string;
   } | null;
 };
@@ -1996,7 +2023,6 @@ export type WorkSmallFragment = {
         display: string;
         code: FictionNonfictionCode;
       } | null;
-      publicationYear: { __typename?: "PublicationYear"; display: string };
       materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
       creators: Array<
         | { __typename: "Corporation"; display: string }
@@ -2018,7 +2044,14 @@ export type WorkSmallFragment = {
         | { __typename?: "Corporation"; display: string }
         | { __typename?: "Person"; display: string }
       >;
-      edition?: { __typename?: "Edition"; summary: string } | null;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2047,7 +2080,7 @@ export type WorkSmallFragment = {
       >;
       shelfmark?: {
         __typename?: "Shelfmark";
-        postfix: string;
+        postfix?: string | null;
         shelfmark: string;
       } | null;
     }>;
@@ -2066,7 +2099,6 @@ export type WorkSmallFragment = {
         display: string;
         code: FictionNonfictionCode;
       } | null;
-      publicationYear: { __typename?: "PublicationYear"; display: string };
       materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
       creators: Array<
         | { __typename: "Corporation"; display: string }
@@ -2088,7 +2120,14 @@ export type WorkSmallFragment = {
         | { __typename?: "Corporation"; display: string }
         | { __typename?: "Person"; display: string }
       >;
-      edition?: { __typename?: "Edition"; summary: string } | null;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2117,7 +2156,7 @@ export type WorkSmallFragment = {
       >;
       shelfmark?: {
         __typename?: "Shelfmark";
-        postfix: string;
+        postfix?: string | null;
         shelfmark: string;
       } | null;
     };
@@ -2226,7 +2265,6 @@ export type WorkMediumFragment = {
         display: string;
         code: FictionNonfictionCode;
       } | null;
-      publicationYear: { __typename?: "PublicationYear"; display: string };
       materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
       creators: Array<
         | { __typename: "Corporation"; display: string }
@@ -2248,7 +2286,14 @@ export type WorkMediumFragment = {
         | { __typename?: "Corporation"; display: string }
         | { __typename?: "Person"; display: string }
       >;
-      edition?: { __typename?: "Edition"; summary: string } | null;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2277,7 +2322,7 @@ export type WorkMediumFragment = {
       >;
       shelfmark?: {
         __typename?: "Shelfmark";
-        postfix: string;
+        postfix?: string | null;
         shelfmark: string;
       } | null;
     }>;
@@ -2296,7 +2341,6 @@ export type WorkMediumFragment = {
         display: string;
         code: FictionNonfictionCode;
       } | null;
-      publicationYear: { __typename?: "PublicationYear"; display: string };
       materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
       creators: Array<
         | { __typename: "Corporation"; display: string }
@@ -2318,7 +2362,14 @@ export type WorkMediumFragment = {
         | { __typename?: "Corporation"; display: string }
         | { __typename?: "Person"; display: string }
       >;
-      edition?: { __typename?: "Edition"; summary: string } | null;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2347,7 +2398,7 @@ export type WorkMediumFragment = {
       >;
       shelfmark?: {
         __typename?: "Shelfmark";
-        postfix: string;
+        postfix?: string | null;
         shelfmark: string;
       } | null;
     };
@@ -2379,9 +2430,6 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
     display
     code
   }
-  publicationYear {
-    display
-  }
   materialTypes {
     specific
   }
@@ -2410,6 +2458,9 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
   }
   edition {
     summary
+    publicationYear {
+      display
+    }
   }
   audience {
     generalAudience

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -12,13 +12,19 @@ import { FaustId, Pid } from "../types/ids";
 import { getUrlQueryParam } from "./url";
 import { LoanType } from "../types/loan-type";
 
+export const getManifestationPublicationYear = (
+  manifestation: Manifestation
+): string | null => {
+  return manifestation.edition?.publicationYear?.display || null;
+};
+
 export const orderManifestationsByYear = (
   manifestations: Manifestation[],
   order: "asc" | "desc" = "desc"
 ) => {
   return manifestations.sort((a, b) => {
-    const currentDate = Number(a.edition?.publicationYear?.display);
-    const prevDate = Number(b.edition?.publicationYear?.display);
+    const currentDate = Number(getManifestationPublicationYear(a));
+    const prevDate = Number(getManifestationPublicationYear(b));
     if (order === "desc") {
       return prevDate - currentDate;
     }
@@ -75,8 +81,9 @@ export const getFirstPublishedManifestation = (
 
 export const getFirstPublishedYear = (manifestations: Manifestation[]) => {
   return String(
-    getFirstPublishedManifestation(manifestations)?.edition?.publicationYear
-      ?.display
+    getManifestationPublicationYear(
+      getFirstPublishedManifestation(manifestations)
+    )
   );
 };
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -17,8 +17,8 @@ export const orderManifestationsByYear = (
   order: "asc" | "desc" = "desc"
 ) => {
   return manifestations.sort((a, b) => {
-    const currentDate = Number(a.publicationYear.display);
-    const prevDate = Number(b.publicationYear.display);
+    const currentDate = Number(a.edition?.publicationYear?.display);
+    const prevDate = Number(b.edition?.publicationYear?.display);
     if (order === "desc") {
       return prevDate - currentDate;
     }
@@ -75,7 +75,8 @@ export const getFirstPublishedManifestation = (
 
 export const getFirstPublishedYear = (manifestations: Manifestation[]) => {
   return String(
-    getFirstPublishedManifestation(manifestations)?.publicationYear.display
+    getFirstPublishedManifestation(manifestations)?.edition?.publicationYear
+      ?.display
   );
 };
 


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-315

#### The FBI API has changed the location of publicationYear
it has moved from being a child of manifestation to being in manifestation.edition.publicationYear. this means that I have had to correct the search query, fixtures, and rewrites in all components that touch publicationYear.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
It is especially this commit where I made logical corrections that you should pay attention to
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/221/commits/30062e7d7b1ff3f07c4a72c585470e1bfb11540f
