### PR TITLE
Correcting syntax error in MaterialButtons

### DIFF
--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -66,7 +66,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   );
   const isPeriodical = manifestation.materialTypes.some(
     (materialType: Manifestation["materialTypes"][0]) => {
-      return materialType.specific.includes("tidsskrift");
+      return materialType.specific === "tidsskrift";
     }
   );
 

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -46,15 +46,15 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
             />
           </>
         )}
-      {hasCorrectAccessType(AccessTypeCode.Online, manifestation) ||
-        (hasCorrectAccess("DigitalArticleService", manifestation) && (
-          <MaterialButtonsOnline
-            manifestation={manifestation}
-            size={size}
-            workId={workId}
-            dataCy={`${dataCy}-find-on-shelf`}
-          />
-        ))}
+      {(hasCorrectAccessType(AccessTypeCode.Online, manifestation) ||
+        hasCorrectAccess("DigitalArticleService", manifestation)) && (
+        <MaterialButtonsOnline
+          manifestation={manifestation}
+          size={size}
+          workId={workId}
+          dataCy={`${dataCy}-find-on-shelf`}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
#### Correcting syntax error in MaterialButtons
Brackets were missing to check if either hasCorrectAccessType or hasCorrectAccess was true

#### Change isPeriodical to check that it exactly contains "tidsskrift"
Instead of using includes as returned true because "tidsskrift" is part of "tidsskriftsartikel" which is the type of material that can be ordered as a digital copy

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

