### PR TITLE
Add missing campaign interception in Cypress tests

### DIFF
--- a/src/apps/search-result/facet-browser.test.ts
+++ b/src/apps/search-result/facet-browser.test.ts
@@ -173,8 +173,29 @@ describe("The Facet Browser", () => {
 
     cy.getBySel("modal-facet-browser-modal-close-button").click();
 
-    cy.contains("h1", "“harry” (843)");
+    // Intercept covers.
+    cy.fixture("cover.json")
+      .then((result) => {
+        cy.intercept("GET", "**/covers**", result);
+      })
+      .as("Cover service");
+
+    // Intercept material list service.
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404,
+      body: {}
+    }).as("Material list service");
+
+    // Intercept campaign query.
+    cy.fixture("search-result/campaign.json")
+      .then((result) => {
+        cy.intercept("**/dpl_campaign/match", result);
+      })
+      .as("Campaign service - full campaign");
+
+    cy.visit("/iframe.html?id=apps-search-result--search-result");
+    cy.contains("button", "+ more filters").click();
   });
 });
 
-export {};
+export default {};

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -128,6 +128,13 @@ describe("Search Result", () => {
       statusCode: 404,
       body: {}
     }).as("Material list service");
+
+    // Intercept campaign query.
+    cy.fixture("search-result/campaign.json")
+      .then((result) => {
+        cy.intercept("**/dpl_campaign/match", result);
+      })
+      .as("Campaign service - full campaign");
   });
 });
 


### PR DESCRIPTION
#### Description

Since the campaign endpoint was introduced in search results
we need to have the requests intercepted in all tests that shows search results


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
