### PR TITLE
Fix bug: Change <main> to <section>

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -113,6 +113,17 @@
               "__typename"
             ]
           }
+        ],
+        "react/forbid-elements": [
+          1,
+          {
+            "forbid": [
+              {
+                "element": "main",
+                "message": "dpl-cms provide a <main> to render react in, therefore you must use <section> to avoid duplicate main"
+              }
+            ]
+          }
         ]
       }
     },

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -159,7 +159,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const shouldOpenReviewDisclosure = !!getUrlQueryParam("disclosure");
 
   return (
-    <main className="material-page">
+    <section className="material-page">
       <MaterialHeader
         wid={wid}
         work={work}
@@ -262,7 +262,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           )}
         </>
       )}
-    </main>
+    </section>
   );
 };
 


### PR DESCRIPTION
## depends on https://github.com/danskernesdigitalebibliotek/dpl-react/pull/265

#### https://reload.atlassian.net/browse/DDFSOEG-337

#### Because dpl-cms provides a main tag where react is rendered, we cannot also use main in the code
<img width="1075" alt="Skærmbillede 2022-12-05 kl  15 12 42" src="https://user-images.githubusercontent.com/49920322/205659650-eca4b10a-5247-479a-9232-4455a2417373.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
