### PR TITLE
THIS IS A TEMPORARY TEST SOLUTION

### DIFF
--- a/src/core/cover-service-api/mutator/fetcher.ts
+++ b/src/core/cover-service-api/mutator/fetcher.ts
@@ -1,6 +1,6 @@
 import { getToken, TOKEN_LIBRARY_KEY } from "../../token";
 
-const baseURL = "https://cover.dandigbib.org"; // use your own URL here or environment variable
+const baseURL = "http://cover.dandigbib.org"; // use your own URL here or environment variable
 
 export const fetcher = async <ResponseType>({
   url,
@@ -36,8 +36,7 @@ export const fetcher = async <ResponseType>({
   const body = data ? JSON.stringify(data) : null;
 
   const response = await fetch(
-    `${baseURL}${url}${
-      params ? `?${new URLSearchParams(params as FetchParams)}` : ""
+    `${baseURL}${url}${params ? `?${new URLSearchParams(params as FetchParams)}` : ""
     }`,
     {
       method,

--- a/src/core/dbc-gateway/graphql-fetcher.ts
+++ b/src/core/dbc-gateway/graphql-fetcher.ts
@@ -20,7 +20,7 @@ export const fetcher = <TData, TVariables>(
       // For now the endpoint is hardcoded. (although it is unclear which agency id to use)
       // When we get wiser of when the library id and profile is changing
       // we will update it with a dynamic version:
-      "https://fbi-api.dbc.dk/opac/graphql",
+      "http://fbi-api.dbc.dk/opac/graphql",
       {
         method: "POST",
         ...{

--- a/src/core/fbs/mutator/fetcher.ts
+++ b/src/core/fbs/mutator/fetcher.ts
@@ -1,7 +1,7 @@
 import { getToken, TOKEN_LIBRARY_KEY, TOKEN_USER_KEY } from "../../token";
 import { getFetcherUrl, configTypes } from "../../utils/helpers/fetcher";
 
-const defaultBaseUrl = "https://fbs-openplatform.dbc.dk";
+const defaultBaseUrl = "http://fbs-openplatform.dbc.dk";
 
 type FetchParams =
   | string

--- a/src/core/material-list-api/mutator/fetcher.ts
+++ b/src/core/material-list-api/mutator/fetcher.ts
@@ -1,6 +1,6 @@
 import { getToken, TOKEN_USER_KEY } from "../../token";
 
-const baseURL = "https://prod.materiallist.dandigbib.org"; // use your own URL here or environment variable
+const baseURL = "http://prod.materiallist.dandigbib.org"; // use your own URL here or environment variable
 
 export const fetcher = async <ResponseType>({
   url,

--- a/src/core/publizon/mutator/fetcher.ts
+++ b/src/core/publizon/mutator/fetcher.ts
@@ -1,7 +1,7 @@
 import { getToken, TOKEN_USER_KEY, TOKEN_LIBRARY_KEY } from "../../token";
 import { getFetcherUrl, configTypes } from "../../utils/helpers/fetcher";
 
-const defaultBaseUrl = "https://pubhub-openplatform.test.dbc.dk";
+const defaultBaseUrl = "http://pubhub-openplatform.test.dbc.dk";
 
 type FetchParams =
   | string


### PR DESCRIPTION
We are hardcoding the fetcher baseurls to use http because of cert
errors when running pa11y

#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
