### PR TITLE
Add StockAndReservationInfo to ReservationSucces

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -253,13 +253,13 @@ export default {
     materialsInStockInfoText: {
       name: "Materials in stock info text",
       defaultValue:
-        '{"type":"plural","text":["We have 1 copy of the material in stock","We have @count copies of the material in stock"]}',
+        '{"type":"plural","text":["We have 1 copy of the material in stock. ","We have @count copies of the material in stock. "]}',
       control: { type: "text" }
     },
     materialReservationInfoText: {
       name: "Material Reservation info text",
       defaultValue:
-        '{"type":"plural","text":["1 copy has been reserved","@count copies have been reserved"]}',
+        '{"type":"plural","text":["1 copy has been reserved.","@count copies have been reserved."]}',
       control: { type: "text" }
     },
     onlineLimitMonthInfoText: {
@@ -427,7 +427,7 @@ export default {
     },
     numberInQueueText: {
       name: "Number in queue text",
-      defaultValue: "You are number @number in the queue",
+      defaultValue: "You are number @number in the queue. ",
       control: { type: "text" }
     },
     alreadyReservedText: {

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { totalMaterials } from "../../../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
 import { Pid } from "../../../../core/utils/types/ids";
@@ -25,7 +24,7 @@ const MaterialAvailabilityTextPhysical: React.FC<
   return (
     <MaterialAvailabilityTextParagraph>
       <StockAndReservationInfo
-        stockCount={totalMaterials(holdings)}
+        holdings={holdings}
         reservationCount={reservations}
       />
     </MaterialAvailabilityTextParagraph>

--- a/src/components/material/StockAndReservationInfo.tsx
+++ b/src/components/material/StockAndReservationInfo.tsx
@@ -1,19 +1,22 @@
 import * as React from "react";
 import { FC } from "react";
 import { useText } from "../../core/utils/text";
+import { totalMaterials } from "../../apps/material/helper";
+import { HoldingsV3 } from "../../core/fbs/model";
 
 export interface StockAndReservationInfoProps {
-  stockCount: number;
+  holdings: HoldingsV3[];
   reservationCount: number;
   numberInQueue?: number;
 }
 
 const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
-  stockCount,
+  holdings,
   reservationCount,
   numberInQueue
 }) => {
   const t = useText();
+  const stockCount = totalMaterials(holdings);
 
   const materialsInStockInfoText = t("materialsInStockInfoText", {
     count: stockCount,

--- a/src/components/material/StockAndReservationInfo.tsx
+++ b/src/components/material/StockAndReservationInfo.tsx
@@ -5,11 +5,13 @@ import { useText } from "../../core/utils/text";
 export interface StockAndReservationInfoProps {
   stockCount: number;
   reservationCount: number;
+  numberInQueue?: number;
 }
 
 const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
   stockCount,
-  reservationCount
+  reservationCount,
+  numberInQueue
 }) => {
   const t = useText();
 
@@ -22,10 +24,17 @@ const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
     placeholders: { "@count": reservationCount }
   });
 
+  const numberInQueueText = numberInQueue
+    ? t("numberInQueueText", {
+        placeholders: { "@number": numberInQueue }
+      })
+    : false;
+
   return (
     <>
-      {materialsInStockInfoText && `${materialsInStockInfoText}.`}{" "}
-      {materialReservationInfoText && materialReservationInfoText}
+      {materialsInStockInfoText && `${materialsInStockInfoText}.`}
+      {materialReservationInfoText && ` ${materialReservationInfoText}.`}
+      {numberInQueueText && ` ${numberInQueueText}`}
     </>
   );
 };

--- a/src/components/material/StockAndReservationInfo.tsx
+++ b/src/components/material/StockAndReservationInfo.tsx
@@ -32,9 +32,9 @@ const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
 
   return (
     <>
-      {materialsInStockInfoText && `${materialsInStockInfoText}.`}
-      {materialReservationInfoText && ` ${materialReservationInfoText}.`}
-      {numberInQueueText && ` ${numberInQueueText}`}
+      {numberInQueueText && numberInQueueText}
+      {materialsInStockInfoText && materialsInStockInfoText}
+      {materialReservationInfoText && materialReservationInfoText}
     </>
   );
 };

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -21,7 +21,6 @@ import {
 import UserListItems from "./UserListItems";
 import ReservationSucces from "./ReservationSucces";
 import ReservationError from "./ReservationError";
-import { totalMaterials } from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,
@@ -184,7 +183,7 @@ const ReservationModalBody = ({
             <div className="reservation-modal-submit">
               <MaterialAvailabilityTextParagraph>
                 <StockAndReservationInfo
-                  stockCount={totalMaterials(holdings)}
+                  holdings={holdings}
                   reservationCount={reservations}
                 />
               </MaterialAvailabilityTextParagraph>
@@ -244,7 +243,7 @@ const ReservationModalBody = ({
             reservationDetails.pickupBranch,
             branches
           )}
-          stockCount={totalMaterials(holdings)}
+          holdings={holdings}
           reservationCount={reservations}
           numberInQueue={reservationDetails.numberInQueue}
         />

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -244,6 +244,8 @@ const ReservationModalBody = ({
             reservationDetails.pickupBranch,
             branches
           )}
+          stockCount={totalMaterials(holdings)}
+          reservationCount={reservations}
           numberInQueue={reservationDetails.numberInQueue}
         />
       )}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -4,6 +4,7 @@ import { closeModal } from "../../core/modal.slice";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 import StockAndReservationInfo from "../material/StockAndReservationInfo";
+import { HoldingsV3 } from "../../core/fbs/model";
 
 type ReservationSuccesProps = {
   title: string;
@@ -11,7 +12,7 @@ type ReservationSuccesProps = {
   modalId: string;
   numberInQueue?: number;
   reservationCount: number;
-  stockCount: number;
+  holdings: HoldingsV3[];
 };
 
 const ReservationSucces: React.FC<ReservationSuccesProps> = ({
@@ -20,7 +21,7 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   preferredPickupBranch,
   numberInQueue,
   reservationCount,
-  stockCount
+  holdings
 }) => {
   const dispatch = useDispatch();
   const t = useText();
@@ -43,7 +44,7 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         className="text-body-medium-regular pb-24"
       >
         <StockAndReservationInfo
-          stockCount={stockCount}
+          holdings={holdings}
           reservationCount={reservationCount}
           numberInQueue={numberInQueue}
         />

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -3,19 +3,24 @@ import { useDispatch } from "react-redux";
 import { closeModal } from "../../core/modal.slice";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
+import StockAndReservationInfo from "../material/StockAndReservationInfo";
 
 type ReservationSuccesProps = {
   title: string;
   preferredPickupBranch: string;
   modalId: string;
   numberInQueue?: number;
+  reservationCount: number;
+  stockCount: number;
 };
 
 const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   modalId,
   title,
   preferredPickupBranch,
-  numberInQueue
+  numberInQueue,
+  reservationCount,
+  stockCount
 }) => {
   const dispatch = useDispatch();
   const t = useText();
@@ -32,6 +37,12 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         className="text-body-medium-regular pb-24"
       >
         {title} {t("reservationSuccesIsReservedForYouText")}
+      </p>
+      <p className="text-body-medium-regular">
+        <StockAndReservationInfo
+          stockCount={stockCount}
+          reservationCount={reservationCount}
+        />
       </p>
       {numberInQueue && (
         <p

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -38,22 +38,16 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
       >
         {title} {t("reservationSuccesIsReservedForYouText")}
       </p>
-      <p className="text-body-medium-regular">
+      <p
+        data-cy="number-in-queue-text"
+        className="text-body-medium-regular pb-24"
+      >
         <StockAndReservationInfo
           stockCount={stockCount}
           reservationCount={reservationCount}
+          numberInQueue={numberInQueue}
         />
       </p>
-      {numberInQueue && (
-        <p
-          data-cy="number-in-queue-text"
-          className="text-body-medium-regular pb-24"
-        >
-          {t("numberInQueueText", {
-            placeholders: { "@number": numberInQueue }
-          })}
-        </p>
-      )}
       <p
         data-cy="reservation-success-preferred-pickup-branch-text"
         className="text-body-medium-regular pb-48"


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-344

#### Display information about stock and reservation counts in ReservationSucces

The StockAndReservationInfo component was added to the ReservationSucces to display more information about the stockCount and reservationCount of a reservation. This information may be useful for the user to know, as it can help them understand the availability and popularity of the item they are interested in.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/49920322/210379463-f276449a-6cfe-473a-9274-6b66fff46360.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions