### PR TITLE
Add space between title and publication year (FindOnShelf)

### DIFF
--- a/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
@@ -41,7 +41,7 @@ const FindOnShelfManifestationListItem: FC<
     <li className="find-on-shelf__row text-body-medium-regular">
       <span className="find-on-shelf__material-text">
         {title}
-        {publicationYear ?? ""}
+        {publicationYear && ` (${publicationYear})`}
       </span>
       <span>
         {locationArray.length


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-336

#### Add space between title and publication year (FindOnShelf)
I have used a template literals to create a string with a space in front of the publication year and changed the rendering logic to not render an empty string if there is no publication year

#### Screenshot of the result
![Skærmbillede 2022-12-08 kl  14 42 12](https://user-images.githubusercontent.com/49920322/206461278-fb742275-d84a-4fd7-9cf8-e673f718e6e4.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
