### PR TITLE
Fix: Warning: Each child in a list should have a unique "key" prop + Add createJSXkey

### DIFF
--- a/src/apps/loan-list/list/loan-list-items.tsx
+++ b/src/apps/loan-list/list/loan-list-items.tsx
@@ -5,6 +5,7 @@ import { ListView } from "../../../core/utils/types/list-view";
 import { LoanType } from "../../../core/utils/types/loan-type";
 import { getUrlQueryParam } from "../../../core/utils/helpers/url";
 import { isDate } from "../../../core/utils/helpers/date";
+import { createJSXkey } from "../../../core/utils/helpers/general";
 
 interface LoanListItemProps {
   loans: LoanType[];
@@ -34,7 +35,7 @@ const LoanListItems: FC<LoanListItemProps> = ({
   return (
     <div className="list-reservation-container m-32">
       {view === "stacked" &&
-        localDueDates.map((uniqueDueDate: string | null) => {
+        localDueDates.map((uniqueDueDate: string | null, i) => {
           // Stack items:
           // if multiple items have the same due date, they are "stacked"
           // which means styling making it look like there are multiple materials,
@@ -54,7 +55,7 @@ const LoanListItems: FC<LoanListItemProps> = ({
           }
 
           return (
-            <div>
+            <div key={createJSXkey([loan.faust, loan.identifier, i])}>
               {loan && (
                 <StackableMaterial
                   pageSize={pageSize}
@@ -63,7 +64,6 @@ const LoanListItems: FC<LoanListItemProps> = ({
                   identifier={loan.identifier}
                   faust={loan.faust}
                   openModal={openModal}
-                  key={loan.faust || loan.identifier}
                   amountOfMaterialsWithDueDate={loansUniqueDueDate.length}
                   stack={loansUniqueDueDate}
                 />
@@ -72,7 +72,7 @@ const LoanListItems: FC<LoanListItemProps> = ({
           );
         })}
       {view === "list" &&
-        loans.map((loan) => {
+        loans.map((loan, i) => {
           return (
             <StackableMaterial
               pageSize={pageSize}
@@ -80,7 +80,7 @@ const LoanListItems: FC<LoanListItemProps> = ({
               identifier={loan.identifier}
               faust={loan.faust}
               dueDateLabel={dueDateLabel}
-              key={loan.faust || loan.identifier}
+              key={createJSXkey([loan.faust, loan.identifier, i])}
               loan={loan}
             />
           );

--- a/src/apps/loan-list/modal/renew-loans-modal-content.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal-content.tsx
@@ -4,7 +4,8 @@ import SelectableMaterial from "../materials/selectable-material";
 import { useRenewLoansV2 } from "../../../core/fbs/fbs";
 import {
   getRenewableMaterials,
-  getAmountOfRenewableLoans
+  getAmountOfRenewableLoans,
+  createJSXkey
 } from "../../../core/utils/helpers/general";
 import { Button } from "../../../components/Buttons/Button";
 import { LoanType } from "../../../core/utils/types/loan-type";
@@ -119,12 +120,12 @@ const RenewLoansModalContent: FC<RenewLoansModalContentProps> = ({
               : ""
           }`}
         >
-          {displayedLoans.map((loanType) => {
+          {displayedLoans.map((loanType, i) => {
             return (
               <SelectableMaterial
                 faust={loanType.faust}
                 identifier={loanType.identifier}
-                key={loanType.faust}
+                key={createJSXkey([loanType.faust, i])}
                 materialsToRenew={materialsToRenew}
                 onChecked={onChecked}
                 disabled={!loanType.isRenewable}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -123,11 +123,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       >
         {manifestations.map((manifestation: Manifestation) => {
           return (
-            <>
-              <MaterialMainfestationItem
-                key={manifestation.pid}
-                manifestation={manifestation}
-              />
+            <div key={manifestation.pid}>
+              <MaterialMainfestationItem manifestation={manifestation} />
               <FindOnShelfModal
                 manifestations={[manifestation]}
                 workTitles={manifestation.titles.main}
@@ -140,7 +137,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
                 mainManifestation={manifestation}
                 parallelManifestations={parallelManifestations}
               />
-            </>
+            </div>
           );
         })}
       </Disclosure>

--- a/src/apps/patron-page/util/BranchesDropdown.tsx
+++ b/src/apps/patron-page/util/BranchesDropdown.tsx
@@ -57,6 +57,7 @@ const BranchesDropdown: FC<BranchesDropdownProps> = ({
               )}
               {pickupModalBranches.map(({ branchId, title }) => (
                 <option
+                  key={branchId}
                   selected={selected === branchId}
                   className="dropdown__option"
                   value={branchId}

--- a/src/apps/reservation-list/list/list.tsx
+++ b/src/apps/reservation-list/list/list.tsx
@@ -1,7 +1,10 @@
 import React, { FC, useState, useEffect } from "react";
 import EmptyList from "../../../components/empty-list/empty-list";
 import usePager from "../../../components/result-pager/use-pager";
-import { getListItems } from "../../../core/utils/helpers/general";
+import {
+  createJSXkey,
+  getListItems
+} from "../../../core/utils/helpers/general";
 import { ReservationType } from "../../../core/utils/types/reservation-type";
 import ReservationMaterial from "../reservation-material/reservation-material";
 
@@ -37,9 +40,9 @@ const List: FC<ListProps> = ({ list, header, emptyListLabel, pageSize }) => {
         {displayedReservations.length === 0 && (
           <EmptyList emptyListText={emptyListLabel} />
         )}
-        {displayedReservations.map((reservation) => (
+        {displayedReservations.map((reservation, i) => (
           <ReservationMaterial
-            key={reservation.identifier || reservation.faust}
+            key={createJSXkey([reservation.identifier, reservation.faust, i])}
             identifier={reservation.identifier}
             faust={reservation.faust}
             reservation={reservation}

--- a/src/apps/reservation-list/reservation-material/reservation-status.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-status.tsx
@@ -1,4 +1,5 @@
 import React, { FC, ReactNode } from "react";
+import { createJSXkey } from "../../../core/utils/helpers/general";
 import StatusCircleIcon from "../../loan-list/materials/utils/status-circle-icon";
 
 interface ReservationStatusProps {
@@ -42,8 +43,15 @@ const ReservationStatus: FC<ReservationStatusProps> = ({
             <p className="text-small-caption">{label}</p>
           )}
           {typeof label !== "string" &&
-            label.map((localLabel) => {
-              return <p className="text-small-caption">{localLabel}</p>;
+            label.map((localLabel, i) => {
+              return (
+                <p
+                  key={createJSXkey([localLabel, i])}
+                  className="text-small-caption"
+                >
+                  {localLabel}
+                </p>
+              );
             })}
         </div>
       </div>

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -3,6 +3,7 @@ import { UseComboboxPropGetters } from "downshift";
 import * as React from "react";
 import { FC } from "react";
 import { SuggestionsFromQueryStringQuery } from "../../core/dbc-gateway/generated/graphql";
+import { createJSXkey } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { Suggestion } from "../../core/utils/types/autosuggest";
 
@@ -39,7 +40,7 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
                   "autosuggest__text--highlight": highlightedIndex === index
                 }
               )}`}
-              key={item}
+              key={createJSXkey([item.term, index])}
               {...getItemProps({ item, index })}
             >
               {`${item.term} ${t("inText")}`}

--- a/src/components/autosuggest-text/autosuggest-text.tsx
+++ b/src/components/autosuggest-text/autosuggest-text.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import { UseComboboxPropGetters } from "downshift";
 import React from "react";
 import { SuggestionType } from "../../core/dbc-gateway/generated/graphql";
+import { createJSXkey } from "../../core/utils/helpers/general";
 import { Suggestion, Suggestions } from "../../core/utils/types/autosuggest";
 import AutosuggestTextItem from "./autosuggest-text-item";
 
@@ -45,6 +46,7 @@ export const AutosuggestText: React.FC<AutosuggestTextProps> = ({
           };
           return (
             <AutosuggestTextItem
+              key={createJSXkey([item.term, index])}
               classes={classes}
               item={item}
               index={index}

--- a/src/components/description-list/description-list.tsx
+++ b/src/components/description-list/description-list.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { createJSXkey } from "../../core/utils/helpers/general";
 
 export interface DescriptionListProps {
   classNames?: string;
@@ -11,10 +12,10 @@ const DescriptionList: React.FC<DescriptionListProps> = ({
 }) => {
   return (
     <dl className={`list-description ${classNames ?? ""}`}>
-      {data.map((item) => {
+      {data.map((item, i) => {
         const { label, value } = item;
         return (
-          <div>
+          <div key={createJSXkey([label, i])}>
             <dt>{label}</dt>
             <dd>{value}</dd>
           </div>

--- a/src/components/find-on-shelf/FindOnShelfManifestationList.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationList.tsx
@@ -4,7 +4,10 @@ import { totalAvailableMaterials } from "../../apps/material/helper";
 import { useText } from "../../core/utils/text";
 import { ManifestationHoldings } from "./types";
 import FindOnShelfManifestationListItem from "./FindOnShelfManifestationListItem";
-import { getManifestationPublicationYear } from "../../core/utils/helpers/general";
+import {
+  createJSXkey,
+  getManifestationPublicationYear
+} from "../../core/utils/helpers/general";
 
 export interface FindOnShelfManifestationListProps {
   libraryBranchHoldings: ManifestationHoldings;
@@ -26,7 +29,7 @@ const FindOnShelfManifestationList: FC<FindOnShelfManifestationListProps> = ({
           {t("findOnShelfModalListItemCountText")}
         </span>
       </li>
-      {libraryBranchHoldings.map((branchHolding) => {
+      {libraryBranchHoldings.map((branchHolding, i) => {
         return (
           <FindOnShelfManifestationListItem
             shelfmark={branchHolding.manifestation.shelfmark}
@@ -40,7 +43,7 @@ const FindOnShelfManifestationList: FC<FindOnShelfManifestationListProps> = ({
             numberAvailable={totalAvailableMaterials(
               branchHolding.holding.materials
             )}
-            key={branchHolding.holding.branch.branchId}
+            key={createJSXkey([branchHolding.holding.branch.branchId, i])}
           />
         );
       })}

--- a/src/components/list-details/list-details.tsx
+++ b/src/components/list-details/list-details.tsx
@@ -26,7 +26,9 @@ const ListDetails: FC<ListDetailsProps> = ({
           )}
           {typeof labels !== "string" &&
             labels.map((label: string) => (
-              <p className="text-small-caption">{label}</p>
+              <p key={label} className="text-small-caption">
+                {label}
+              </p>
             ))}
         </div>
       </div>

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { createJSXkey } from "../../../core/utils/helpers/general";
 import { Manifestation } from "../../../core/utils/types/entities";
 import MaterialAvailabilityTextOnline from "./online/MaterialAvailabilityTextOnline";
 import MaterialAvailabilityTextPhysical from "./physical/MaterialAvailabilityTextPhysical";
@@ -13,11 +14,17 @@ const MaterialAvailabilityText: React.FC<Props> = ({
 }) => {
   return (
     <>
-      {manifestation.accessTypes.map((item) => {
+      {manifestation.accessTypes.map((item, i) => {
+        const key = createJSXkey([item.code, i]);
         if (item.code === "PHYSICAL")
-          return <MaterialAvailabilityTextPhysical pid={pid} />;
+          return <MaterialAvailabilityTextPhysical key={key} pid={pid} />;
         if (item.code === "ONLINE" && identifiers.length > 0)
-          return <MaterialAvailabilityTextOnline isbn={identifiers[0].value} />;
+          return (
+            <MaterialAvailabilityTextOnline
+              key={key}
+              isbn={identifiers[0].value}
+            />
+          );
         return null;
       })}
     </>

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
+import { createJSXkey } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
   constructSearchUrl
@@ -42,9 +43,10 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
       )}
       <div className="material-description__links mt-32">
         {inSeries &&
-          inSeries.map((seriesItem) => {
+          inSeries.map((seriesItem, i) => {
             return (
               <HorizontalTermLine
+                key={createJSXkey([seriesItem.title, i])}
                 title={`${t("numberDescriptionText")} ${
                   seriesItem.numberInSeries?.number
                 }`}

--- a/src/components/material/MaterialReviews.tsx
+++ b/src/components/material/MaterialReviews.tsx
@@ -4,6 +4,7 @@ import {
   InfomediaReview,
   LibrariansReview
 } from "../../core/dbc-gateway/generated/graphql";
+import { createJSXkey } from "../../core/utils/helpers/general";
 import ReviewExternal from "./ReviewExternal";
 import ReviewInfomedia from "./ReviewInfomedia";
 import ReviewLibrarian from "./ReviewLibrarian";
@@ -17,14 +18,17 @@ export const MaterialReviews: React.FC<MaterialReviewsProps> = ({
 }) => {
   return (
     <ul className="reviews">
-      {listOfReviews.map((review) => {
+      {listOfReviews.map((review, i) => {
+        const key = createJSXkey([review.author, review.date, i]);
         if (review.__typename === "ExternalReview") {
-          return <ReviewExternal review={review} />;
+          return <ReviewExternal key={key} review={review} />;
         }
         if (review.__typename === "InfomediaReview") {
-          return <ReviewInfomedia review={review} />;
+          return <ReviewInfomedia key={key} review={review} />;
         }
-        return <ReviewLibrarian review={review as LibrariansReview} />;
+        return (
+          <ReviewLibrarian key={key} review={review as LibrariansReview} />
+        );
       })}
     </ul>
   );

--- a/src/components/material/ReviewExternal.tsx
+++ b/src/components/material/ReviewExternal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ExternalReview } from "../../core/dbc-gateway/generated/graphql";
 import ReviewMetadata, { usDateStringToDateObj } from "./ReviewMetadata";
 import ReviewHearts from "./ReviewHearts";
+import { createJSXkey } from "../../core/utils/helpers/general";
 
 export interface ReviewExternalProps {
   review: ExternalReview;
@@ -16,9 +17,13 @@ const ReviewExternal: React.FC<ReviewExternalProps> = ({
       {(author || reviewDate) && <ReviewMetadata author={author} date={date} />}
       {rating && <ReviewHearts amountOfHearts={rating} />}
       {urls &&
-        urls.map(({ url, origin }) => {
+        urls.map(({ url, origin }, i) => {
           return (
-            <a href={url} className="link-tag text-small-caption mb-8">
+            <a
+              href={url}
+              key={createJSXkey([url, i])}
+              className="link-tag text-small-caption mb-8"
+            >
               {origin}
             </a>
           );

--- a/src/components/material/ReviewLibrarian.tsx
+++ b/src/components/material/ReviewLibrarian.tsx
@@ -3,6 +3,7 @@ import {
   LibrariansReview,
   LibrariansReviewSection
 } from "../../core/dbc-gateway/generated/graphql";
+import { createJSXkey } from "../../core/utils/helpers/general";
 import ReviewMetadata, { usDateStringToDateObj } from "./ReviewMetadata";
 
 export interface ReviewLibrarianProps {
@@ -17,16 +18,16 @@ const ReviewLibrarian: React.FC<ReviewLibrarianProps> = ({ review }) => {
         <ReviewMetadata author={review.author} date={date} />
       )}
       {review.sections &&
-        review.sections.map((section: LibrariansReviewSection) => {
+        review.sections.map((section: LibrariansReviewSection, i) => {
           return (
-            <>
+            <div key={createJSXkey([section.heading, i])}>
               {section.heading && (
                 <div className="review__headline mb-8">{section.heading}</div>
               )}
               {section.text && (
                 <div className="review__body mb-8">{section.text}</div>
               )}
-            </>
+            </div>
           );
         })}
     </li>

--- a/src/components/reservation/forms/ModalReservationFormSelect.tsx
+++ b/src/components/reservation/forms/ModalReservationFormSelect.tsx
@@ -72,7 +72,7 @@ const ModalReservationFormSelect = ({
               {t("chooseOneText")}
             </option>
             {items.map(({ label, value }) => (
-              <option className="dropdown__option" value={value}>
+              <option key={value} className="dropdown__option" value={value}>
                 {label}
               </option>
             ))}

--- a/src/components/search-result-list/SearchResultList.tsx
+++ b/src/components/search-result-list/SearchResultList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCoverTint } from "../../core/utils/helpers/general";
+import { createJSXkey, getCoverTint } from "../../core/utils/helpers/general";
 import { Work } from "../../core/utils/types/entities";
 import SearchResultListItem from "./search-result-list-item/search-result-list-item";
 
@@ -11,7 +11,7 @@ const SearchResultList: React.FC<SearchResultListProps> = ({ resultItems }) => {
   return (
     <ul className="search-result-page__list my-16">
       {resultItems.map((item, i) => (
-        <li key={item.workId}>
+        <li key={createJSXkey([item.workId, i])}>
           <SearchResultListItem item={item} coverTint={getCoverTint(i)} />
         </li>
       ))}

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -279,4 +279,13 @@ export const pageSizeGlobal = (
   return pageSize;
 };
 
+export const createJSXkey = (
+  elements: (string | number | null | undefined)[]
+) => {
+  const filteredElements = elements
+    .filter((element) => element)
+    .map((element) => String(element).replace(/ /g, "-"));
+  return filteredElements.join("-");
+};
+
 export default {};


### PR DESCRIPTION
### This PR ensures that all child components of a map function have a key to prevent this warning: Each child in a list should have a unique "key" prop

This is important for the way react renders and re-renders. In some places, it could be solved by inserting a key with a unique value that was already there. 

Elsewhere I have used a new function createJSXkey that accepts an array of strings and retunes a compiled key that removes falsy values and replaces spaces with hyphens

I have used this function in several places together with the index number I can retrieve from the map function to avoid the keys may be the same. This mostly happens because we use fixture data in cypress and I have found console errors via testing

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
