### PR TITLE
Remove goToEReolenText as a material app prop.

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -208,11 +208,6 @@ export default {
       defaultValue: "Creators are missing",
       control: { type: "text" }
     },
-    goToEReolenText: {
-      name: "Go to e-Reolen",
-      defaultValue: "Go to e-Reolen",
-      control: { type: "text" }
-    },
     readArticleText: {
       name: "Read article",
       defaultValue: "Read article",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -36,7 +36,6 @@ interface MaterialEntryTextProps {
   findOnShelfModalScreenReaderModalDescriptionText: string;
   genreAndFormText: string;
   getOnlineText: string;
-  goToEReolenText: string;
   goToText: string;
   haveNoInterestAfterText: string;
   identifierText: string;


### PR DESCRIPTION
#### Description
goToEReolenText is depricated since the introduction of the @source placeholder in the goToText. We no longer use it in any of the apps. 

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.