### PR TITLE
Adds new function `getWorkTitle`

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -5,6 +5,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
+  materialIsFiction,
   orderManifestationsByYear
 } from "../../core/utils/helpers/general";
 import { UseTextFunction } from "../../core/utils/text";
@@ -36,6 +37,25 @@ export const getManifestationFromType = (
   return allManifestationsThatMatchType.shift();
 };
 
+export const getWorkTitle = (
+  work: Work,
+  type: "original" | "full"
+): string | null => {
+  if (!materialIsFiction(work)) return null;
+
+  let title: string | null = null;
+
+  if (type === "original" && work.titles.original) {
+    title = work.titles.original.shift() ?? null;
+  }
+
+  if (type === "full" && work.titles.full) {
+    title = work.titles.full.shift() ?? null;
+  }
+
+  return title ? `${title} ${work.workYear}` : null;
+};
+
 export const getWorkDescriptionListData = ({
   manifestation,
   work,
@@ -45,7 +65,7 @@ export const getWorkDescriptionListData = ({
   work: Work;
   t: UseTextFunction;
 }): ListData => {
-  const { titles, mainLanguages, creators, workYear } = work;
+  const { mainLanguages, creators } = work;
 
   const allLanguages = mainLanguages
     .map((language) => language.display)
@@ -79,7 +99,7 @@ export const getWorkDescriptionListData = ({
     { label: t("contributorsText"), value: creatorsText, type: "link" },
     {
       label: t("originalTitleText"),
-      value: titles && workYear ? `${titles?.original} ${workYear}` : "",
+      value: getWorkTitle(work, "original") ?? "",
       type: "standard"
     },
     {


### PR DESCRIPTION
### See this comment https://reload.atlassian.net/browse/DDFSOEG-339?focusedCommentId=105517

#### https://reload.atlassian.net/browse/DDFSOEG-339
#### Adds new function `getWorkTitle`

This PR adds a new function called `getWorkTitle` to the project. The function takes in a `Work` object and a string indicating the type of title to retrieve ("original" or "full"). If the `Work` object is fiction and the specified title exists, the function returns the title with the work year appended to it. Otherwise, it returns `null`.

#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

