### PR TITLE
Fix the "view online" button

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -245,7 +245,7 @@ export default {
     },
     goToText: {
       name: "Go to",
-      defaultValue: "Go to",
+      defaultValue: "Go to @source",
       control: { type: "text" }
     },
     materialIsLoanedOutText: {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -233,6 +233,11 @@ export default {
       defaultValue: "See online",
       control: { type: "text" }
     },
+    listenOnlineText: {
+      name: "Listen online",
+      defaultValue: "Listen online",
+      control: { type: "text" }
+    },
     cantReserveText: {
       name: "Can't be reserved",
       defaultValue: "Can't be reserved",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -97,6 +97,7 @@ interface MaterialEntryTextProps {
   reviewsText: string;
   scopeText: string;
   seeOnlineText: string;
+  listenOnlineText: string;
   shiftText: string;
   sixMonthsText: string;
   threeMonthsText: string;

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, FC, useEffect } from "react";
+import { MaterialType } from "../../../../core/dbc-gateway/generated/graphql";
 import { useProxyUrlGET } from "../../../../core/dpl-cms/dpl-cms";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -47,7 +48,10 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
     }
   }, [data, error, translatedUrl, urlWasTranslated]);
 
-  const label = (sourceName: string, materialTypes: string[]) => {
+  const label = (
+    sourceName: string,
+    materialTypes: MaterialType["specific"][]
+  ) => {
     if (sourceName.includes("ereol")) {
       return `${t("goToText")} ereolen`;
     }

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -53,10 +53,10 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
     materialTypes: MaterialType["specific"][]
   ) => {
     if (sourceName.includes("ereol")) {
-      return `${t("goToText")} ereolen`;
+      return t("goToText", { placeholders: { "@source": "ereolen" } });
     }
     if (sourceName.includes("filmstriben")) {
-      return `${t("goToText")} filmstriben`;
+      return t("goToText", { placeholders: { "@source": "filmstriben" } });
     }
     if (materialTypes.find((element) => element.includes("lydbog"))) {
       return t("listenOnlineText");

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -2,6 +2,7 @@ import React, { useState, FC, useEffect } from "react";
 import { useProxyUrlGET } from "../../../../core/dpl-cms/dpl-cms";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
+import { Manifestation } from "../../../../core/utils/types/entities";
 import { LinkNoStyle } from "../../../atoms/link-no-style";
 import { Button } from "../../../Buttons/Button";
 
@@ -10,13 +11,15 @@ export interface MaterialButtonOnlineExternalProps {
   externalUrl: string;
   origin: string;
   size?: ButtonSize;
+  manifestation: Manifestation;
 }
 
 const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   loginRequired,
   externalUrl = "",
   origin,
-  size
+  size,
+  manifestation
 }) => {
   const [translatedUrl, setTranslatedUrl] = useState<URL>(new URL(externalUrl));
   const [urlWasTranslated, setUrlWasTranslated] = useState<boolean | null>(
@@ -44,10 +47,27 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
     }
   }, [data, error, translatedUrl, urlWasTranslated]);
 
+  const label = (sourceName: string, materialTypes: string[]) => {
+    if (sourceName.includes("ereol")) {
+      return `${t("goToText")} ereolen`;
+    }
+    if (sourceName.includes("filmstriben")) {
+      return `${t("goToText")} filmstriben`;
+    }
+    if (materialTypes.find((element) => element.includes("lydbog"))) {
+      return t("listenOnlineText");
+    }
+    return t("seeOnlineText");
+  };
   return (
     <LinkNoStyle url={translatedUrl}>
       <Button
-        label={`${t("goToText")} ${origin}`}
+        label={label(
+          origin,
+          manifestation.materialTypes.map(
+            (materialType) => materialType.specific
+          )
+        )}
         buttonType="external-link"
         variant="filled"
         disabled={false}

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -1,5 +1,8 @@
 import React, { useState, FC, useEffect } from "react";
-import { MaterialType } from "../../../../core/dbc-gateway/generated/graphql";
+import {
+  AccessUrl,
+  MaterialType
+} from "../../../../core/dbc-gateway/generated/graphql";
 import { useProxyUrlGET } from "../../../../core/dpl-cms/dpl-cms";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -14,6 +17,22 @@ export interface MaterialButtonOnlineExternalProps {
   size?: ButtonSize;
   manifestation: Manifestation;
 }
+
+export const getOnlineMaterialType = (
+  sourceName: AccessUrl["origin"],
+  materialTypes: MaterialType["specific"][]
+) => {
+  if (sourceName.includes("ereol")) {
+    return "ebook";
+  }
+  if (sourceName.includes("filmstriben")) {
+    return "emovie";
+  }
+  if (materialTypes.find((element) => element.includes("lydbog"))) {
+    return "audiobook";
+  }
+  return "unknown";
+};
 
 const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   loginRequired,
@@ -49,19 +68,20 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   }, [data, error, translatedUrl, urlWasTranslated]);
 
   const label = (
-    sourceName: string,
+    sourceName: AccessUrl["origin"],
     materialTypes: MaterialType["specific"][]
   ) => {
-    if (sourceName.includes("ereol")) {
-      return t("goToText", { placeholders: { "@source": "ereolen" } });
+    const onlineMaterialType = getOnlineMaterialType(sourceName, materialTypes);
+    switch (onlineMaterialType) {
+      case "ebook":
+        return t("goToText", { placeholders: { "@source": "ereolen" } });
+      case "emovie":
+        return t("goToText", { placeholders: { "@source": "filmstriben" } });
+      case "audiobook":
+        return t("listenOnlineText");
+      default:
+        return t("seeOnlineText");
     }
-    if (sourceName.includes("filmstriben")) {
-      return t("goToText", { placeholders: { "@source": "filmstriben" } });
-    }
-    if (materialTypes.find((element) => element.includes("lydbog"))) {
-      return t("listenOnlineText");
-    }
-    return t("seeOnlineText");
   };
   return (
     <LinkNoStyle url={translatedUrl}>

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -36,6 +36,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
         externalUrl={externalUrl}
         origin={origin}
         size={size}
+        manifestation={manifestation}
       />
     );
   }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-301

#### Description
This PR fixes an issue with the material page action. button. For online materials it should be showing:
- go to filmstriben (when the source is filmstriben)
- go to ereolen (when the source is ereol)
- listen online (when the material type is lydbog (net))
- see online (for the rest)

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/202388109-7cef6a7a-91b7-4adf-afc7-f64df6ac5f70.png)
![image](https://user-images.githubusercontent.com/28546954/202388146-2953ac79-fbd5-4a59-a32f-e830f8c62dec.png)
![image](https://user-images.githubusercontent.com/28546954/202388170-6240df9e-67a4-4fab-bb48-dad8b6449652.png)
![image](https://user-images.githubusercontent.com/28546954/202390672-b8afae3c-6983-4424-bd9a-8c11fe1f19ee.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a