### PR TITLE
Fix falling material test

### DIFF
--- a/src/components/material/periodical/MaterialPeriodical.tsx
+++ b/src/components/material/periodical/MaterialPeriodical.tsx
@@ -45,7 +45,7 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
     "volumeYear"
   );
 
-  if (!groupByVolumeYear || !selectedPeriodical || !selectPeriodicalHandler) {
+  if (!groupByVolumeYear || !selectPeriodicalHandler) {
     return null;
   }
 


### PR DESCRIPTION
#### Fix falling material test

An unnecessary check has been introduced by mistake

in the MaterialPeriodical was there a check for if selectedPeriodical has a value

but selectedPeriodical is null to start with and will not be set until later in the flow.

The check in MaterialPeriodical ensures that MaterialPeriodicalSelect will never be rendered. which we do not want. Therefore I have removed it.

This is also why material tests fail.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

