### PR TITLE
Fix unwanted redirect to material page on tab

### DIFF
--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -98,7 +98,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     <article
       className="search-result-item arrow arrow__hover--right-small"
       onClick={handleClick}
-      onKeyUp={handleClick}
+      onKeyUp={(e) => e.key === "Enter" && handleClick}
     >
       <div className="search-result-item__cover">
         <SearchResultListItemCover


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Fix unwanted redirect to material page on tab
Because we use onKeyUp we also need to specify which key we are listening to. Therefore we check if e.key === "Enter" otherwise the tab button and all other buttons will also activate the function.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

