### PR TITLE
Fix reservation modal accessibility

### DIFF
--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -76,7 +76,7 @@ function Modal({
         <button
           type="button"
           /* A focusable element in a modal must have focus when opened,
-        or else the screen reader will remain on the main page */
+          or else the screen reader will remain on the main page */
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus
           className="btn-ui modal-btn-close"

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -65,7 +65,7 @@ function Modal({
           classNames
         )}
         role="dialog"
-        aria-describedby={`modal-${modalId}`}
+        aria-labelledby={`modal-${modalId}`}
       >
         <div
           className="modal__screen-reader-description"

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -65,7 +65,7 @@ function Modal({
           classNames
         )}
         role="dialog"
-        aria-label={screenReaderModalDescriptionText}
+        aria-describedby={`modal-${modalId}`}
       >
         <div
           className="modal__screen-reader-description"

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -80,7 +80,6 @@ function Modal({
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus
           className="btn-ui modal-btn-close"
-          aria-describedby={`modal-${modalId}`}
           style={{
             // same as comment above
             zIndex: modalIds.indexOf(modalId) + 10

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -65,6 +65,7 @@ function Modal({
           classNames
         )}
         role="dialog"
+        aria-label={screenReaderModalDescriptionText}
       >
         <div
           className="modal__screen-reader-description"


### PR DESCRIPTION

#### Link to issue
DDFSOEG-352

#### Description
We are getting an error from the accessibility test in the dpl-cms telling us that an element that has a role of a dialog needs to have a label in order for it to be accessible. 

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a