### PR TITLE
Add tracking to digital article reservation

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -249,6 +249,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             <DigitalModal
               digitalArticleIssn={getDigitalArticleIssn(currentManifestation)}
               pid={currentManifestation.pid}
+              workId={wid}
             />
           )}
         </>

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -66,7 +66,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   );
   const isPeriodical = manifestation.materialTypes.some(
     (materialType: Manifestation["materialTypes"][0]) => {
-      return materialType.specific.includes("tidsskrift");
+      return materialType.specific === "tidsskrift";
     }
   );
 

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -46,15 +46,15 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
             />
           </>
         )}
-      {hasCorrectAccessType(AccessTypeCode.Online, manifestation) ||
-        (hasCorrectAccess("DigitalArticleService", manifestation) && (
-          <MaterialButtonsOnline
-            manifestation={manifestation}
-            size={size}
-            workId={workId}
-            dataCy={`${dataCy}-find-on-shelf`}
-          />
-        ))}
+      {(hasCorrectAccessType(AccessTypeCode.Online, manifestation) ||
+        hasCorrectAccess("DigitalArticleService", manifestation)) && (
+        <MaterialButtonsOnline
+          manifestation={manifestation}
+          size={size}
+          workId={workId}
+          dataCy={`${dataCy}-find-on-shelf`}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-296

#### Description
This PR adds the functionality to track successful orders of digital article copies. We use the already established `useStatistics()` custom hook.  

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/206208413-6f8a4c36-8378-4758-893d-78dcbc647205.png)

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Please disregard the first two commits (f36d526 & 64db96c) as they are from a different PR ( #264 ) that was necessary to test this PR's functionality.