### PR TITLE
Enable "find on shelf" button if no material specimens available

### DIFF
--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -20,7 +20,7 @@ export interface AvailabilityLabelsProps {
   cursorPointer?: boolean;
 }
 
-export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
+export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
   manifestations,
   workId,
   selectedManifestation: manifestation,

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { WorkId } from "../../core/utils/types/ids";
-import { AvailabiltityLabels } from "../availability-label/availability-labels";
+import { AvailabilityLabels } from "../availability-label/availability-labels";
 import ButtonFavourite, {
   ButtonFavouriteId
 } from "../button-favourite/button-favourite";
@@ -108,7 +108,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <ButtonFavourite id={wid} addToListRequest={addToListRequest} />
         <MaterialHeaderText title={String(title)} author={author} />
         <div className="material-header__availability-label">
-          <AvailabiltityLabels
+          <AvailabilityLabels
             cursorPointer
             workId={wid}
             manifestations={manifestations}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -69,15 +69,12 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
       return materialType.specific === "tidsskrift";
     }
   );
-
   const containsDanish = mainLanguages.some((language) =>
     language?.isoCode.toLowerCase().includes("dan")
   );
-
   const allLanguages = mainLanguages
     .map((language) => language.display)
     .join(", ");
-
   const title = containsDanish ? fullTitle : `${fullTitle} (${allLanguages})`;
   const coverPid = pid || getManifestationPid(manifestations);
   const { track } = useStatistics();

--- a/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { FC } from "react";
-import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
 import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -21,25 +20,15 @@ const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
 }) => {
   const t = useText();
   const { open } = useModalButtonHandler();
-  const { data, isLoading, isError } = useGetAvailabilityV3({
-    recordid: faustIds
-  });
-
   const onClick = () => {
     open(findOnShelfModalId(faustIds[0]));
   };
-
   // If element is currently focused on, we would like to let users open it using enter
   const onKeyUp = (key: string) => {
     if (key === "Enter") {
       onClick();
     }
   };
-
-  if (!data || isError || isLoading) {
-    // TODO: handle error here once we handle errors
-    return null;
-  }
 
   if (size !== "small") {
     return (

--- a/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
@@ -42,19 +42,6 @@ const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
   }
 
   if (size !== "small") {
-    if (!data[0].available) {
-      return (
-        <Button
-          label={t("materialIsLoanedOutText")}
-          buttonType="none"
-          variant="outline"
-          disabled
-          collapsible={false}
-          size="large"
-          dataCy={dataCy}
-        />
-      );
-    }
     return (
       <Button
         label={t("findOnBookshelfText")}
@@ -66,14 +53,6 @@ const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
         onClick={onClick}
         dataCy={dataCy}
       />
-    );
-  }
-
-  if (!data[0].available) {
-    return (
-      <span className="text-small-caption material-manifestation-item__find capitalize-all">
-        {t("materialIsLoanedOutText")}
-      </span>
     );
   }
 

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -143,7 +143,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         className="search-result-item__availability"
         data-cy="search-result-item-availability"
       >
-        <AvailabiltityLabels
+        <AvailabilityLabels
           cursorPointer
           workId={workId}
           manifestations={manifestations}

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 import { useText } from "../../../core/utils/text";
 import { WorkId } from "../../../core/utils/types/ids";
 import Arrow from "../../atoms/icons/arrow/arrow";
-import { AvailabiltityLabels } from "../../availability-label/availability-labels";
+import { AvailabilityLabels } from "../../availability-label/availability-labels";
 import ButtonFavourite, {
   ButtonFavouriteId
 } from "../../button-favourite/button-favourite";
@@ -137,7 +137,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         )}
       </div>
       <div className="search-result-item__availability">
-        <AvailabiltityLabels
+        <AvailabilityLabels
           cursorPointer
           workId={workId}
           manifestations={manifestations}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-359

#### Description
The find on shelf button should always be enabled for physical materials such as books, CDs, etc., even though they are unavailable. 

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/209960617-3852c68f-78a4-4e0c-a9b0-afef4be3f57a.png)
![image](https://user-images.githubusercontent.com/28546954/209960733-50c4d2e6-a533-4894-a9bc-3f41aa027412.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Please disregard the failing "loan-list" test. Sine is working on fixing it.