### PR TITLE
Fix campaign test

### DIFF
--- a/cypress/fixtures/search-result/campaign-image-only.json
+++ b/cypress/fixtures/search-result/campaign-image-only.json
@@ -1,10 +1,12 @@
 {
   "data": {
+    "id": "1999",
+    "title": "Campaign title",
     "text": null,
     "image": {
       "url": "https://picsum.photos/id/777/300/200",
       "alt": "I am a campaign image."
     },
-    "url": null
+    "url": "http://localhost/?path=/story/apps-search-result--search-result"
   }
 }

--- a/cypress/fixtures/search-result/campaign-text-only.json
+++ b/cypress/fixtures/search-result/campaign-text-only.json
@@ -1,10 +1,12 @@
 {
   "data": {
+    "id": "1999",
+    "title": "Campaign title",
     "text": "Lorem ipsum Harry Potter dolor sit amet, consectetur adipiscing elit. Nunc pellentesque, nulla et tempor iaculis, elit dui dictum nisl, quis porta.",
     "image": {
       "url": null,
       "alt": null
     },
-    "url": null
+    "url": "http://localhost/?path=/story/apps-search-result--search-result"
   }
 }

--- a/cypress/fixtures/search-result/campaign.json
+++ b/cypress/fixtures/search-result/campaign.json
@@ -1,5 +1,7 @@
 {
   "data": {
+    "id": "1999",
+    "title": "Campaign title",
     "text": "Lorem ipsum Harry Potter dolor sit amet, consectetur adipiscing elit. Nunc pellentesque, nulla et tempor iaculis, elit dui dictum nisl, quis porta.",
     "image": {
       "url": "https://picsum.photos/id/777/300/200",

--- a/src/components/campaign/CampaignBody.tsx
+++ b/src/components/campaign/CampaignBody.tsx
@@ -8,9 +8,10 @@ export interface CampaignBodyProps {
 
 const CampaignBody: FC<CampaignBodyProps> = ({ campaignData }) => {
   return (
-    <section className="campaign mt-35">
+    <section className="campaign mt-35" data-cy="campaign-body">
       {campaignData.image && campaignData.image.url && (
         <img
+          data-cy="campaign-image"
           className={`campaign__image ${
             !campaignData.text ? "campaign__image--full-width" : ""
           }`}

--- a/src/components/campaign/campaign.test.ts
+++ b/src/components/campaign/campaign.test.ts
@@ -71,13 +71,7 @@ describe("Campaign", () => {
     isImageLoaded(cy);
     cy.getBySel("campaign-image").should("have.attr", "alt");
     cy.getBySel("campaign-body").should("be.visible").contains("Harry Potter");
-    cy.get("a")
-      .first()
-      .should(
-        "have.attr",
-        "href",
-        "http://localhost/?path=/story/apps-search-result--search-result"
-      );
+    cy.getBySel("link-no-style").should("have.attr", "role", "button");
   });
 
   it("Shows a text-only campaign without an image", () => {


### PR DESCRIPTION
#### Link to issue
/

#### Description
This PR makes changes to the campaign cypress test in order to prevent it from failing. The problems stemmed from recent 
 campaign component semantic changes for how it is displayed when it should be clickable. The test now reflects these changes.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/204797676-d6739bd3-50f4-4e70-a1c6-8261639c01b4.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a