### PR TITLE
Add test for order digital copy + Move infomedia & periodical into its own separate files

### DIFF
--- a/cypress/fixtures/material/order-digital-copy/order-digital-fbi-api.json
+++ b/cypress/fixtures/material/order-digital-copy/order-digital-fbi-api.json
@@ -1,0 +1,275 @@
+{
+  "data": {
+    "work": {
+      "workId": "work-of:870971-tsart:34310815",
+      "titles": {
+        "full": [
+          "Faglig formidling er ikke kun skriveteknik"
+        ],
+        "original": []
+      },
+      "abstract": [
+        "Om skriftlig formidling af faglig viden til ikke-fagfolk"
+      ],
+      "creators": [
+        {
+          "display": "Leif Becker Jensen",
+          "__typename": "Person"
+        }
+      ],
+      "series": [
+        {
+          "title": "Skriftlig faglig formidling",
+          "isPopular": null,
+          "numberInSeries": null,
+          "readThisFirst": null,
+          "readThisWhenever": null
+        }
+      ],
+      "seriesMembers": [
+        {
+          "workId": "work-of:870971-tsart:34310858",
+          "titles": {
+            "main": [
+              "Skriftlighed i overgangen fra folkeskole til gymnasieuddannelse"
+            ],
+            "full": [
+              "Skriftlighed i overgangen fra folkeskole til gymnasieuddannelse"
+            ],
+            "original": []
+          }
+        },
+        {
+          "workId": "work-of:870971-tsart:34310866",
+          "titles": {
+            "main": [
+              "Grammatikkens poesi"
+            ],
+            "full": [
+              "Grammatikkens poesi"
+            ],
+            "original": []
+          }
+        },
+        {
+          "workId": "work-of:870971-tsart:34310815",
+          "titles": {
+            "main": [
+              "Faglig formidling er ikke kun skriveteknik"
+            ],
+            "full": [
+              "Faglig formidling er ikke kun skriveteknik"
+            ],
+            "original": []
+          }
+        },
+        {
+          "workId": "work-of:870971-tsart:34310831",
+          "titles": {
+            "main": [
+              "Skal det være så svært at lære at skrive godt?"
+            ],
+            "full": [
+              "Skal det være så svært at lære at skrive godt? : om at træne grundlæggende skrivekompetencer med udgangspunkt i en konkret tværfaglig skriveopgave i dansk og matematik"
+            ],
+            "original": []
+          }
+        }
+      ],
+      "genreAndForm": [],
+      "manifestations": {
+        "all": [
+          {
+            "pid": "870971-tsart:34310815",
+            "genreAndForm": [],
+            "source": [
+              "Tidsskriftsartikler"
+            ],
+            "titles": {
+              "main": [
+                "Faglig formidling er ikke kun skriveteknik"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "tidsskriftsartikel"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Leif Becker Jensen",
+                "__typename": "Person"
+              }
+            ],
+            "hostPublication": {
+              "title": "Dansk noter",
+              "creator": null,
+              "publisher": null,
+              "year": {
+                "year": 2010
+              }
+            },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [],
+            "contributors": [],
+            "edition": {
+              "summary": "2010",
+              "publicationYear": {
+                "display": "2010"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "DigitalArticleService",
+                "issn": "01071424"
+              },
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null
+          }
+        ],
+        "latest": {
+          "pid": "870971-tsart:34310815",
+          "genreAndForm": [],
+          "source": [
+            "Tidsskriftsartikler"
+          ],
+          "titles": {
+            "main": [
+              "Faglig formidling er ikke kun skriveteknik"
+            ],
+            "original": []
+          },
+          "fictionNonfiction": {
+            "display": "faglitteratur",
+            "code": "NONFICTION"
+          },
+          "materialTypes": [
+            {
+              "specific": "tidsskriftsartikel"
+            }
+          ],
+          "creators": [
+            {
+              "display": "Leif Becker Jensen",
+              "__typename": "Person"
+            }
+          ],
+          "hostPublication": {
+            "title": "Dansk noter",
+            "creator": null,
+            "publisher": null,
+            "year": {
+              "year": 2010
+            }
+          },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk"
+              }
+            ]
+          },
+          "identifiers": [],
+          "contributors": [],
+          "edition": {
+            "summary": "2010",
+            "publicationYear": {
+              "display": "2010"
+            }
+          },
+          "audience": {
+            "generalAudience": []
+          },
+          "physicalDescriptions": [
+            {
+              "numberOfPages": null
+            }
+          ],
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "01071424"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": null
+        }
+      },
+      "materialTypes": [
+        {
+          "specific": "tidsskriftsartikel"
+        }
+      ],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
+      "subjects": {
+        "all": [
+          {
+            "display": "formidling"
+          },
+          {
+            "display": "videnskab"
+          },
+          {
+            "display": "retorik"
+          },
+          {
+            "display": "forskning"
+          },
+          {
+            "display": "skriftlig fremstilling"
+          }
+        ]
+      },
+      "reviews": [],
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "workYear": null,
+      "dk5MainEntry": {
+        "display": "19.1 Forskningsteknik i alm."
+      }
+    }
+  }
+}

