### PR TITLE
Set develop as the default branch for Codecov code coverage reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  branch: develop
+
 # PR comments and annotations duplicate information that is also available in
 # the Codecov UI
 comment: false


### PR DESCRIPTION
#### Description

We have decided to drop `release/*` branches for continual development and move this to a permanent `develop` branch.

The admin UI is configured to use `release/4` and is filled with many other branches. For some reason develop does not show up. Lets hope defining it in code will work. It is preferable to have it in code anyways.

#### Screenshot of the problem

https://user-images.githubusercontent.com/73966/202441159-8735c0d7-48eb-4ec5-add6-61d2e9abe6ba.mp4

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

### Comments for the reviewer

The failing test is unrelated to the change at hand.