### PR TITLE
Update rendering of InfomediaModal and DigitalModal components

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -232,20 +232,20 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           />
         </>
       ))}
-      {currentManifestation && infomediaId && (
-        <>
-          <InfomediaModal
-            mainManifestation={currentManifestation}
-            infoMediaId={infomediaId}
-          />
-          {hasCorrectAccess("DigitalArticleService", currentManifestation) && (
-            <DigitalModal
-              digitalArticleIssn={getDigitalArticleIssn(currentManifestation)}
-              pid={currentManifestation.pid}
-              workId={wid}
-            />
-          )}
-        </>
+
+      {infomediaId && (
+        <InfomediaModal
+          mainManifestation={currentManifestation}
+          infoMediaId={infomediaId}
+        />
+      )}
+
+      {hasCorrectAccess("DigitalArticleService", currentManifestation) && (
+        <DigitalModal
+          digitalArticleIssn={getDigitalArticleIssn(currentManifestation)}
+          pid={currentManifestation.pid}
+          workId={wid}
+        />
       )}
     </section>
   );


### PR DESCRIPTION
#### https://reload.atlassian.net/browse/DDFSOEG-365


#### This pull request refactors the code for rendering the InfomediaModal and DigitalModal components in the material app. 

Changes made:

- InfomediaModal is now always rendered as long as infomediaId is truthy.
- DigitalModal is now only rendered if the result of hasCorrectAccess("DigitalArticleService") is true 

**Previously, the rendering of DigitalModal was dependent on infomediaId, which was not necessary.**

This commit also removes the unnecessary check for currentManifestation and refactors the code to correctly render the InfomediaModal and DigitalModal components based on their respective prop values.


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.