### PR TITLE
Feature/5411 paginate last page

### DIFF
--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -1,7 +1,7 @@
 const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
 
 describe("Search Result", () => {
-  it("should render the site", () => {
+  it("Should render the site", () => {
     cy.visit(
       "/iframe.html?id=apps-search-result--search-result&args=pageSizeDesktop:2;pageSizeMobile:2"
     );
@@ -62,7 +62,7 @@ describe("Search Result", () => {
   });
 
   // TODO: When the pager bug has been solved, this test can be re-enabled.
-  it.skip("Do we have a pager?", () => {
+  it("Do we have a pager?", () => {
     cy.get(".result-pager__title").should(
       "contain.text",
       "Showing 2 out of 9486 results"

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -50,11 +50,8 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   );
   const cleanBranches = cleanBranchesId(whitelistBranches);
   const [resultItems, setResultItems] = useState<Work[]>([]);
-  const [hitcount, setHitCount] = useState<number | null>(null);
-  const { PagerComponent, page, resetPager } = usePager(
-    hitcount === null ? 0 : hitcount,
-    pageSize
-  );
+  const [hitcount, setHitCount] = useState<number>(0);
+  const { PagerComponent, page } = usePager(hitcount, pageSize);
   const { filters, filterHandler } = useFilterHandler();
   const { mutate } = useCampaignMatchPOST();
   const [campaignData, setCampaignData] = useState<CampaignMatchPOST200 | null>(
@@ -62,7 +59,6 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   );
   const filteringHandler: TermOnClickHandler = (filterInfo) => {
     filterHandler(filterInfo);
-    resetPager();
   };
   const { facets: campaignFacets } = useGetFacets(q, filters);
 
@@ -134,13 +130,14 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
       };
     };
 
+    setHitCount(resultCount);
+
     // if page has change then append the new result to the existing result
     if (page > 0) {
       setResultItems((prev) => [...prev, ...resultWorks]);
       return;
     }
 
-    setHitCount(resultCount);
     setResultItems(resultWorks);
   }, [data, page]);
 

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -51,6 +51,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   const cleanBranches = cleanBranchesId(whitelistBranches);
   const [resultItems, setResultItems] = useState<Work[]>([]);
   const [hitcount, setHitCount] = useState<number>(0);
+  const [canWeTrackHitcount, setCanWeTrackHitcount] = useState<boolean>(false);
   const { PagerComponent, page } = usePager(hitcount, pageSize);
   const { filters, filterHandler } = useFilterHandler();
   const { mutate } = useCampaignMatchPOST();
@@ -142,9 +143,11 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   }, [data, page]);
 
   useEffect(() => {
-    // We want to disregard the first search result length because it is always 0
-    // (we set it using setHitCount useEffect() above)
-    if (hitcount === null) {
+    // We want to disregard the first hitcount because it is always 0 and doesn't
+    // represent reality (the number is set manually by us in the code). We only
+    // track all the following hitcount values that are based on the data.
+    if (!canWeTrackHitcount) {
+      setCanWeTrackHitcount(true);
       return;
     }
     track("click", {

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ResultPager from "./result-pager";
 
 const usePager = (
@@ -11,21 +11,28 @@ const usePager = (
     hitcount = 0;
   }
 
-  const [itemsShown, setitemsShown] = useState(
+  const [itemsShown, setItemsShown] = useState(
     pageSize >= hitcount ? hitcount : pageSize
   );
   const [page, setPage] = useState<number>(0);
 
   const resetPager = () => {
     setPage(0);
-    setitemsShown(pageSize);
+    setItemsShown(pageSize);
   };
+
+  useEffect(() => {
+    setItemsShown(pageSize >= hitcount ? hitcount : pageSize);
+  }, [hitcount, pageSize]);
 
   const pagehandler = () => {
     const currentPage = page + 1;
     const itemsOnPage = (currentPage + 1) * pageSize;
+    const onLastPage = itemsOnPage > hitcount;
+    // the "itemsOnPage > hitcount"-check is to
+    // To avoid the "showing 10 out of 8"-situation
+    setItemsShown(onLastPage ? hitcount : itemsOnPage);
     setPage(currentPage);
-    setitemsShown(itemsOnPage);
   };
 
   const PagerComponent = hitcount ? (

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -6,23 +6,14 @@ const usePager = (
   pageSize: number,
   overrideItemsShown?: () => number
 ) => {
-  if (hitcount === null) {
-    // eslint-disable-next-line no-param-reassign
-    hitcount = 0;
-  }
-
   const [itemsShown, setItemsShown] = useState(
     pageSize >= hitcount ? hitcount : pageSize
   );
   const [page, setPage] = useState<number>(0);
 
-  const resetPager = () => {
-    setPage(0);
-    setItemsShown(pageSize);
-  };
-
   useEffect(() => {
-    setItemsShown(pageSize >= hitcount ? hitcount : pageSize);
+    const onLastPage = pageSize > hitcount;
+    setItemsShown(onLastPage ? hitcount : pageSize);
   }, [hitcount, pageSize]);
 
   const pagehandler = () => {
@@ -43,7 +34,7 @@ const usePager = (
     />
   ) : null;
 
-  return { itemsShown, PagerComponent, page, resetPager };
+  return { itemsShown, PagerComponent, page };
 };
 
 export default usePager;

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import ResultPager from "./result-pager";
 
 const usePager = (
-  hitcount: number | null,
+  hitcount: number,
   pageSize: number,
   overrideItemsShown?: () => number
 ) => {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5411

#### Description

Corrected error (setitemsShown => setItemsShown)
added useeffect, that set initial total amount 
removed resetPager, as above mentioned useeffect makes it obsolete
renamed so the phrase "last page" is used -> readability
