### PR TITLE
Feature/cmn 398 renew loans

### DIFF
--- a/src/apps/loan-list/list/ToggleListViewButtons.tsx
+++ b/src/apps/loan-list/list/ToggleListViewButtons.tsx
@@ -75,9 +75,11 @@ const ToggleListViewButtons: FC<ToggleListViewButtonsProps> = ({
               openRenewLoansModal();
             }}
             disabled={disableRenewLoansButton}
+            className={`btn-primary btn-filled btn-small arrow__hover--right-small ${
+              disableRenewLoansButton ? "btn-outline" : ""
+            }`}
             id="test-renew-button"
             aria-describedby="renew-multiple-modal"
-            className="btn-primary btn-filled btn-small arrow__hover--right-small"
           >
             {t("loanListRenewMultipleButtonText")}
           </button>

--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -3,6 +3,7 @@ import { formatDate, isDigital } from "../../utils/helpers";
 import { useText } from "../../../../core/utils/text";
 import StatusBadge from "../utils/status-badge";
 import { LoanType } from "../../../../core/utils/types/loan-type";
+import { LoanId } from "../../../../core/utils/types/ids";
 import fetchMaterial, { MaterialProps } from "../utils/material-fetch-hoc";
 import fetchDigitalMaterial from "../utils/digital-material-fetch-hoc";
 import CheckBox from "../../../../components/checkbox/Checkbox";
