### PR TITLE
Update design-system to use latest css

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-2d4af063fa3e915fa99b1626820807af11d24b08",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-b7f5caa23580a00859acdfcf292439e365b26660",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,10 +1754,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-2d4af063fa3e915fa99b1626820807af11d24b08":
-  version "0.0.0-2d4af063fa3e915fa99b1626820807af11d24b08"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-2d4af063fa3e915fa99b1626820807af11d24b08/c2f956c4595ce4df98003997941ee1998b0ba93c#c2f956c4595ce4df98003997941ee1998b0ba93c"
-  integrity sha512-UUS1IJAkEZP/DzdAS2WjqsUmZWjlW5678X97yasUGfxl5q1oxBYiQiBoNYDwyUGyV9MF03NIsi4/QFncYbT37Q==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-b7f5caa23580a00859acdfcf292439e365b26660":
+  version "0.0.0-b7f5caa23580a00859acdfcf292439e365b26660"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-b7f5caa23580a00859acdfcf292439e365b26660/477ea708a0679d53038ca3f8bb29d803e0af40fb#477ea708a0679d53038ca3f8bb29d803e0af40fb"
+  integrity sha512-9AcMD63fA2UvSXObYT8sRenFNNT9Cy+AyQxKaWUdjKIT83PsXzdWX6lKsSbbeKvC9DF5+BSyUSvBRYo0nu7ZpQ==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION



#### Update design-system to use the latest CSS

This is because we have changed the .tag class to use border instead of outline 

#### Screenshot of the result
<img width="253" alt="Skærmbillede 2022-12-07 kl  17 18 34" src="https://user-images.githubusercontent.com/49920322/206233638-ceab3a29-207b-4ce4-9698-10f194354717.png">



#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.