### PR TITLE
Add close logic to facet browser showResults button

### DIFF
--- a/src/components/facet-browser/FacetBrowserModal.tsx
+++ b/src/components/facet-browser/FacetBrowserModal.tsx
@@ -6,9 +6,7 @@ import {
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import FacetBrowserModalBody from "./FacetBrowserModalBody";
-import { useGetFacets } from "./helper";
-
-export const FacetBrowserModalId = "facet-browser-modal";
+import { FacetBrowserModalId, useGetFacets } from "./helper";
 
 interface FacetBrowserModalProps {
   q: string;

--- a/src/components/facet-browser/FacetBrowserModalBody.tsx
+++ b/src/components/facet-browser/FacetBrowserModalBody.tsx
@@ -9,6 +9,8 @@ import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 import ButtonTag from "../Buttons/ButtonTag";
 import FacetBrowserDisclosure from "./FacetBrowserDisclosure";
+import { useModalButtonHandler } from "../../core/utils/modal";
+import { FacetBrowserModalId } from "./helper";
 
 interface FacetBrowserModalBodyProps {
   facets: FacetResult[];
@@ -21,6 +23,7 @@ interface FacetBrowserModalBodyProps {
 const FacetBrowserModalBody: React.FunctionComponent<
   FacetBrowserModalBodyProps
 > = ({ facets, filterHandler, filters, openFacets, setOpenFacets }) => {
+  const { close } = useModalButtonHandler();
   const t = useText();
 
   const toggleFacets = (facet: string) => () => {
@@ -115,6 +118,9 @@ const FacetBrowserModalBody: React.FunctionComponent<
         collapsible={false}
         size="medium"
         variant="filled"
+        onClick={() => {
+          close(FacetBrowserModalId);
+        }}
       />
     </section>
   );

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -63,4 +63,6 @@ export function useGetFacets(query: string, filters: Filter) {
   return { facets, isLoading };
 }
 
+export const FacetBrowserModalId = "facet-browser-modal";
+
 export default {};

--- a/src/components/search-bar/search-result-header/SearchResultHeader.tsx
+++ b/src/components/search-bar/search-result-header/SearchResultHeader.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useDispatch } from "react-redux";
 import { openModal } from "../../../core/modal.slice";
 import { useText } from "../../../core/utils/text";
-import { FacetBrowserModalId } from "../../facet-browser/FacetBrowserModal";
+import { FacetBrowserModalId } from "../../facet-browser/helper";
 import ButtonTag from "../../Buttons/ButtonTag";
 
 export interface SearchResultHeaderProps {


### PR DESCRIPTION
#### Add close logic to facet browser showResults button

it is now possible to press the showResults button to close the modal instead of the cross in the corner.

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.


