### PR TITLE
Creators are missing" should not appear when there is no value (Remove creatorsAreMissingText)

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -200,11 +200,6 @@ export default {
       defaultValue: "Genre",
       control: { type: "text" }
     },
-    creatorsAreMissingText: {
-      name: "Creators are missing",
-      defaultValue: "Creators are missing",
-      control: { type: "text" }
-    },
     readArticleText: {
       name: "Read article",
       defaultValue: "Read article",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -15,7 +15,6 @@ interface MaterialEntryTextProps {
   chooseOneText: string;
   closeText: string;
   contributorsText: string;
-  creatorsAreMissingText: string;
   daysText: string;
   descriptionHeadlineText: string;
   detailsOfTheMaterialText: string;

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -55,9 +55,10 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
     recordid: faustIdArray,
     ...(blacklistBranches ? { exclude: blacklistBranches } : {})
   });
-  const author =
-    creatorsToString(flattenCreators(filterCreators(authors, ["Person"])), t) ||
-    t("creatorsAreMissingText");
+  const author = creatorsToString(
+    flattenCreators(filterCreators(authors, ["Person"])),
+    t
+  );
   const title = workTitles.join(", ");
   const modalId = findOnShelfModalId(
     convertPostIdToFaustId(manifestations[0].pid)
@@ -175,7 +176,8 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
     >
       <>
         <h2 className="text-header-h2 modal-find-on-shelf__headline">
-          {`${title} / ${author}`}
+          {title}
+          {author && ` / ${author}`}
         </h2>
         {isPeriodical && selectedPeriodical && (
           <FindOnShelfPeriodicalDropdowns

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -60,7 +60,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
       })
     );
   };
-  const creatorsText = creatorsToString(
+  const author = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t
   );
@@ -69,8 +69,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
       return materialType.specific === "tidsskrift";
     }
   );
-
-  const author = creatorsText || t("creatorsAreMissingText");
 
   const containsDanish = mainLanguages.some((language) =>
     language?.isoCode.toLowerCase().includes("dan")

--- a/src/components/material/MaterialHeaderText.tsx
+++ b/src/components/material/MaterialHeaderText.tsx
@@ -18,15 +18,17 @@ const MaterialHeaderText: React.FC<MaterialHeaderTextProps> = ({
   return (
     <>
       <h1 className="text-header-h1 mb-16">{title}</h1>
-      <p data-cy="material-header-author-text" className="text-body-large">
-        <span>{t("materialHeaderAuthorByText")} </span>
-        <LinkNoStyle
-          url={constructSearchUrl(searchUrl, author)}
-          className="arrow__link"
-        >
-          {author}
-        </LinkNoStyle>
-      </p>
+      {author && (
+        <p data-cy="material-header-author-text" className="text-body-large">
+          <span>{t("materialHeaderAuthorByText")} </span>
+          <LinkNoStyle
+            url={constructSearchUrl(searchUrl, author)}
+            className="arrow__link"
+          >
+            {author}
+          </LinkNoStyle>
+        </p>
+      )}
     </>
   );
 };

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -50,11 +50,10 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   const t = useText();
   const { materialUrl, searchUrl } = useUrls();
   const dispatch = useDispatch<TypedDispatch>();
-  const creatorsText = creatorsToString(
+  const author = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
     t
   );
-  const author = creatorsText || t("creatorsAreMissingText");
   const manifestationPid = getManifestationPid(manifestations);
   const firstInSeries = series?.[0];
   const { title: seriesTitle, numberInSeries } = firstInSeries || {};


### PR DESCRIPTION


#### https://reload.atlassian.net/browse/DDFSOEG-334

#### Creators are missing" should not appear when there is no value

The situation is due to the fact that we have transitioned from a situation where dummydata always contained authors/origin to a situation where this is no longer the case.

#### Screenshot of the result
![Skærmbillede 2022-12-20 kl  14 04 29 (3)](https://user-images.githubusercontent.com/49920322/208674550-65261644-8cfa-4ad4-8f17-d722f77c28f5.png)

![Skærmbillede 2022-12-20 kl  14 06 32 (3)](https://user-images.githubusercontent.com/49920322/208674582-05c89ccb-f21c-463b-8e70-14c944a270d1.png)

![Skærmbillede 2022-12-20 kl  14 07 07 (3)](https://user-images.githubusercontent.com/49920322/208674604-f246baee-c5da-4379-a77a-1cce14778073.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