--- a/src/apps/material/infomedia.test.ts
+++ b/src/apps/material/infomedia.test.ts
@@ -1,0 +1,64 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("Material - Infomedia", () => {
+  beforeEach(() => {
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
+
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+
+    cy.interceptRest({
+      aliasName: "periodical holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/periodical-holdings.json"
+    });
+
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/infomedia-fbi-api.json"
+    });
+
+    cy.interceptGraphql({
+      operationName: "getInfomedia",
+      fixtureFilePath: "material/infomedia-article.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story");
+  });
+
+  it("Render infomedia + Read article + Close modal", () => {
+    cy.getBySel("material-header-buttons-find-on-shelf-infomedia-article")
+      .should("be.visible")
+      .and("contain", "Read article")
+      .click();
+
+    cy.get("h2")
+      .should("be.visible")
+      .and("contain", "BUTLERENS UTROLIGE HISTORIE");
+
+    cy.getBySelStartEnd("modal-infomedia-modal-", "-close-button")
+      .should("be.visible")
+      .click();
+  });
+});
+
+export default {};

--- a/src/apps/material/infomedia.test.ts
+++ b/src/apps/material/infomedia.test.ts
@@ -46,7 +46,7 @@ describe("Material - Infomedia", () => {
   });
 
   it("Render infomedia + Read article + Close modal", () => {
-    cy.getBySel("material-header-buttons-find-on-shelf-infomedia-article")
+    cy.getBySel("material-header-buttons-online-infomedia-article")
       .should("be.visible")
       .and("contain", "Read article")
       .click();

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -161,46 +161,6 @@ describe("Material", () => {
       .click();
   });
 
-  //  periodical test.
-  it("Render periodical + change to 2021, nr. 52 + Aprove resevation", () => {
-    cy.interceptRest({
-      aliasName: "periodical holdings",
-      url: "**/agencyid/catalog/holdings/**",
-      fixtureFilePath: "material/periodical-holdings.json"
-    });
-
-    cy.interceptGraphql({
-      operationName: "getMaterial",
-      fixtureFilePath: "material/periodical-fbi-api.json"
-    });
-    cy.visit(
-      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
-    );
-    cy.get("#year").select("2021");
-    cy.get("#editions").should("have.value", "52");
-    cy.getBySel("material-header-buttons-physical")
-      .should("be.visible")
-      .and("contain", "Reserve tidsskrift")
-      .click();
-
-    cy.get("h2").should("contain", "2021, nr. 52");
-
-    cy.getBySel("reservation-modal-submit-button", true).click();
-
-    cy.getBySel("reservation-success-title-text")
-      .should("be.visible")
-      .and("contain", "Material is available and reserved for you!");
-
-    cy.getBySel("number-in-queue-text")
-      .should("be.visible")
-      .and("contain", "You are number 3 in the queue");
-
-    cy.getBySel("reservation-success-close-button")
-      .should("be.visible")
-      .and("contain", "Ok")
-      .click();
-  });
-
   //  infomedia test.
   it("Render infomedia + Read article + Close modal", () => {
     cy.interceptGraphql({

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -161,33 +161,6 @@ describe("Material", () => {
       .click();
   });
 
-  //  infomedia test.
-  it("Render infomedia + Read article + Close modal", () => {
-    cy.interceptGraphql({
-      operationName: "getMaterial",
-      fixtureFilePath: "material/infomedia-fbi-api.json"
-    });
-    cy.interceptGraphql({
-      operationName: "getInfomedia",
-      fixtureFilePath: "material/infomedia-article.json"
-    });
-
-    cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story");
-
-    cy.getBySel("material-header-buttons-find-on-shelf-infomedia-article")
-      .should("be.visible")
-      .and("contain", "Read article")
-      .click();
-
-    cy.get("h2")
-      .should("be.visible")
-      .and("contain", "BUTLERENS UTROLIGE HISTORIE");
-
-    cy.getBySelStartEnd("modal-infomedia-modal-", "-close-button")
-      .should("be.visible")
-      .click();
-  });
-
   beforeEach(() => {
     cy.interceptRest({
       httpMethod: "POST",

--- a/src/apps/material/order-digital-copy.test.ts
+++ b/src/apps/material/order-digital-copy.test.ts
@@ -54,33 +54,27 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .and("contain", "Faglig formidling er ikke kun skriveteknik");
 
-    cy.getBySel("material-header-buttons-find-on-shelf-digital-article").should(
+    cy.getBySel("material-header-buttons-online-digital-article").should(
       "be.visible"
     );
   });
 
   it("render modal to order digital copy", () => {
-    cy.getBySel("material-header-buttons-find-on-shelf-digital-article")
+    cy.getBySel("material-header-buttons-online-digital-article")
       .should("be.visible")
       .click();
 
-    cy.getBySel("email-order-digital-copy")
-      .should("be.visible")
-      .and("have.value", "test@test.com");
+    cy.getBySel("email-order-digital-copy").should("be.visible");
 
-    cy.getBySel("button")
+    cy.getBySel("order-digital-button")
       .should("be.visible")
       .and("contain", "Order digital copy");
   });
 
-  it("order digital copy with fail", () => {
-    cy.getBySel("material-header-buttons-find-on-shelf-digital-article")
+  it("shows an error message if ordering fails", () => {
+    cy.getBySel("material-header-buttons-online-digital-article")
       .should("be.visible")
       .click();
-
-    cy.getBySel("email-order-digital-copy")
-      .should("be.visible")
-      .and("have.value", "test@test.com");
 
     cy.intercept("POST", "**/dpl_das/order", {
       statusCode: 500,
@@ -90,33 +84,54 @@ describe("Material - Order digital copy", () => {
       }
     });
 
-    cy.getBySel("button").should("be.visible").click();
+    cy.getBySel("order-digital-button").should("be.visible").click();
 
-    cy.contains("Error ordering digital copy");
-    cy.getBySel("button").should("be.visible").and("contain", "Close").click();
+    cy.getBySel("order-digital-feedback-title").should(
+      "contain",
+      "Error ordering digital copy"
+    );
+
+    cy.getBySel("order-digital-feedback-button")
+      .should("be.visible")
+      .and("contain", "Close")
+      .click();
   });
 
-  it("order digital copy with succes", () => {
-    cy.getBySel("material-header-buttons-find-on-shelf-digital-article")
+  it("uses the patron email adress by default", () => {
+    cy.getBySel("material-header-buttons-online-digital-article")
       .should("be.visible")
       .click();
 
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
       .and("have.value", "test@test.com");
+  });
+
+  it("shows a confirmation message when an order is completed", () => {
+    cy.getBySel("material-header-buttons-online-digital-article")
+      .should("be.visible")
+      .click();
+
+    cy.getBySel("email-order-digital-copy")
+      .should("be.visible")
+      .clear()
+      .type("new-mail.test.com");
 
     cy.intercept("POST", "**/dpl_das/order", {
-      statusCode: 200,
+      statusCode: 201,
       body: {
         pid: "870971-tsart:34310815",
-        email: "test@test.com"
+        email: "new-mail.test.com"
       }
     });
 
-    cy.getBySel("button").should("be.visible").click();
+    cy.getBySel("order-digital-button").should("be.visible").click();
 
     cy.contains("Digital copy ordered");
-    cy.getBySel("button").should("be.visible").and("contain", "Close").click();
+    cy.getBySel("order-digital-feedback-button")
+      .should("be.visible")
+      .and("contain", "Close")
+      .click();
   });
 });
 

--- a/src/apps/material/order-digital-copy.test.ts
+++ b/src/apps/material/order-digital-copy.test.ts
@@ -1,0 +1,123 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("Material - Order digital copy", () => {
+  beforeEach(() => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/order-digital-copy/order-digital-fbi-api"
+    });
+
+    cy.interceptRest({
+      aliasName: "user",
+      url: "**/agencyid/patrons/patronid/v2",
+      fixtureFilePath: "material/user.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/holdings.json"
+    });
+
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+
+    cy.visit(
+      "/iframe.html?id=apps-material--digital&viewMode=story&type=tidsskriftsartikel"
+    );
+  });
+
+  it("render a material that can be ordered as a digital copy", () => {
+    cy.get("h1")
+      .should("be.visible")
+      .and("contain", "Faglig formidling er ikke kun skriveteknik");
+
+    cy.getBySel("material-header-buttons-find-on-shelf-digital-article").should(
+      "be.visible"
+    );
+  });
+
+  it("render modal to order digital copy", () => {
+    cy.getBySel("material-header-buttons-find-on-shelf-digital-article")
+      .should("be.visible")
+      .click();
+
+    cy.getBySel("email-order-digital-copy")
+      .should("be.visible")
+      .and("have.value", "test@test.com");
+
+    cy.getBySel("button")
+      .should("be.visible")
+      .and("contain", "Order digital copy");
+  });
+
+  it("order digital copy with fail", () => {
+    cy.getBySel("material-header-buttons-find-on-shelf-digital-article")
+      .should("be.visible")
+      .click();
+
+    cy.getBySel("email-order-digital-copy")
+      .should("be.visible")
+      .and("have.value", "test@test.com");
+
+    cy.intercept("POST", "**/dpl_das/order", {
+      statusCode: 500,
+      body: {
+        pid: "870971-tsart:34310815",
+        email: "test@test.com"
+      }
+    });
+
+    cy.getBySel("button").should("be.visible").click();
+
+    cy.contains("Error ordering digital copy");
+    cy.getBySel("button").should("be.visible").and("contain", "Close").click();
+  });
+
+  it("order digital copy with succes", () => {
+    cy.getBySel("material-header-buttons-find-on-shelf-digital-article")
+      .should("be.visible")
+      .click();
+
+    cy.getBySel("email-order-digital-copy")
+      .should("be.visible")
+      .and("have.value", "test@test.com");
+
+    cy.intercept("POST", "**/dpl_das/order", {
+      statusCode: 200,
+      body: {
+        pid: "870971-tsart:34310815",
+        email: "test@test.com"
+      }
+    });
+
+    cy.getBySel("button").should("be.visible").click();
+
+    cy.contains("Digital copy ordered");
+    cy.getBySel("button").should("be.visible").and("contain", "Close").click();
+  });
+});
+
+export default {};

--- a/src/apps/material/periodical.test.ts
+++ b/src/apps/material/periodical.test.ts
@@ -1,0 +1,85 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("Material - Periodical", () => {
+  beforeEach(() => {
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "user",
+      url: "**/agencyid/patrons/patronid/v2",
+      fixtureFilePath: "material/user.json"
+    });
+
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+
+    cy.interceptRest({
+      aliasName: "periodical holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/periodical-holdings.json"
+    });
+
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/periodical-fbi-api.json"
+    });
+
+    cy.interceptRest({
+      httpMethod: "POST",
+      aliasName: "reservations",
+      url: "**/patrons/patronid/reservations/**",
+      fixtureFilePath: "material/reservations.json"
+    });
+
+    cy.visit(
+      "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
+    );
+  });
+
+  it("Render periodical + change to 2021, nr. 52 + Aprove resevation", () => {
+    cy.get("#year").select("2021");
+    cy.get("#editions").should("have.value", "52");
+    cy.getBySel("material-header-buttons-physical")
+      .should("be.visible")
+      .and("contain", "Reserve tidsskrift")
+      .click();
+
+    cy.get("h2").should("contain", "2021, nr. 52");
+
+    cy.getBySel("reservation-modal-submit-button", true).click();
+
+    cy.getBySel("reservation-success-title-text")
+      .should("be.visible")
+      .and("contain", "Material is available and reserved for you!");
+
+    cy.getBySel("number-in-queue-text")
+      .should("be.visible")
+      .and("contain", "You are number 3 in the queue");
+
+    cy.getBySel("reservation-success-close-button")
+      .should("be.visible")
+      .and("contain", "Ok")
+      .click();
+  });
+});
+
+export default {};

--- a/src/apps/material/periodical.test.ts
+++ b/src/apps/material/periodical.test.ts
@@ -43,13 +43,6 @@ describe("Material - Periodical", () => {
       fixtureFilePath: "material/periodical-fbi-api.json"
     });
 
-    cy.interceptRest({
-      httpMethod: "POST",
-      aliasName: "reservations",
-      url: "**/patrons/patronid/reservations/**",
-      fixtureFilePath: "material/reservations.json"
-    });
-
     cy.visit(
       "/iframe.html?id=apps-material--periodical&viewMode=story&type=tidsskrift"
     );
@@ -64,6 +57,13 @@ describe("Material - Periodical", () => {
       .click();
 
     cy.get("h2").should("contain", "2021, nr. 52");
+
+    cy.interceptRest({
+      httpMethod: "POST",
+      aliasName: "reservations",
+      url: "**/patrons/patronid/reservations/**",
+      fixtureFilePath: "material/reservations.json"
+    });
 
     cy.getBySel("reservation-modal-submit-button", true).click();
 

--- a/src/components/material/digital-modal/DigitalModalBody.tsx
+++ b/src/components/material/digital-modal/DigitalModalBody.tsx
@@ -23,6 +23,7 @@ const DigitalModalBody: React.FunctionComponent<DigitalModalBodyProps> = ({
 
   return (
     <ReservationForm
+      cyData="order-digital"
       title={t("orderDigitalCopyTitleText")}
       description={[t("orderDigitalCopyDescriptionText")]}
       onSubmit={handleOnSubmit}

--- a/src/components/material/digital-modal/DigitalModalFeedback.tsx
+++ b/src/components/material/digital-modal/DigitalModalFeedback.tsx
@@ -16,6 +16,7 @@ const DigitalModalFeedback: React.FunctionComponent<
 
   return (
     <ReservationForm
+      cyData="order-digital-feedback"
       title={
         isError
           ? t("orderDigitalCopyErrorTitleText")

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -52,7 +52,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
           manifestation={manifestation}
           size={size}
           workId={workId}
-          dataCy={`${dataCy}-find-on-shelf`}
+          dataCy={`${dataCy}-online`}
         />
       )}
     </>

--- a/src/components/reservation/forms/ReservationForm.tsx
+++ b/src/components/reservation/forms/ReservationForm.tsx
@@ -9,6 +9,7 @@ export interface ReservationFormProps {
   onSubmit: () => void;
   buttonLabel?: string;
   disabledButton?: boolean;
+  cyData?: string;
 }
 
 const ReservationForm = ({
@@ -17,7 +18,8 @@ const ReservationForm = ({
   children,
   onSubmit,
   buttonLabel,
-  disabledButton
+  disabledButton,
+  cyData = "reservation-form"
 }: ReservationFormProps) => {
   const t = useText();
 
@@ -25,9 +27,13 @@ const ReservationForm = ({
     <section className="reservation-modal reservation-form">
       <div className="reservation-form__content">
         <div className="reservation-form__header">
-          <h3 className="text-header-h3 mb-35">{title}</h3>
+          <h3 className="text-header-h3 mb-35" data-cy={`${cyData}-title`}>
+            {title}
+          </h3>
           {description.map((paragraph) => (
-            <p className="text-body-large">{paragraph}</p>
+            <p className="text-body-large" data-cy={`${cyData}-description`}>
+              {paragraph}
+            </p>
           ))}
         </div>
         <form>
@@ -43,6 +49,7 @@ const ReservationForm = ({
               size="xlarge"
               variant="filled"
               onClick={onSubmit}
+              dataCy={`${cyData}-button`}
             />
           </div>
         </form>


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-304

#### add a test for order digital copy + Move infomedia & periodical into its own separate files

There is now a test that checks the following things
- render a material that can be ordered as a digital copy
- render modal to order digital copy
- order digital copy with fail
- order digital copy with succes

in addition, I have split up the material test so that Periodical + Infomedia has its own test files

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