@@ -15,7 +16,7 @@ interface SelectableMaterialProps {
   loan: LoanType;
   disabled?: boolean;
   materialsToRenew: number[];
-  onChecked?: (loanId: number) => void;
+  onChecked?: (loanId: LoanId) => void;
 }
 
 const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({

--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -3,7 +3,6 @@ import { formatDate, isDigital } from "../../utils/helpers";
 import { useText } from "../../../../core/utils/text";
 import StatusBadge from "../utils/status-badge";
 import { LoanType } from "../../../../core/utils/types/loan-type";
-import { FaustId } from "../../../../core/utils/types/ids";
 import fetchMaterial, { MaterialProps } from "../utils/material-fetch-hoc";
 import fetchDigitalMaterial from "../utils/digital-material-fetch-hoc";
 import CheckBox from "../../../../components/checkbox/Checkbox";
@@ -15,8 +14,8 @@ import StatusMessage from "./StatusMessage";
 interface SelectableMaterialProps {
   loan: LoanType;
   disabled?: boolean;
-  materialsToRenew: FaustId[];
-  onChecked?: (faust: FaustId) => void;
+  materialsToRenew: number[];
+  onChecked?: (loanId: number) => void;
 }
 
 const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
@@ -28,7 +27,7 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
 }) => {
   const t = useText();
   const { open } = useModalButtonHandler();
-  const { dueDate, faust, identifier } = loan;
+  const { dueDate, faust, identifier, loanId } = loan;
   const { authors, materialType, year, title } = material || {};
 
   const selectListMaterial = useCallback(
@@ -53,11 +52,11 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
           }`}
         >
           <div className="mr-32">
-            {faust && onChecked && (
+            {loanId && faust && onChecked && (
               <CheckBox
-                onChecked={() => onChecked(faust)}
+                onChecked={() => onChecked(loanId)}
                 id={faust}
-                selected={Boolean(materialsToRenew?.indexOf(faust) > -1)}
+                selected={Boolean(materialsToRenew?.indexOf(loanId) > -1)}
                 disabled={disabled}
                 label={t("groupModalHiddenLabelCheckboxOnMaterialText")}
                 hideLabel

--- a/src/apps/loan-list/modal/material-details.tsx
+++ b/src/apps/loan-list/modal/material-details.tsx
@@ -60,7 +60,7 @@ const MaterialDetails: FC<MaterialDetailsProps & MaterialProps> = ({
           />
         )}
       </ModalDetailsHeader>
-      {!isDigital(loan) && faust && (
+      {!isDigital(loan) && faust && loanId && (
         <RenewButton faust={faust} loanId={loanId} renewable={isRenewable} />
       )}
       {isDigital(loan) && (

--- a/src/apps/loan-list/modal/material-details.tsx
+++ b/src/apps/loan-list/modal/material-details.tsx
@@ -30,6 +30,7 @@ const MaterialDetails: FC<MaterialDetailsProps & MaterialProps> = ({
   const {
     dueDate,
     faust,
+    loanId,
     identifier,
     isRenewable,
     materialItemNumber,
@@ -60,7 +61,7 @@ const MaterialDetails: FC<MaterialDetailsProps & MaterialProps> = ({
         )}
       </ModalDetailsHeader>
       {!isDigital(loan) && faust && (
-        <RenewButton faust={faust} renewable={isRenewable} />
+        <RenewButton faust={faust} loanId={loanId} renewable={isRenewable} />
       )}
       {isDigital(loan) && (
         <div className="modal-details__buttons">

--- a/src/apps/loan-list/modal/renew-button.tsx
+++ b/src/apps/loan-list/modal/renew-button.tsx
@@ -6,11 +6,12 @@ import { FaustId } from "../../../core/utils/types/ids";
 import { useModalButtonHandler } from "../../../core/utils/modal";
 
 interface RenewButtonProps {
-  faust: FaustId;
+  loanId: number;
   renewable: boolean;
+  faust: FaustId;
 }
 
-const RenewButton: FC<RenewButtonProps> = ({ faust, renewable }) => {
+const RenewButton: FC<RenewButtonProps> = ({ loanId, faust, renewable }) => {
   const t = useText();
   const queryClient = useQueryClient();
   const { close } = useModalButtonHandler();
@@ -44,7 +45,7 @@ const RenewButton: FC<RenewButtonProps> = ({ faust, renewable }) => {
       <button
         type="button"
         disabled={!renewable}
-        onClick={() => renew(parseInt(faust, 10))}
+        onClick={() => renew(loanId)}
         className="btn-primary btn-filled btn-small arrow__hover--right-small"
       >
         {t("materialDetailsRenewLoanButtonText")}

--- a/src/apps/loan-list/modal/renew-button.tsx
+++ b/src/apps/loan-list/modal/renew-button.tsx
@@ -46,7 +46,9 @@ const RenewButton: FC<RenewButtonProps> = ({ loanId, faust, renewable }) => {
         type="button"
         disabled={!renewable}
         onClick={() => renew(loanId)}
-        className="btn-primary btn-filled btn-small arrow__hover--right-small"
+        className={`btn-primary btn-filled btn-small arrow__hover--right-small ${
+          !renewable ? "btn-outline" : ""
+        }`}
       >
         {t("materialDetailsRenewLoanButtonText")}
       </button>

--- a/src/apps/loan-list/modal/renew-button.tsx
+++ b/src/apps/loan-list/modal/renew-button.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, FC } from "react";
 import { useQueryClient } from "react-query";
 import { useText } from "../../../core/utils/text";
 import { useRenewLoansV2, getGetLoansV2QueryKey } from "../../../core/fbs/fbs";
-import { FaustId } from "../../../core/utils/types/ids";
+import { FaustId, LoanId } from "../../../core/utils/types/ids";
 import { useModalButtonHandler } from "../../../core/utils/modal";
 
 interface RenewButtonProps {
-  loanId: number;
+  loanId: LoanId;
   renewable: boolean;
   faust: FaustId;
 }

--- a/src/apps/loan-list/modal/renew-loans-modal-content.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal-content.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../../core/utils/helpers/general";
 import { Button } from "../../../components/Buttons/Button";
 import { LoanType } from "../../../core/utils/types/loan-type";
+import { LoanId } from "../../../core/utils/types/ids";
 import usePager from "../../../components/result-pager/use-pager";
 import CheckBox from "../../../components/checkbox/Checkbox";
 import modalIdsConf from "../../../core/configuration/modal-ids.json";
@@ -71,7 +72,7 @@ const RenewLoansModalContent: FC<RenewLoansModalContentProps> = ({
     }
   };
 
-  const onChecked = (loanId: number) => {
+  const onChecked = (loanId: LoanId) => {
     const materialsToRenewCopy = [...materialsToRenew];
 
     const indexOfItemToRemove = materialsToRenew.indexOf(loanId);

--- a/src/apps/loan-list/modal/renew-loans-modal-content.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal-content.tsx
@@ -10,7 +10,6 @@ import {
 import { Button } from "../../../components/Buttons/Button";
 import { LoanType } from "../../../core/utils/types/loan-type";
 import usePager from "../../../components/result-pager/use-pager";
-import { FaustId } from "../../../core/utils/types/ids";
 import CheckBox from "../../../components/checkbox/Checkbox";
 import modalIdsConf from "../../../core/configuration/modal-ids.json";
 import { useModalButtonHandler } from "../../../core/utils/modal";
@@ -72,14 +71,14 @@ const RenewLoansModalContent: FC<RenewLoansModalContentProps> = ({
     }
   };
 
-  const onChecked = (faust: FaustId) => {
+  const onChecked = (loanId: number) => {
     const materialsToRenewCopy = [...materialsToRenew];
 
-    const indexOfItemToRemove = materialsToRenew.indexOf(faust);
+    const indexOfItemToRemove = materialsToRenew.indexOf(loanId);
     if (indexOfItemToRemove > -1) {
       materialsToRenewCopy.splice(indexOfItemToRemove, 1);
     } else {
-      materialsToRenewCopy.push(faust);
+      materialsToRenewCopy.push(loanId);
     }
     setMaterialsToRenew(materialsToRenewCopy);
   };

--- a/src/apps/loan-list/modal/renew-loans-modal-content.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal-content.tsx
@@ -35,16 +35,13 @@ const RenewLoansModalContent: FC<RenewLoansModalContentProps> = ({
   const { isIntersecting: isVisible } = useIntersection(intersectionRef, {
     threshold: 0
   }) || { isIntersecting: false };
-  const [materialsToRenew, setMaterialsToRenew] = useState<FaustId[]>([]);
+  const [materialsToRenew, setMaterialsToRenew] = useState<number[]>([]);
   const [displayedLoans, setDisplayedLoans] = useState<LoanType[]>([]);
 
   const renewSelected = useCallback(() => {
-    const numberMaterialIds = materialsToRenew.map((materialId) =>
-      parseInt(materialId, 10)
-    );
     mutate(
       {
-        data: numberMaterialIds
+        data: materialsToRenew
       },
       {
         onSuccess: (result) => {

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -59,9 +59,9 @@ export const Button: React.FC<ButtonProps> = ({
     <button
       data-cy={dataCy || "button"}
       type="button"
-      className={`btn-primary btn-${variant} btn-${size} arrow__hover--right-small ${
-        classNames ?? ""
-      }`}
+      className={`btn-primary btn-${variant} btn-${size} ${
+        disabled ? "btn-outline" : ""
+      } arrow__hover--right-small ${classNames ?? ""}`}
       disabled={disabled}
       onClick={onClick}
       id={id}

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -198,7 +198,7 @@ export const getPageSizeFromConfiguration = (pageSizeConf: ConfScope) => {
 export const getRenewableMaterials = (list: LoanType[]) => {
   return list
     .filter(({ isRenewable }) => isRenewable)
-    .map(({ faust }) => faust) as FaustId[];
+    .map(({ loanId }) => loanId) as number[];
 };
 
 export const getAmountOfRenewableLoans = (list: LoanType[]) => {

--- a/src/core/utils/helpers/list-mapper.ts
+++ b/src/core/utils/helpers/list-mapper.ts
@@ -1,4 +1,4 @@
-import { LoanV2, RenewedLoanV2, ReservationDetailsV2 } from "../../fbs/model";
+import { LoanV2, ReservationDetailsV2 } from "../../fbs/model";
 import { FaustId } from "../types/ids";
 import { GetManifestationViaMaterialByFaustQuery } from "../../dbc-gateway/generated/graphql";
 import { BasicDetailsType } from "../types/basic-details-type";
@@ -68,7 +68,8 @@ export const mapPublizonLoanToLoanType = (list: Loan[]): LoanType[] => {
       renewalStatusList: [],
       loanType: null,
       identifier: libraryBook?.identifier || null,
-      faust: null
+      faust: null,
+      loanId: null
     };
   });
 };
@@ -88,28 +89,8 @@ export const mapFBSLoanToLoanType = (list: LoanV2[]): LoanType[] => {
       materialItemNumber: loanDetails.materialItemNumber,
       loanType: loanDetails.loanType,
       identifier: null,
-      faust: (loanDetails.recordId as FaustId) || null
-    };
-  });
-};
-
-// RenewedLoanV2 is a renewed loan from FBS, and for the moment has no
-// equivalent in publizon. It is mapped to loan type, because the only
-// thing relevant in the UI is that the loan has been renewed, and is
-// Not renewable any longer.
-export const mapFBSRenewedLoanToLoanType = (
-  list: RenewedLoanV2[]
-): LoanType[] => {
-  return list.map(({ loanDetails }) => {
-    return {
-      dueDate: loanDetails.dueDate,
-      loanDate: loanDetails.loanDate,
-      renewalStatusList: [],
-      isRenewable: false,
-      materialItemNumber: loanDetails.materialItemNumber,
-      loanType: loanDetails.loanType,
-      identifier: null,
-      faust: (loanDetails.recordId as FaustId) || null
+      faust: (loanDetails.recordId as FaustId) || null,
+      loanId: loanDetails.loanId
     };
   });
 };

--- a/src/core/utils/types/ids.ts
+++ b/src/core/utils/types/ids.ts
@@ -5,3 +5,4 @@ export type Pid = `${number}-${string}:${FaustId}`;
 export type WorkId = `work-of:${number}-${string}:${FaustId}`;
 export type GuardedAppId = "material" | "search-result";
 export type IssnId = DigitalArticleService["issn"];
+export type LoanId = number;

--- a/src/core/utils/types/loan-type.ts
+++ b/src/core/utils/types/loan-type.ts
@@ -1,4 +1,5 @@
 import { ListType } from "./list-type";
+import { LoanId } from "./ids";
 
 export interface LoanType extends ListType {
   dueDate?: string | null;
@@ -8,5 +9,5 @@ export interface LoanType extends ListType {
   materialItemNumber?: string | null;
   renewalStatusList: string[];
   loanType: string | null;
-  loanId: number | null;
+  loanId: LoanId | null;
 }

--- a/src/core/utils/types/loan-type.ts
+++ b/src/core/utils/types/loan-type.ts
@@ -8,4 +8,5 @@ export interface LoanType extends ListType {
   materialItemNumber?: string | null;
   renewalStatusList: string[];
   loanType: string | null;
+  loanId: number | null;
 }


### PR DESCRIPTION
#### Link to issue

n/a

#### Description

- button disable are not supposed to be black
- renew is (apparently) not with faust but with loanid
- remove unused mapper

#### Screenshot of the result

disabled knap: 

<img width="275" alt="image" src="https://user-images.githubusercontent.com/15377965/208404860-1fc70820-9ad4-48c6-ae93-f9ca6a74ad39.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
