### PR TITLE
Manifestation edition publication year fixes

### DIFF
--- a/cypress/fixtures/search-result/fbi-api.json
+++ b/cypress/fixtures/search-result/fbi-api.json
@@ -5,17 +5,12 @@
       "works": [
         {
           "workId": "work-of:870970-basis:22629344",
+          "workYear": "1839",
           "titles": {
-            "full": [
-              "Dummy Some Title: Full"
-            ],
-            "original": [
-              "Dummy Some Title Origintal"
-            ]
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
           },
-          "abstract": [
-            "Dummy The abstract"
-          ],
+          "abstract": ["Dummy The abstract"],
           "creators": [
             {
               "display": "Dummy Jens Jensen",
@@ -32,9 +27,7 @@
               "isPopular": true,
               "numberInSeries": {
                 "display": "Dummy number one",
-                "number": [
-                  1
-                ]
+                "number": [1]
               },
               "readThisFirst": true,
               "readThisWhenever": false
@@ -44,9 +37,7 @@
               "isPopular": false,
               "numberInSeries": {
                 "display": "Dummy number one",
-                "number": [
-                  1
-                ]
+                "number": [1]
               },
               "readThisFirst": null,
               "readThisWhenever": null
@@ -55,236 +46,128 @@
           "seriesMembers": [
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             }
           ],
@@ -293,12 +176,8 @@
               {
                 "pid": "870970-basis:22629344",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -347,9 +226,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -360,12 +237,8 @@
               {
                 "pid": "870970-basis:22252852",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -414,9 +287,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -427,12 +298,8 @@
               {
                 "pid": "870970-basis:22441671",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -481,9 +348,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -494,12 +359,8 @@
               {
                 "pid": "870970-basis:23148048",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -548,9 +409,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -561,12 +420,8 @@
               {
                 "pid": "870970-basis:27638708",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -615,9 +470,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -628,12 +481,8 @@
               {
                 "pid": "870970-basis:38289977",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -682,9 +531,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -695,12 +542,8 @@
               {
                 "pid": "870970-basis:51989252",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -749,9 +592,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -762,12 +603,8 @@
               {
                 "pid": "870970-basis:54871910",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -816,9 +653,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -829,12 +664,8 @@
               {
                 "pid": "870970-basis:22513354",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -883,9 +714,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -896,12 +725,8 @@
               {
                 "pid": "870970-basis:24168638",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -950,9 +775,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -963,12 +786,8 @@
               {
                 "pid": "870970-basis:23108283",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1017,9 +836,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1030,12 +847,8 @@
               {
                 "pid": "870970-basis:23195151",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1084,9 +897,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1097,12 +908,8 @@
               {
                 "pid": "870970-basis:24343081",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1151,9 +958,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1164,12 +969,8 @@
               {
                 "pid": "870970-basis:23862476",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1218,9 +1019,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1231,12 +1030,8 @@
               {
                 "pid": "870970-basis:26178533",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1285,9 +1080,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1298,12 +1091,8 @@
               {
                 "pid": "870970-basis:23819104",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1352,9 +1141,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1365,12 +1152,8 @@
               {
                 "pid": "870970-basis:25194853",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1419,9 +1202,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1432,12 +1213,8 @@
               {
                 "pid": "870970-basis:46018869",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1486,9 +1263,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1499,12 +1274,8 @@
               {
                 "pid": "870970-basis:29317038",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1553,9 +1324,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1566,12 +1335,8 @@
               {
                 "pid": "870970-basis:51980247",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1620,9 +1385,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1635,17 +1398,12 @@
         },
         {
           "workId": "work-of:870970-basis:25807995",
+          "workYear": "1839",
           "titles": {
-            "full": [
-              "Dummy Some Title: Full"
-            ],
-            "original": [
-              "Dummy Some Title Origintal"
-            ]
+            "full": ["Dummy Some Title: Full"],
+            "original": ["Dummy Some Title Origintal"]
           },
-          "abstract": [
-            "Dummy The abstract"
-          ],
+          "abstract": ["Dummy The abstract"],
           "creators": [
             {
               "display": "Dummy Jens Jensen",
@@ -1662,9 +1420,7 @@
               "isPopular": true,
               "numberInSeries": {
                 "display": "Dummy number one",
-                "number": [
-                  1
-                ]
+                "number": [1]
               },
               "readThisFirst": true,
               "readThisWhenever": false
@@ -1674,9 +1430,7 @@
               "isPopular": false,
               "numberInSeries": {
                 "display": "Dummy number one",
-                "number": [
-                  1
-                ]
+                "number": [1]
               },
               "readThisFirst": null,
               "readThisWhenever": null
@@ -1685,236 +1439,128 @@
           "seriesMembers": [
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             },
             {
               "titles": {
-                "main": [
-                  "Dummy Some Title"
-                ],
-                "full": [
-                  "Dummy Some Title: Full"
-                ],
-                "original": [
-                  "Dummy Some Title Origintal"
-                ]
+                "main": ["Dummy Some Title"],
+                "full": ["Dummy Some Title: Full"],
+                "original": ["Dummy Some Title Origintal"]
               }
             }
           ],
@@ -1923,12 +1569,8 @@
               {
                 "pid": "870970-basis:25807995",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -1977,9 +1619,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -1990,12 +1630,8 @@
               {
                 "pid": "870970-basis:25998960",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2044,9 +1680,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2057,12 +1691,8 @@
               {
                 "pid": "870970-basis:26056829",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2111,9 +1741,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2124,12 +1752,8 @@
               {
                 "pid": "870970-basis:26137276",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2178,9 +1802,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2191,12 +1813,8 @@
               {
                 "pid": "870970-basis:27639674",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2245,9 +1863,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2258,12 +1874,8 @@
               {
                 "pid": "870970-basis:54872003",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2312,9 +1924,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2325,12 +1935,8 @@
               {
                 "pid": "870970-basis:25771893",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2379,9 +1985,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2392,12 +1996,8 @@
               {
                 "pid": "870970-basis:26068053",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2446,9 +2046,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2459,12 +2057,8 @@
               {
                 "pid": "870970-basis:26285240",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2513,9 +2107,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2526,12 +2118,8 @@
               {
                 "pid": "870970-basis:29317100",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2580,9 +2168,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {
@@ -2593,12 +2179,8 @@
               {
                 "pid": "870970-basis:51980212",
                 "titles": {
-                  "main": [
-                    "Dummy Some Title"
-                  ],
-                  "original": [
-                    "Dummy Some Title: Original"
-                  ]
+                  "main": ["Dummy Some Title"],
+                  "original": ["Dummy Some Title: Original"]
                 },
                 "materialTypes": [
                   {
@@ -2647,9 +2229,7 @@
                   }
                 },
                 "audience": {
-                  "generalAudience": [
-                    "Dummy general audience"
-                  ]
+                  "generalAudience": ["Dummy general audience"]
                 },
                 "physicalDescriptions": [
                   {

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -49,7 +49,7 @@ describe("Search Result", () => {
   it("Does the search result have authors?", () => {
     cy.get(".search-result-page__list .search-result-item").should(
       "contain.text",
-      "By Dummy Jens Jensen (Dummy 1839)"
+      "By Dummy Jens Jensen (1839)"
     );
   });
 

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -127,7 +127,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
         <p className="text-small-caption">
           {t("materialHeaderAuthorByText")} {creatorsText}
           {edition?.publicationYear?.display &&
-            ` (${edition?.publicationYear?.display})`}
+            ` (${edition.publicationYear.display})`}
         </p>
 
         <div

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -125,8 +125,9 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           {titles?.main[0]}
         </h2>
         <p className="text-small-caption">
-          {t("materialHeaderAuthorByText")} {creatorsText} (
-          {hostPublication?.year?.year})
+          {t("materialHeaderAuthorByText")} {creatorsText}
+          {edition?.publicationYear?.display &&
+            ` (${edition?.publicationYear?.display})`}
         </p>
 
         <div

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -13,7 +13,6 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getFirstPublishedYear,
   getManifestationPid
 } from "../../../core/utils/helpers/general";
 import SearchResultListItemCover from "./search-result-list-item-cover";
@@ -42,7 +41,8 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     series,
     creators,
     manifestations: { all: manifestations },
-    workId
+    workId,
+    workYear
   },
   coverTint,
   resultNumber
@@ -55,7 +55,6 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     t
   );
   const author = creatorsText || t("creatorsAreMissingText");
-  const datePublished = getFirstPublishedYear(manifestations);
   const manifestationPid = getManifestationPid(manifestations);
   const firstInSeries = series?.[0];
   const { title: seriesTitle, numberInSeries } = firstInSeries || {};
@@ -132,9 +131,10 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         </h2>
 
         {author && (
-          <p className="text-small-caption">{`${t(
-            "byAuthorText"
-          )} ${author} (${datePublished})`}</p>
+          <p className="text-small-caption">
+            {`${t("byAuthorText")} ${author}`}
+            {workYear && ` (${workYear})`}
+          </p>
         )}
       </div>
       <div className="search-result-item__availability">

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -124,6 +124,7 @@ fragment WorkSmall on Work {
       original
     }
   }
+  workYear
   genreAndForm
   manifestations {
     ...ManifestationsSimple
@@ -176,7 +177,6 @@ fragment WorkMedium on Work {
     display
     code
   }
-  workYear
   dk5MainEntry {
     display
   }

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -715,6 +715,257 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "CopyRequestInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "authorOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issueOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "openURL",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pagesOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pickUpAgencySubdivision",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pid",
+            "description": "The pid of an article or periodica",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publicationDateOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publicationTitle",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publicationYearOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userInterestDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userMail",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "volumeOfComponent",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CopyRequestResponse",
+        "description": null,
+        "fields": [
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CopyRequestStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CopyRequestStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ERROR_AGENCY_NOT_SUBSCRIBED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERROR_INVALID_PICKUP_BRANCH",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERROR_PID_NOT_RESERVABLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERROR_UNAUTHENTICATED_USER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Corporation",
         "description": null,
@@ -935,6 +1186,18 @@
           },
           {
             "name": "detail_500",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "origin",
             "description": null,
             "args": [],
             "type": {
@@ -1230,6 +1493,62 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "ElbaServices",
+        "description": null,
+        "fields": [
+          {
+            "name": "placeCopyRequest",
+            "description": null,
+            "args": [
+              {
+                "name": "dryRun",
+                "description": "If this is true, the copy request will not be send to the elba service\nUse it for testing",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CopyRequestInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CopyRequestResponse",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "EntryType",
         "description": null,
@@ -1404,6 +1723,12 @@
         "enumValues": [
           {
             "name": "accessTypes",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canAlwaysBeLoaned",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -3290,6 +3615,22 @@
             "deprecationReason": null
           },
           {
+            "name": "relations",
+            "description": "Relations to other manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Relations",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "series",
             "description": "Series for this work",
             "args": [],
@@ -3983,9 +4324,37 @@
         "description": null,
         "fields": [
           {
+            "name": "elba",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ElbaServices",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "submitPeriodicaArticleOrder",
             "description": null,
             "args": [
+              {
+                "name": "dryRun",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "input",
                 "description": null,
@@ -4956,8 +5325,8 @@
             "description": null,
             "args": [
               {
-                "name": "branch",
-                "description": "Name of branch to filter by",
+                "name": "branchId",
+                "description": "Id of branch to filter by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -5853,6 +6222,569 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "Relations",
+        "description": null,
+        "fields": [
+          {
+            "name": "continuedIn",
+            "description": "The story of this article is continued in this or these other article(s)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "continues",
+            "description": "This story of this article actually started in this or these other article(s)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discussedIn",
+            "description": "The contents of this articles is also discussed in these articles",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discusses",
+            "description": "The article discusses the content of these articles",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasAdaptation",
+            "description": "This story is adapted in this or these movie(s)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasAnalysis",
+            "description": "The contents of this manifestation is analysed in these manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasCreatorDescription",
+            "description": "The creator of this manifestation is portrayed in these manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasDescriptionFromPublisher",
+            "description": "The publisher of this manifestation has made a description of the content",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasManuscript",
+            "description": "This movie is based on this manuscript",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasReusedReview",
+            "description": "This manifestation has a 'materialevurdering' that was originally made for another manifestation, but it is still relevant (e.g. book/ebook)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasReview",
+            "description": "This manifestation has these reviews",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasSoundtrack",
+            "description": "This movie or game has this sound track",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasTrack",
+            "description": "This album has these tracks",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isAdaptationOf",
+            "description": "This movie is based on this or these books",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isAnalysisOf",
+            "description": "This manifestation is an analysis of these manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDescriptionFromPublisherOf",
+            "description": "This is a description from the original publisher of these manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isManuscriptOf",
+            "description": "This movie is based on this manuscript",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPartOfAlbum",
+            "description": "This music track is part of these albums",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPartOfManifestation",
+            "description": "This article or book part can be found in these manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isReusedReviewOf",
+            "description": "This 'materialevurdering' can also be used to review these relevant manifestations, even though it was originally made for another publication",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isReviewOf",
+            "description": "This manifestation is a review of these manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isSoundtrackOfGame",
+            "description": "This sound track for a game is related to these games",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isSoundtrackOfMovie",
+            "description": "This sound track for a movie is related to these movies",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INTERFACE",
         "name": "Review",
         "description": null,
@@ -6040,6 +6972,26 @@
           },
           {
             "name": "branchId",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canAlwaysBeLoaned",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -7480,6 +8432,22 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "relations",
+            "description": "Relations to other manifestations",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Relations",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -125,6 +125,37 @@ export type ComplexSearchResponseWorksArgs = {
   offset: Scalars["Int"];
 };
 
+export type CopyRequestInput = {
+  authorOfComponent?: InputMaybe<Scalars["String"]>;
+  issueOfComponent?: InputMaybe<Scalars["String"]>;
+  openURL?: InputMaybe<Scalars["String"]>;
+  pagesOfComponent?: InputMaybe<Scalars["String"]>;
+  pickUpAgencySubdivision?: InputMaybe<Scalars["String"]>;
+  /** The pid of an article or periodica */
+  pid: Scalars["String"];
+  publicationDateOfComponent?: InputMaybe<Scalars["String"]>;
+  publicationTitle?: InputMaybe<Scalars["String"]>;
+  publicationYearOfComponent?: InputMaybe<Scalars["String"]>;
+  titleOfComponent?: InputMaybe<Scalars["String"]>;
+  userInterestDate?: InputMaybe<Scalars["String"]>;
+  userMail?: InputMaybe<Scalars["String"]>;
+  userName?: InputMaybe<Scalars["String"]>;
+  volumeOfComponent?: InputMaybe<Scalars["String"]>;
+};
+
+export type CopyRequestResponse = {
+  __typename?: "CopyRequestResponse";
+  status: CopyRequestStatus;
+};
+
+export enum CopyRequestStatus {
+  ErrorAgencyNotSubscribed = "ERROR_AGENCY_NOT_SUBSCRIBED",
+  ErrorInvalidPickupBranch = "ERROR_INVALID_PICKUP_BRANCH",
+  ErrorPidNotReservable = "ERROR_PID_NOT_RESERVABLE",
+  ErrorUnauthenticatedUser = "ERROR_UNAUTHENTICATED_USER",
+  Ok = "OK"
+}
+
 export type Corporation = Creator &
   Subject & {
     __typename?: "Corporation";
@@ -156,6 +187,7 @@ export type Cover = {
   detail117?: Maybe<Scalars["String"]>;
   detail207?: Maybe<Scalars["String"]>;
   detail500?: Maybe<Scalars["String"]>;
+  origin?: Maybe<Scalars["String"]>;
   thumbnail?: Maybe<Scalars["String"]>;
 };
 
@@ -202,6 +234,16 @@ export type Edition = {
   summary: Scalars["String"];
 };
 
+export type ElbaServices = {
+  __typename?: "ElbaServices";
+  placeCopyRequest: CopyRequestResponse;
+};
+
+export type ElbaServicesPlaceCopyRequestArgs = {
+  dryRun?: InputMaybe<Scalars["Boolean"]>;
+  input: CopyRequestInput;
+};
+
 export enum EntryType {
   AdditionalEntry = "ADDITIONAL_ENTRY",
   MainEntry = "MAIN_ENTRY",
@@ -229,6 +271,7 @@ export type ExternalReview = Review & {
 /** The supported facet fields */
 export enum FacetField {
   AccessTypes = "accessTypes",
+  CanAlwaysBeLoaned = "canAlwaysBeLoaned",
   ChildrenOrAdults = "childrenOrAdults",
   Creators = "creators",
   FictionNonfiction = "fictionNonfiction",
@@ -507,6 +550,8 @@ export type Manifestation = {
   recordCreationDate: Scalars["String"];
   /** Notes about relations to this book/periodical/journal, - like previous names or related journals */
   relatedPublications: Array<RelatedPublication>;
+  /** Relations to other manifestations */
+  relations: Relations;
   /** Series for this work */
   series: Array<Series>;
   /** Information about on which shelf in the library this manifestation can be found */
@@ -598,10 +643,12 @@ export type MaterialType = {
 
 export type Mutation = {
   __typename?: "Mutation";
+  elba: ElbaServices;
   submitPeriodicaArticleOrder: PeriodicaArticleOrderResponse;
 };
 
 export type MutationSubmitPeriodicaArticleOrderArgs = {
+  dryRun?: InputMaybe<Scalars["Boolean"]>;
   input: PeriodicaArticleOrder;
 };
 
@@ -761,7 +808,7 @@ export type QueryInfomediaArgs = {
 };
 
 export type QueryLocalSuggestArgs = {
-  branch?: InputMaybe<Scalars["String"]>;
+  branchId?: InputMaybe<Scalars["String"]>;
   limit?: InputMaybe<Scalars["Int"]>;
   q: Scalars["String"];
   suggestType?: InputMaybe<Array<SuggestionType>>;
@@ -862,6 +909,56 @@ export type RelatedPublication = {
   urlText?: Maybe<Scalars["String"]>;
 };
 
+export type Relations = {
+  __typename?: "Relations";
+  /** The story of this article is continued in this or these other article(s) */
+  continuedIn: Array<Manifestation>;
+  /** This story of this article actually started in this or these other article(s) */
+  continues: Array<Manifestation>;
+  /** The contents of this articles is also discussed in these articles */
+  discussedIn: Array<Manifestation>;
+  /** The article discusses the content of these articles */
+  discusses: Array<Manifestation>;
+  /** This story is adapted in this or these movie(s) */
+  hasAdaptation: Array<Manifestation>;
+  /** The contents of this manifestation is analysed in these manifestations */
+  hasAnalysis: Array<Manifestation>;
+  /** The creator of this manifestation is portrayed in these manifestations */
+  hasCreatorDescription: Array<Manifestation>;
+  /** The publisher of this manifestation has made a description of the content */
+  hasDescriptionFromPublisher: Array<Manifestation>;
+  /** This movie is based on this manuscript */
+  hasManuscript: Array<Manifestation>;
+  /** This manifestation has a 'materialevurdering' that was originally made for another manifestation, but it is still relevant (e.g. book/ebook) */
+  hasReusedReview: Array<Manifestation>;
+  /** This manifestation has these reviews */
+  hasReview: Array<Manifestation>;
+  /** This movie or game has this sound track */
+  hasSoundtrack: Array<Manifestation>;
+  /** This album has these tracks */
+  hasTrack: Array<Manifestation>;
+  /** This movie is based on this or these books */
+  isAdaptationOf: Array<Manifestation>;
+  /** This manifestation is an analysis of these manifestations */
+  isAnalysisOf: Array<Manifestation>;
+  /** This is a description from the original publisher of these manifestations */
+  isDescriptionFromPublisherOf: Array<Manifestation>;
+  /** This movie is based on this manuscript */
+  isManuscriptOf: Array<Manifestation>;
+  /** This music track is part of these albums */
+  isPartOfAlbum: Array<Manifestation>;
+  /** This article or book part can be found in these manifestations */
+  isPartOfManifestation: Array<Manifestation>;
+  /** This 'materialevurdering' can also be used to review these relevant manifestations, even though it was originally made for another publication */
+  isReusedReviewOf: Array<Manifestation>;
+  /** This manifestation is a review of these manifestations */
+  isReviewOf: Array<Manifestation>;
+  /** This sound track for a game is related to these games */
+  isSoundtrackOfGame: Array<Manifestation>;
+  /** This sound track for a movie is related to these movies */
+  isSoundtrackOfMovie: Array<Manifestation>;
+};
+
 export type Review = {
   author?: Maybe<Scalars["String"]>;
   date?: Maybe<Scalars["String"]>;
@@ -890,6 +987,7 @@ export enum SchoolUseCode {
 export type SearchFilters = {
   accessTypes?: InputMaybe<Array<Scalars["String"]>>;
   branchId?: InputMaybe<Array<Scalars["String"]>>;
+  canAlwaysBeLoaned?: InputMaybe<Array<Scalars["String"]>>;
   childrenOrAdults?: InputMaybe<Array<Scalars["String"]>>;
   creators?: InputMaybe<Array<Scalars["String"]>>;
   department?: InputMaybe<Array<Scalars["String"]>>;
@@ -1084,6 +1182,8 @@ export type Work = {
   manifestations: Manifestations;
   /** The type of material of the manifestation based on bibliotek.dk types */
   materialTypes: Array<MaterialType>;
+  /** Relations to other manifestations */
+  relations: Relations;
   reviews: Array<Review>;
   /** Series for this work */
   series: Array<Series>;
@@ -1181,9 +1281,9 @@ export type GetMaterialQuery = {
   __typename?: "Query";
   work?: {
     __typename?: "Work";
-    workYear?: string | null;
     workId: string;
     abstract?: Array<string> | null;
+    workYear?: string | null;
     genreAndForm: Array<string>;
     materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
     mainLanguages: Array<{
@@ -1466,6 +1566,7 @@ export type SearchWithPaginationQuery = {
       __typename?: "Work";
       workId: string;
       abstract?: Array<string> | null;
+      workYear?: string | null;
       genreAndForm: Array<string>;
       titles: {
         __typename?: "WorkTitles";
@@ -1998,6 +2099,7 @@ export type WorkSmallFragment = {
   __typename?: "Work";
   workId: string;
   abstract?: Array<string> | null;
+  workYear?: string | null;
   genreAndForm: Array<string>;
   titles: {
     __typename?: "WorkTitles";
@@ -2189,9 +2291,9 @@ export type WorkSmallFragment = {
 
 export type WorkMediumFragment = {
   __typename?: "Work";
-  workYear?: string | null;
   workId: string;
   abstract?: Array<string> | null;
+  workYear?: string | null;
   genreAndForm: Array<string>;
   materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
   mainLanguages: Array<{
@@ -2560,6 +2662,7 @@ export const WorkSmallFragmentDoc = `
       original
     }
   }
+  workYear
   genreAndForm
   manifestations {
     ...ManifestationsSimple
@@ -2614,7 +2717,6 @@ export const WorkMediumFragmentDoc = `
     display
     code
   }
-  workYear
   dk5MainEntry {
     display
   }

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -74,6 +74,9 @@ export const getCreatorTextFromManifestations = (
   return creatorsToString(creators, t);
 };
 
+// We deliberately left this function here although we don't use it anywhere in the
+// project. It can be used if ever needed to retrieve a chronologically oldest edition,
+// provided a manifestation object.
 export const getFirstPublishedManifestation = (
   manifestations: Manifestation[]
 ) => {

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -77,7 +77,7 @@ export const getCreatorTextFromManifestations = (
 export const getFirstPublishedManifestation = (
   manifestations: Manifestation[]
 ) => {
-  const ordered = orderManifestationsByYear(manifestations);
+  const ordered = orderManifestationsByYear(manifestations, "asc");
   return ordered[0];
 };
 


### PR DESCRIPTION
#### Link to issue
DDFSOEG-338

#### Description
This PR fixes a mistake, where a helper function for retrieving a manifestation's first edition publish year was instead retrieving the publish year for the latest edition. We got it reported as a bug from Tue based on the cards on the search result page showing the latest edition publication year. The helper function isn't used in the end, as just as Tue suggests in the bug report we can use the already existing data prop called workYear - which shows the year of the first publication of a given work. 

I also found out that on the material page under editions - the edition cards show empty brackets for publication year if the data doesn't exist, so I fixed that too. 

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/206473402-00c70bb7-da03-4e35-86cc-b2e275be5556.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Please don't look through the autogenerated files. ("/generated" folder)