### PR TITLE
Fix aria attributes for the disclosure element

### DIFF
--- a/src/components/Disclosures/DisclosureControllable.tsx
+++ b/src/components/Disclosures/DisclosureControllable.tsx
@@ -66,7 +66,9 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
           alt=""
         />
       </div>
-      {isOpen && <div id={disclosureId}>{children}</div>}
+      <div id={disclosureId} className={clsx({ "hide-visually": !isOpen })}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/components/Disclosures/DisclosureControllable.tsx
+++ b/src/components/Disclosures/DisclosureControllable.tsx
@@ -66,9 +66,7 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
           alt=""
         />
       </div>
-      <div id={disclosureId} className={clsx({ "hide-visually": !isOpen })}>
-        {children}
-      </div>
+      {isOpen && <div id={disclosureId}>{children}</div>}
     </div>
   );
 };

--- a/src/components/Disclosures/DisclosureControllable.tsx
+++ b/src/components/Disclosures/DisclosureControllable.tsx
@@ -36,22 +36,22 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
 
   return (
     <div
-      data-cy={cyData}
       className={`disclosure text-body-large ${
         fullWidth ? "disclosure--full-width" : ""
       }`}
-      aria-controls={disclosureId}
-      aria-expanded={isOpen}
     >
       <div
         className={clsx(
           "disclosure__headline text-body-large",
           removeHeadlinePadding && "disclosure__headline--no-padding"
         )}
+        data-cy={cyData}
         onClick={toggleOpen}
         onKeyDown={toggleOpen}
         role="button"
         tabIndex={0}
+        aria-controls={disclosureId}
+        aria-expanded={isOpen}
       >
         {mainIconPath && (
           <div className="disclosure__icon bg-identity-tint-120">


### PR DESCRIPTION
#### Link to issue
DDFSOEG-347

#### Description
This PR fixes a Pa11y accessibility error where our disclosure component aria attributes were not located on the same HTML element. 

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
