### PR TITLE
Move getManifestationType for app independence

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -5,13 +5,11 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
+  getManifestationType,
   orderManifestationsByYear
 } from "../../core/utils/helpers/general";
 import { UseTextFunction } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-
-export const getManifestationType = (manifestation: Manifestation) =>
-  manifestation?.materialTypes?.[0]?.specific;
 
 export const getWorkManifestation = (work: Work) => {
   return work.manifestations.latest as Manifestation;

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -24,7 +24,6 @@ import {
 import {
   getWorkDescriptionListData,
   getManifestationFromType,
-  getManifestationType,
   getWorkManifestation,
   getInfomediaId
 } from "./helper";
@@ -32,6 +31,7 @@ import FindOnShelfModal from "../../components/find-on-shelf/FindOnShelfModal";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import {
   getManifestationPid,
+  getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import ReservationModal from "../../components/reservation/ReservationModal";

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { getManifestationType } from "../../apps/material/helper";
-import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import {
+  convertPostIdToFaustId,
+  getManifestationType
+} from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
   setQueryParametersInUrl

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -3,6 +3,7 @@ import Various from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/
 import { useQueryClient } from "react-query";
 import {
   convertPostIdToFaustId,
+  getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
@@ -20,10 +21,7 @@ import {
 import UserListItems from "./UserListItems";
 import ReservationSucces from "./ReservationSucces";
 import ReservationError from "./ReservationError";
-import {
-  getManifestationType,
-  totalMaterials
-} from "../../apps/material/helper";
+import { totalMaterials } from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -317,4 +317,7 @@ export const filterLoansSoonOverdue = (loans: LoanType[]) => {
   });
 };
 
+export const getManifestationType = (manifestation: Manifestation) =>
+  manifestation?.materialTypes?.[0]?.specific;
+
 export default {};


### PR DESCRIPTION
#### Move getManifestationType for app independence

This pull request moves the getManifestationType function from material/helper.ts to core/utils/helpers/general.ts. The purpose of this change is to ensure that the three apps can work independently of each other.

I have updated all relevant imports and references to the function to reflect its new location. 

I believe this change will improve the modularity and maintainability of the codebase.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.