### PR TITLE
Add support for zero count in plural texts

### DIFF
--- a/src/core/utils/text.tsx
+++ b/src/core/utils/text.tsx
@@ -111,8 +111,16 @@ export const useText = (): UseTextFunction => {
     const textDefinition = constructTextDefinitionFromRawTextTextEntry(
       data?.[key] ?? key
     );
-    const processedTexts = placeholders
-      ? processTexts(textDefinition.text, placeholders)
+
+    const textPlaceholders = { ...(placeholders ?? {}) };
+    // If we are in plural mode we make sure
+    // that we do not also need to specify a count placeholder.
+    if (textDefinition.type === "plural") {
+      textPlaceholders["@count"] = String(count);
+    }
+
+    const processedTexts = textPlaceholders
+      ? processTexts(textDefinition.text, textPlaceholders)
       : textDefinition.text;
 
     switch (textDefinition.type) {

--- a/src/core/utils/text.tsx
+++ b/src/core/utils/text.tsx
@@ -92,6 +92,14 @@ const constructTextDefinitionFromRawTextTextEntry = (
 const processTexts = (texts: string[], placeholders: Placeholders) =>
   texts.map((text: string) =>
     text.replace(/@\w+/g, (match) => {
+      // If the placeholder value is zero we need to handle it specifically.
+      if (placeholders[match] === 0) {
+        return "0";
+      }
+      // Otherwise we check if we have a value for the placeholder.
+      // We return the value of the placeholder if found.
+      // Otherwise we return the placeholder itself
+      // to show that the placeholder value cannot be found.
       return String(placeholders[match] || match);
     })
   );
@@ -99,7 +107,7 @@ const processTexts = (texts: string[], placeholders: Placeholders) =>
 export const useText = (): UseTextFunction => {
   const { data } = useSelector((state: RootState) => state.text);
 
-  return (key: string, { placeholders, count } = {}) => {
+  return (key: string, { placeholders, count } = { count: 0 }) => {
     const textDefinition = constructTextDefinitionFromRawTextTextEntry(
       data?.[key] ?? key
     );
@@ -109,6 +117,10 @@ export const useText = (): UseTextFunction => {
 
     switch (textDefinition.type) {
       case "plural":
+        // If count is 0 we need the second text because it is the plural form.
+        if (count === 0) {
+          return processedTexts[1];
+        }
         // If count is 1 we select the first text entry
         // otherwise we select the second text entry.
         return processedTexts[1 % (count ?? 1)];


### PR DESCRIPTION
#### Description

Zero values was not being considered in the first version. This fixes the bug.

Additionally a feature to skip @count placeholder in plural mode has been added.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
