### PR TITLE
Change name from periodikum to tidsskrift (new)

### DIFF
--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -19,7 +19,7 @@
               "display": "FAGLITTERATUR",
               "code": "NONFICTION"
             },
-            "materialTypes": [{ "specific": "periodikum" }],
+            "materialTypes": [{ "specific": "tidsskrift" }],
             "creators": [],
             "hostPublication": null,
             "languages": { "main": [{ "display": "dansk" }] },
@@ -47,7 +47,7 @@
             "display": "FAGLITTERATUR",
             "code": "NONFICTION"
           },
-          "materialTypes": [{ "specific": "periodikum" }],
+          "materialTypes": [{ "specific": "tidsskrift" }],
           "creators": [],
           "hostPublication": null,
           "languages": { "main": [{ "display": "dansk" }] },

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -125,11 +125,11 @@ describe("Material", () => {
       fixtureFilePath: "material/periodical-fbi-api.json"
     });
     cy.visit(
-      "/iframe.html?id=apps-material--periodical&viewMode=story&type=periodikum"
+      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
     );
     cy.get("#year").select("2021");
     cy.get("#editions").should("have.value", "52");
-    cy.contains("button:visible", "Reserve periodikum").click();
+    cy.contains("button:visible", "Reserve tidsskrift").click();
     cy.contains("h2", "2021, nr. 52");
     cy.contains("button:visible", "Approve reservation").click();
     cy.contains("Material is available and reserved for you!");

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -64,7 +64,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   );
   const isPeriodical = manifestations.some((manifestation) => {
     return manifestation.materialTypes.some((materialType) => {
-      return materialType.specific.includes("periodikum");
+      return materialType.specific.includes("tidsskrift");
     });
   });
 

--- a/src/components/find-on-shelf/mocked-data.ts
+++ b/src/components/find-on-shelf/mocked-data.ts
@@ -161,7 +161,7 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
     },
     materialTypes: [
       {
-        specific: "periodikum"
+        specific: "tidsskrift"
       }
     ],
     creators: [],

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -63,9 +63,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   );
   const isPeriodical = manifestation.materialTypes.some(
     (materialType: Manifestation["materialTypes"][0]) => {
-      return materialType.specific.includes("periodikum");
+      return materialType.specific.includes("tidsskrift");
     }
   );
+
   const author = creatorsText || t("creatorsAreMissingText");
 
   const containsDanish = mainLanguages.some((language) =>
@@ -96,6 +97,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
             selectManifestationHandler={selectManifestationHandler}
           />
         </div>
+
         {isPeriodical && (
           <MaterialPeriodical
             faustId={convertPostIdToFaustId(pid)}
@@ -103,7 +105,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
             selectPeriodicalHandler={selectPeriodicalHandler}
           />
         )}
-
         {manifestation && (
           <>
             <div className="material-header__button">


### PR DESCRIPTION
#### [DDFSOEG-280](https://reload.atlassian.net/browse/DDFSOEG-280)

#### FBI API has been changed so that materialType is now called "tidsskrift" instead of "periodikum"

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
