### PR TITLE
One availability label per material type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,8 @@
     },
     {
       "files": [
-        "*.tsx"
+        "*.tsx",
+        "*.ts"
       ],
       "rules": {
         // We do not use prop-types in ts.

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -11,6 +11,7 @@ import {
 } from "../../core/utils/helpers/general";
 import { UseTextFunction } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
+import { FaustId } from "../../core/utils/types/ids";
 import MaterialType from "../../core/utils/types/material-type";
 
 export const getLatestWorkManifestation = (work: Work) => {
@@ -244,4 +245,9 @@ export const getBestMaterialTypeForWork = (work: Work) => {
   }
   return getManifestationsWithMaterialType(work.manifestations.all)[0]
     .materialTypes[0].specific;
+};
+
+export const reservationModalId = (faustIds: FaustId[]) => {
+  const sortedFaustIds = faustIds.sort();
+  return `reservation-modal-${sortedFaustIds.join("-")}`;
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -177,6 +177,20 @@ export const getAllUniqueMaterialTypes = (manifestations: Manifestation[]) => {
   return uniq(allMaterialTypes);
 };
 
+export const divideManifestationsByMaterialType = (
+  manifestations: Manifestation[]
+) => {
+  const uniqueMaterialTypes = getAllUniqueMaterialTypes(manifestations);
+  return uniqueMaterialTypes.map((uniqueMaterialType) => {
+    return manifestations.filter((manifest) => {
+      const manifestationMaterialTypes = manifest.materialTypes.map(
+        (materialType) => materialType.specific
+      );
+      return manifestationMaterialTypes.includes(uniqueMaterialType);
+    });
+  });
+};
+
 export const getAllIdentifiers = (manifestations: Manifestation[]) => {
   return manifestations
     .map((manifestation) =>

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -150,7 +150,6 @@ export const getInfomediaIds = (manifestations: Manifestation[]) => {
   const infomediaIds = manifestations
     .map((manifestation) =>
       manifestation.access.map((currentAccess) => {
-        // eslint-disable-next-line no-underscore-dangle
         return currentAccess.__typename === "InfomediaService"
           ? currentAccess.id
           : null;

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -259,6 +259,5 @@ export const getBestMaterialTypeForWork = (work: Work) => {
 };
 
 export const reservationModalId = (faustIds: FaustId[]) => {
-  const sortedFaustIds = faustIds.sort();
-  return `reservation-modal-${sortedFaustIds.join("-")}`;
+  return `reservation-modal-${faustIds.sort().join("-")}`;
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -9,7 +9,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getAllUniqueMaterialTypes,
+  getMaterialTypes,
   getManifestationType,
   orderManifestationsByYear
 } from "../../core/utils/helpers/general";
@@ -185,7 +185,7 @@ export const getInfomediaIds = (manifestations: Manifestation[]) => {
 export const divideManifestationsByMaterialType = (
   manifestations: Manifestation[]
 ) => {
-  const uniqueMaterialTypes = getAllUniqueMaterialTypes(manifestations);
+  const uniqueMaterialTypes = getMaterialTypes(manifestations);
   const dividedManifestationsArrays = uniqueMaterialTypes.map(
     (uniqueMaterialType) => {
       return manifestations.filter((manifest) => {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -196,12 +196,13 @@ export const divideManifestationsByMaterialType = (
       });
     }
   );
-  const dividedManifestationsObject: { [key: string]: Manifestation[] } =
-    dividedManifestationsArrays.reduce((result, current, index) => {
+  return dividedManifestationsArrays.reduce<{ [key: string]: Manifestation[] }>(
+    (result, current, index) => {
       const materialType = uniqueMaterialTypes[index];
       return { ...result, [materialType]: current };
-    }, {});
-  return dividedManifestationsObject;
+    },
+    {}
+  );
 };
 
 export const getAllIdentifiers = (manifestations: Manifestation[]) => {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,11 +1,6 @@
 import { compact } from "lodash";
-import { ManifestationHoldings } from "../../components/find-on-shelf/types";
-import { ListData } from "../../components/material/MaterialDetailsList";
 import {
-  HoldingsForBibliographicalRecordV3,
-  HoldingsV3
-} from "../../core/fbs/model";
-import {
+  constructModalId,
   creatorsToString,
   filterCreators,
   flattenCreators,
@@ -13,6 +8,12 @@ import {
   getManifestationType,
   orderManifestationsByYear
 } from "../../core/utils/helpers/general";
+import { ManifestationHoldings } from "../../components/find-on-shelf/types";
+import { ListData } from "../../components/material/MaterialDetailsList";
+import {
+  HoldingsForBibliographicalRecordV3,
+  HoldingsV3
+} from "../../core/fbs/model";
 import { UseTextFunction } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import { FaustId } from "../../core/utils/types/ids";
@@ -259,5 +260,5 @@ export const getBestMaterialTypeForWork = (work: Work) => {
 };
 
 export const reservationModalId = (faustIds: FaustId[]) => {
-  return `reservation-modal-${faustIds.sort().join("-")}`;
+  return constructModalId("reservation-modal", faustIds.sort());
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,4 +1,4 @@
-import { compact, uniq } from "lodash";
+import { compact } from "lodash";
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
 import {
@@ -9,6 +9,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
+  getAllUniqueMaterialTypes,
   getManifestationType,
   orderManifestationsByYear
 } from "../../core/utils/helpers/general";
@@ -24,7 +25,7 @@ export const getLatestWorkManifestation = (work: Work) => {
 export const filterManifestationsByType = (
   type: string,
   manifestations: Manifestation[]
-) => manifestations.filter((item) => getManifestationType(item) === type);
+) => manifestations.filter((item) => getManifestationType([item]) === type);
 
 export const getManifestationsFromType = (
   type: string,
@@ -179,13 +180,6 @@ export const getInfomediaIds = (manifestations: Manifestation[]) => {
     )
     .flat();
   return compact(infomediaIds);
-};
-
-export const getAllUniqueMaterialTypes = (manifestations: Manifestation[]) => {
-  const allMaterialTypes = manifestations
-    .map((manifest) => manifest.materialTypes.map((type) => type.specific))
-    .flat();
-  return uniq(allMaterialTypes);
 };
 
 export const divideManifestationsByMaterialType = (

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,7 +1,10 @@
 import { compact, uniq } from "lodash";
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
-import { HoldingsV3 } from "../../core/fbs/model";
+import {
+  HoldingsForBibliographicalRecordV3,
+  HoldingsV3
+} from "../../core/fbs/model";
 import {
   creatorsToString,
   filterCreators,
@@ -122,8 +125,25 @@ export const getWorkDescriptionListData = ({
   ];
 };
 
-export const totalMaterials = (holdings: HoldingsV3[]) => {
-  return holdings.reduce((acc, curr) => acc + curr.materials.length, 0);
+export const getTotalHoldings = (
+  holdings: HoldingsForBibliographicalRecordV3[]
+) => {
+  return holdings.reduce((acc, curr) => {
+    return (
+      acc +
+      curr.holdings.reduce((accumulator, current) => {
+        return accumulator + current.materials.length;
+      }, 0)
+    );
+  }, 0);
+};
+
+export const getTotalReservations = (
+  holdings: HoldingsForBibliographicalRecordV3[]
+) => {
+  return holdings.reduce((acc, curr) => {
+    return acc + curr.reservations;
+  }, 0);
 };
 
 export const totalAvailableMaterials = (materials: HoldingsV3["materials"]) => {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -198,10 +198,6 @@ export const getAllIdentifiers = (manifestations: Manifestation[]) => {
     .flat();
 };
 
-export const getAllPids = (manifestations: Manifestation[]) => {
-  return manifestations.map((manifestation) => manifestation.pid);
-};
-
 export const getManifestationsWithMaterialType = (
   manifestations: Manifestation[]
 ) => {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,4 +1,4 @@
-import { uniq } from "lodash";
+import { compact, uniq } from "lodash";
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
 import { HoldingsV3 } from "../../core/fbs/model";
@@ -147,15 +147,7 @@ export const totalBranchesHaveMaterial = (
 };
 
 export const getInfomediaIds = (manifestations: Manifestation[]) => {
-  const manifestationsWithInfomediaAccess = manifestations.filter(
-    (manifestation) => {
-      return manifestation.access.find((currentAccess) => {
-        // eslint-disable-next-line no-underscore-dangle
-        return currentAccess.__typename === "InfomediaService";
-      });
-    }
-  );
-  const infomediaIds = manifestationsWithInfomediaAccess
+  const infomediaIds = manifestations
     .map((manifestation) =>
       manifestation.access.map((currentAccess) => {
         // eslint-disable-next-line no-underscore-dangle
@@ -164,10 +156,8 @@ export const getInfomediaIds = (manifestations: Manifestation[]) => {
           : null;
       })
     )
-    .flat()
-    .filter((id) => id);
-
-  return infomediaIds as string[];
+    .flat();
+  return compact(infomediaIds);
 };
 
 export const getAllUniqueMaterialTypes = (manifestations: Manifestation[]) => {

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -58,7 +58,7 @@ describe("Material", () => {
       .and("contain", "Lucinda Riley");
   });
 
-  it("Renders exactly 1 availability label for the book material type that unavailable", () => {
+  it("Renders exactly 1 availability label per material type", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -69,7 +69,20 @@ describe("Material", () => {
     cy.getBySel("availability-label")
       .find('[data-cy="availability-label-type"]')
       .contains("bog")
-      .should("have.length", 1)
+      .should("have.length", 1);
+  });
+
+  it("Shows the book availability as unavailable", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/fbi-api.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+
+    cy.getBySel("availability-label")
+      .find('[data-cy="availability-label-type"]')
+      .contains("bog")
       .parent()
       .find('[data-cy="availability-label-status"]')
       .should("have.text", "unavailable");

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -1,7 +1,7 @@
 const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
 
 describe("Material", () => {
-  it("Does the Material have title?", () => {
+  it("Renders a title", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -10,7 +10,7 @@ describe("Material", () => {
     cy.get(".text-header-h1").should("be.visible");
   });
 
-  it("Check that cover has a src", () => {
+  it("Renders a cover with a source", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -20,7 +20,7 @@ describe("Material", () => {
     cy.get("img").should("have.attr", "src").and("match", coverUrlPattern);
   });
 
-  it("Does the material have favourite buttons?", () => {
+  it("Renders favorite buttons", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -33,7 +33,7 @@ describe("Material", () => {
     );
   });
 
-  it("Does the material have horizontal lines?", () => {
+  it("Renders horizontal lines", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -46,7 +46,7 @@ describe("Material", () => {
       .and("contain.text", "Nr. 1  in seriesDe syv søstre-serien");
   });
 
-  it("Does the material have authors?", () => {
+  it("Renders authors", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -58,7 +58,7 @@ describe("Material", () => {
       .and("contain", "Lucinda Riley");
   });
 
-  it("Has exactly 1 availability label for the book material type that unavailable", () => {
+  it("Renders exactly 1 availability label for the book material type that unavailable", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -75,7 +75,7 @@ describe("Material", () => {
       .should("have.text", "unavailable");
   });
 
-  it("Open material details", () => {
+  it("Can open material details", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -86,7 +86,7 @@ describe("Material", () => {
     cy.getBySel("material-details-disclosure").click();
   });
 
-  it("Does the material have a editions with a buttton to reserved", () => {
+  it("Renders editions with a reservation button", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -104,7 +104,7 @@ describe("Material", () => {
       });
   });
 
-  it("Opens modal by clicking on reserver button (reserve book) and close it with the x bottom", () => {
+  it("Opens modal by clicking on reservation button and closes it with the x button", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -131,7 +131,7 @@ describe("Material", () => {
     ).click();
   });
 
-  it("Clicking on Aprove resevation (Godkend reservation and close modal with Ok button)", () => {
+  it("Can open reservation modal, approve a reservation, and close the modal using buttons)", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -251,6 +251,17 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           workId={wid}
         />
       )}
+
+      {selectedManifestations && (
+        <FindOnShelfModal
+          manifestations={selectedManifestations}
+          authors={work.creators}
+          workTitles={work.titles.full}
+          selectedPeriodical={selectedPeriodical}
+          setSelectedPeriodical={setSelectedPeriodical}
+          isPerMaterialType
+        />
+      )}
     </section>
   );
 };

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -236,7 +236,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       {infomediaIds.length > 0 && (
         <InfomediaModal
           selectedManifestations={selectedManifestations}
-          infoMediaIds={infomediaIds}
+          infoMediaId={infomediaIds[0]}
         />
       )}
 

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -24,8 +24,8 @@ import {
 import {
   getWorkDescriptionListData,
   getManifestationFromType,
-  getLatestWorkManifestation,
-  getInfomediaIds
+  getInfomediaIds,
+  divideManifestationsByMaterialType
 } from "./helper";
 import FindOnShelfModal from "../../components/find-on-shelf/FindOnShelfModal";
 import { Manifestation, Work } from "../../core/utils/types/entities";
@@ -109,12 +109,14 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     if (!data?.work) return;
     const { work } = data as { work: Work };
     const type = getUrlQueryParam("type");
-    // if there is no type in the url, getLatestWorkManifestation is used to set the state and url type parameters
+    // If there is no type in the url, we select one
     if (!type) {
-      const workManifestation = getLatestWorkManifestation(work);
-      setSelectedManifestations([workManifestation]);
+      const manifestationsByMaterialType = divideManifestationsByMaterialType(
+        data.work.manifestations.all as Manifestation[]
+      );
+      setSelectedManifestations(manifestationsByMaterialType[0]);
       setQueryParametersInUrl({
-        type: getManifestationType(workManifestation)
+        type: getManifestationType(manifestationsByMaterialType[0][0])
       });
       return;
     }

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -24,16 +24,13 @@ import {
 } from "../../core/utils/helpers/url";
 import {
   getWorkDescriptionListData,
-  getManifestationFromType,
   getInfomediaIds,
-  divideManifestationsByMaterialType
+  divideManifestationsByMaterialType,
+  getBestMaterialTypeForWork
 } from "./helper";
 import FindOnShelfModal from "../../components/find-on-shelf/FindOnShelfModal";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import {
-  getManifestationPid,
-  getManifestationType
-} from "../../core/utils/helpers/general";
+import { getManifestationPid } from "../../core/utils/helpers/general";
 import ReservationModal from "../../components/reservation/ReservationModal";
 import { PeriodicalEdition } from "../../components/material/periodical/helper";
 import InfomediaModal from "../../components/material/infomedia/InfomediaModal";
@@ -113,23 +110,20 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     if (!data?.work) return;
     const { work } = data as { work: Work };
     const type = getUrlQueryParam("type");
+    const manifestationsByMaterialType = divideManifestationsByMaterialType(
+      work.manifestations.all
+    );
     // If there is no type in the url, we select one
     if (!type) {
-      const manifestationsByMaterialType = divideManifestationsByMaterialType(
-        work.manifestations.all
-      );
-      setSelectedManifestations(manifestationsByMaterialType[0]);
+      const bestMaterialType = getBestMaterialTypeForWork(work);
+      setSelectedManifestations(manifestationsByMaterialType[bestMaterialType]);
       setQueryParametersInUrl({
-        type: getManifestationType(manifestationsByMaterialType[0][0])
+        type: bestMaterialType
       });
       return;
     }
-
-    // if there is a type, getManifestationFromType will sort and filter all manifestation and choose the first one
-    const manifestationFromType = getManifestationFromType(type, work);
-    if (manifestationFromType) {
-      setSelectedManifestations([manifestationFromType]);
-    }
+    // if there is a type, use it to select a group of manifestations
+    setSelectedManifestations(manifestationsByMaterialType[type]);
   }, [data]);
 
   if (isLoading) {

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -218,7 +218,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             key={`reservation-modal-${manifestation.pid}`}
             selectedManifestations={[manifestation]}
             selectedPeriodical={selectedPeriodical}
-            workId={wid}
             work={work}
           />
           <FindOnShelfModal
@@ -252,7 +251,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             <ReservationModal
               selectedManifestations={selectedManifestations}
               selectedPeriodical={selectedPeriodical}
-              workId={wid}
               work={work}
             />
             <FindOnShelfModal

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -5,6 +5,7 @@ import Receipt from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/
 import { useDeepCompareEffect } from "react-use";
 import MaterialHeader from "../../components/material/MaterialHeader";
 import {
+  AccessTypeCode,
   ExternalReview,
   InfomediaReview,
   LibrariansReview,
@@ -31,8 +32,7 @@ import FindOnShelfModal from "../../components/find-on-shelf/FindOnShelfModal";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import {
   getManifestationPid,
-  getManifestationType,
-  materialIsFiction
+  getManifestationType
 } from "../../core/utils/helpers/general";
 import ReservationModal from "../../components/reservation/ReservationModal";
 import { PeriodicalEdition } from "../../components/material/periodical/helper";
@@ -41,7 +41,11 @@ import { useStatistics } from "../../core/statistics/useStatistics";
 import { statistics } from "../../core/statistics/statistics";
 import DisclosureControllable from "../../components/Disclosures/DisclosureControllable";
 import DigitalModal from "../../components/material/digital-modal/DigitalModal";
-import { hasCorrectAccess } from "../../components/material/material-buttons/helper";
+import {
+  hasCorrectAccess,
+  hasCorrectAccessType,
+  isArticle
+} from "../../components/material/material-buttons/helper";
 import { getDigitalArticleIssnIds } from "../../components/material/digital-modal/helper";
 
 export interface MaterialProps {
@@ -155,7 +159,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     work,
     t
   });
-  const parallelManifestations = materialIsFiction(work) ? manifestations : [];
   const infomediaIds = getInfomediaIds(selectedManifestations);
 
   // Get disclosure URL parameter from the current URL to see if it should be open
@@ -220,8 +223,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         <>
           <ReservationModal
             key={`reservation-modal-${manifestation.pid}`}
-            mainManifestation={manifestation}
-            parallelManifestations={parallelManifestations}
+            selectedManifestations={[manifestation]}
             selectedPeriodical={selectedPeriodical}
             workId={wid}
             work={work}
@@ -254,16 +256,28 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         />
       )}
 
-      {selectedManifestations && (
-        <FindOnShelfModal
-          manifestations={selectedManifestations}
-          authors={work.creators}
-          workTitles={work.titles.full}
-          selectedPeriodical={selectedPeriodical}
-          setSelectedPeriodical={setSelectedPeriodical}
-          isPerMaterialType
-        />
-      )}
+      {/* Only create a main version of "reservation" & "find on shelf" modal for physical materials. */}
+      {selectedManifestations &&
+        hasCorrectAccessType(AccessTypeCode.Physical, selectedManifestations) &&
+        !isArticle(selectedManifestations) && (
+          <>
+            <ReservationModal
+              selectedManifestations={selectedManifestations}
+              selectedPeriodical={selectedPeriodical}
+              workId={wid}
+              work={work}
+              isPerMaterialType
+            />
+            <FindOnShelfModal
+              manifestations={selectedManifestations}
+              authors={work.creators}
+              workTitles={work.titles.full}
+              selectedPeriodical={selectedPeriodical}
+              setSelectedPeriodical={setSelectedPeriodical}
+              isPerMaterialType
+            />
+          </>
+        )}
     </section>
   );
 };

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -239,7 +239,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         </>
       ))}
 
-      {infomediaIds && infomediaIds.length > 0 && (
+      {infomediaIds.length > 0 && (
         <InfomediaModal
           selectedManifestations={selectedManifestations}
           infoMediaIds={infomediaIds}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -254,7 +254,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
               selectedPeriodical={selectedPeriodical}
               workId={wid}
               work={work}
-              isPerMaterialType
             />
             <FindOnShelfModal
               manifestations={selectedManifestations}
@@ -262,7 +261,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
               workTitles={work.titles.full}
               selectedPeriodical={selectedPeriodical}
               setSelectedPeriodical={setSelectedPeriodical}
-              isPerMaterialType
             />
           </>
         )}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -43,7 +43,6 @@ import {
   hasCorrectAccessType,
   isArticle
 } from "../../components/material/material-buttons/helper";
-import { getDigitalArticleIssnIds } from "../../components/material/digital-modal/helper";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -241,13 +240,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       )}
 
       {hasCorrectAccess("DigitalArticleService", selectedManifestations) && (
-        <DigitalModal
-          digitalArticleIssnIds={getDigitalArticleIssnIds(
-            selectedManifestations
-          )}
-          pid={selectedManifestations[0].pid}
-          workId={wid}
-        />
+        <DigitalModal pid={selectedManifestations[0].pid} workId={wid} />
       )}
 
       {/* Only create a main version of "reservation" & "find on shelf" modal for physical materials. */}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -84,7 +84,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       });
     }
     // We can afford to only check the latest manifestation because audience doesn't
-    // vary between a specific work's manifestations (information provided by DDF)
+    // vary between a specific work's manifestations (information provided by DDF).
     if (data?.work?.manifestations.latest.audience?.generalAudience) {
       track("click", {
         id: statistics.materialTopicNumber.id,
@@ -104,7 +104,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
-  // This useEffect selects the current manifestation
+  // This useEffect selects the current manifestation.
   useEffect(() => {
     if (!data?.work) return;
     const { work } = data as { work: Work };
@@ -112,7 +112,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     const manifestationsByMaterialType = divideManifestationsByMaterialType(
       work.manifestations.all
     );
-    // If there is no type in the url, we select one
+    // If there is no type in the url, we select one.
     if (!type) {
       const bestMaterialType = getBestMaterialTypeForWork(work);
       setSelectedManifestations(manifestationsByMaterialType[bestMaterialType]);
@@ -121,7 +121,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       });
       return;
     }
-    // if there is a type, use it to select a group of manifestations
+    // If there is a type, use it to select a group of manifestations.
     setSelectedManifestations(manifestationsByMaterialType[type]);
   }, [data]);
 
@@ -129,7 +129,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     return <div>Loading...</div>;
   }
 
-  // TODO: handle error if data is empty array
+  // TODO: handle error if data is empty array.
   if (!data?.work || !selectedManifestations) {
     return <div>No work data</div>;
   }
@@ -154,7 +154,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   });
   const infomediaIds = getInfomediaIds(selectedManifestations);
 
-  // Get disclosure URL parameter from the current URL to see if it should be open
+  // Get disclosure URL parameter from the current URL to see if it should be open.
   const shouldOpenReviewDisclosure = !!getUrlQueryParam("disclosure");
 
   return (

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -217,6 +217,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
       {manifestations.map((manifestation) => (
         <>
           <ReservationModal
+            key={`reservation-modal-${manifestation.pid}`}
             mainManifestation={manifestation}
             parallelManifestations={parallelManifestations}
             selectedPeriodical={selectedPeriodical}
@@ -224,10 +225,10 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
             work={work}
           />
           <FindOnShelfModal
+            key={`find-on-shelf-modal-${manifestation.pid}`}
             manifestations={[manifestation]}
             workTitles={manifestation.titles.main}
             authors={manifestation.creators}
-            key={`find-on-shelf-modal-${manifestation.pid}`}
             selectedPeriodical={selectedPeriodical}
             setSelectedPeriodical={setSelectedPeriodical}
           />

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -243,7 +243,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         <DigitalModal pid={selectedManifestations[0].pid} workId={wid} />
       )}
 
-      {/* Only create a main version of "reservation" & "find on shelf" modal for physical materials. */}
+      {/* Only create a main version of "reservation" & "find on shelf" modal for physical materials.
+        Online materials lead to external links, or to same modals as are created for singular editions. */}
       {selectedManifestations &&
         hasCorrectAccessType(AccessTypeCode.Physical, selectedManifestations) &&
         !isArticle(selectedManifestations) && (

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -116,7 +116,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     // If there is no type in the url, we select one
     if (!type) {
       const manifestationsByMaterialType = divideManifestationsByMaterialType(
-        data.work.manifestations.all as Manifestation[]
+        work.manifestations.all
       );
       setSelectedManifestations(manifestationsByMaterialType[0]);
       setQueryParametersInUrl({

--- a/src/apps/material/order-digital-copy.test.ts
+++ b/src/apps/material/order-digital-copy.test.ts
@@ -47,6 +47,7 @@ describe("Material - Order digital copy", () => {
     cy.visit(
       "/iframe.html?id=apps-material--digital&viewMode=story&type=tidsskriftsartikel"
     );
+    cy.createFakeAuthenticatedSession();
   });
 
   it("render a material that can be ordered as a digital copy", () => {

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -59,15 +59,12 @@ describe("Search Result", () => {
     );
   });
 
-  it("Renders pager info", () => {
+  it("Renders show more button", () => {
     cy.get(".result-pager button").should("contain.text", "SHOW MORE");
   });
 
-  it("Renders show more button", () => {
-    cy.get(".result-pager button").click();
-  });
-
   it("Loads more search result items after clicking show more results", () => {
+    cy.get(".result-pager button").click();
     cy.get(".search-result-page__list").find("li").should("have.length", 4);
   });
 

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -7,36 +7,36 @@ describe("Search Result", () => {
     );
   });
 
-  it("Check search title", () => {
+  it("Renders search title", () => {
     cy.getBySel("search-result-title")
       .should("be.visible")
       .and("contain", "Showing results for “harry” (722)");
   });
 
-  it("Check length of search result list", () => {
+  it("Renders two search results", () => {
     cy.get(".search-result-page__list").find("li").should("have.length", 2);
   });
 
-  it("Do the search results have images?", () => {
+  it("Renders the images", () => {
     cy.get(".search-result-page__list .search-result-item img")
       .should("have.attr", "src")
       .and("match", coverUrlPattern);
   });
 
-  it("Does the search result have favourite buttons?", () => {
+  it("Renders the favorite buttons", () => {
     cy.get(
       ".search-result-page__list .search-result-item .button-favourite"
     ).should("have.attr", "aria-label", "Add to favorites");
   });
 
-  it("Does the search result have titles?", () => {
+  it("Renders the titles", () => {
     cy.getBySel("search-result-item-title")
       .first()
       .should("be.visible")
       .and("contain", "Harry : samtaler med prinsen");
   });
 
-  it("Does the search result have authors?", () => {
+  it("Renders the authors", () => {
     cy.getBySel("search-result-item-author")
       .first()
       .should("be.visible")
@@ -52,26 +52,26 @@ describe("Search Result", () => {
   });
 
   // TODO: When the pager bug has been solved, this test can be re-enabled.
-  it("Do we have a pager?", () => {
+  it("Renders the pager", () => {
     cy.get(".result-pager__title").should(
       "contain.text",
       "Showing 2 out of 722 results"
     );
   });
 
-  it("Do we have some pager info?", () => {
+  it("Renders pager info", () => {
     cy.get(".result-pager button").should("contain.text", "SHOW MORE");
   });
 
-  it("Show more", () => {
+  it("Renders show more button", () => {
     cy.get(".result-pager button").click();
   });
 
-  it("Check length of search result list since it should be twice as long.", () => {
+  it("Loads more search result items after clicking show more results", () => {
     cy.get(".search-result-page__list").find("li").should("have.length", 4);
   });
 
-  it("The pager info should also have been updated.", () => {
+  it("Updates the pager info after clicking show more results", () => {
     cy.get(".result-pager__title").should(
       "contain.text",
       "Showing 4 out of 722 results"

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -13,7 +13,7 @@ describe("Search Result", () => {
       .and("contain", "Showing results for “harry” (722)");
   });
 
-  it("Renders two search results", () => {
+  it("Renders all the search results", () => {
     cy.get(".search-result-page__list").find("li").should("have.length", 2);
   });
 

--- a/src/components/availability-label/availability-label.dev.tsx
+++ b/src/components/availability-label/availability-label.dev.tsx
@@ -97,7 +97,7 @@ Unavailable.args = {
 
 export const EBogPrinsenHarry = Template.bind({});
 EBogPrinsenHarry.args = {
-  isbn: "9788763844123",
+  isbns: ["9788763844123"],
   manifestText: "ebog",
   accessTypes: [AccessTypeCode.Online]
 };

--- a/src/components/availability-label/availability-label.dev.tsx
+++ b/src/components/availability-label/availability-label.dev.tsx
@@ -47,7 +47,7 @@ export default {
       name: "Cypress data attribute",
       control: { type: "text" }
     },
-    isbn: {
+    isbns: {
       name: "ISBN",
       control: { type: "text" }
     },

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -38,7 +38,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   const { isAvailable } = useAvailabilityData({
     accessTypes,
     faustIds,
-    isbn: isbns[0]
+    isbn: isbns ? isbns[0] : null
   });
 
   const availabilityText = isAvailable ? t("available") : t("unavailable");

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -18,7 +18,7 @@ export interface AvailabilityLabelProps {
   handleSelectManifestation?: () => void | undefined;
   cursorPointer?: boolean;
   dataCy?: string;
-  isbn: string;
+  isbns: string[];
 }
 
 export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
@@ -30,7 +30,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   handleSelectManifestation,
   cursorPointer = false,
   dataCy = "availability-label",
-  isbn
+  isbns
 }) => {
   const { track } = useStatistics();
   const t = useText();
@@ -38,7 +38,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   const { isAvailable } = useAvailabilityData({
     accessTypes,
     faustIds,
-    isbn
+    isbn: isbns[0]
   });
 
   const availabilityText = isAvailable ? t("available") : t("unavailable");

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -25,7 +25,7 @@ export interface AvailabilityLabelsProps {
   cursorPointer?: boolean;
 }
 
-export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
+export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
   manifestations,
   workId,
   selectedManifestations,

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -76,7 +76,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
                   }
                 : undefined
             }
-            isbn={identifiers?.[0]}
+            isbns={identifiers}
           />
         );
       })}

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import {
   convertPostIdToFaustId,
-  getAllPids,
-  getManifestationType
+  getAllPids
 } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
@@ -64,7 +63,8 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             accessTypes={accessTypesCodes}
             selected={
               selectedManifestations &&
-              materialType === getManifestationType(selectedManifestations[0])
+              materialType ===
+                getAllUniqueMaterialTypes(selectedManifestations)[0]
             }
             handleSelectManifestation={
               setSelectedManifestations

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {
-  convertPostIdsToFaustIds,
-  getAllPids,
+  getAllFaustIds,
   getMaterialTypes
 } from "../../core/utils/helpers/general";
 import {
@@ -43,9 +42,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
       {allMaterialTypes.map((materialType) => {
         const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
-        const faustIds = convertPostIdsToFaustIds(
-          getAllPids(manifestationsOfMaterialType)
-        ).sort();
+        const faustIds = getAllFaustIds(manifestationsOfMaterialType).sort();
         const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = manifestationsOfMaterialType

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -13,7 +13,8 @@ import { AvailabilityLabel } from "./availability-label";
 import { Manifestation } from "../../core/utils/types/entities";
 import {
   divideManifestationsByMaterialType,
-  getAllIdentifiers
+  getAllIdentifiers,
+  getAllUniqueMaterialTypes
 } from "../../apps/material/helper";
 
 export interface AvailabilityLabelsProps {
@@ -32,17 +33,18 @@ export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
   cursorPointer = false
 }) => {
   const { materialUrl } = useUrls();
-  // Divide manifestations into array of arrays based on material type.
+  const allMaterialTypes = getAllUniqueMaterialTypes(manifestations);
   const manifestationsByMaterialType =
     divideManifestationsByMaterialType(manifestations);
 
-  // Map over the outer array and send array of faust IDs to availability label component.
+  // Map over the distinct material types and assign manifestations of that type to each label
   return (
     <>
-      {manifestationsByMaterialType.map((arrayOfManifestations) => {
+      {allMaterialTypes.map((materialType) => {
+        const arrayOfManifestations =
+          manifestationsByMaterialType[materialType];
         const pidArray = arrayOfManifestations.map((manifest) => manifest.pid);
         const faustIdArray = pidArray.map((pid) => convertPostIdToFaustId(pid));
-        const materialType = arrayOfManifestations[0].materialTypes[0].specific;
         const identifiers = getAllIdentifiers(arrayOfManifestations);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = arrayOfManifestations

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  convertPostIdToFaustId,
+  convertPostIdsToFaustIds,
   getAllPids
 } from "../../core/utils/helpers/general";
 import {
@@ -44,7 +44,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
         const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
         const pids = getAllPids(manifestationsOfMaterialType);
-        const faustIds = pids.map((pid) => convertPostIdToFaustId(pid)).sort();
+        const faustIds = convertPostIdsToFaustIds(pids).sort();
         const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = manifestationsOfMaterialType

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -43,8 +43,9 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
       {allMaterialTypes.map((materialType) => {
         const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
-        const pids = getAllPids(manifestationsOfMaterialType);
-        const faustIds = convertPostIdsToFaustIds(pids).sort();
+        const faustIds = convertPostIdsToFaustIds(
+          getAllPids(manifestationsOfMaterialType)
+        ).sort();
         const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = manifestationsOfMaterialType

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {
   convertPostIdsToFaustIds,
-  getAllPids
+  getAllPids,
+  getAllUniqueMaterialTypes
 } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
@@ -13,8 +14,7 @@ import { AvailabilityLabel } from "./availability-label";
 import { Manifestation } from "../../core/utils/types/entities";
 import {
   divideManifestationsByMaterialType,
-  getAllIdentifiers,
-  getAllUniqueMaterialTypes
+  getAllIdentifiers
 } from "../../apps/material/helper";
 
 export interface AvailabilityLabelsProps {

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -41,13 +41,15 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
   return (
     <>
       {allMaterialTypes.map((materialType) => {
-        const arrayOfManifestations =
+        const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
-        const pidArray = arrayOfManifestations.map((manifest) => manifest.pid);
+        const pidArray = manifestationsOfMaterialType.map(
+          (manifest) => manifest.pid
+        );
         const faustIdArray = pidArray.map((pid) => convertPostIdToFaustId(pid));
-        const identifiers = getAllIdentifiers(arrayOfManifestations);
+        const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
-        const accessTypesCodes = arrayOfManifestations
+        const accessTypesCodes = manifestationsOfMaterialType
           .map((manifest) => {
             return manifest.accessTypes.map((accessType) => accessType.code);
           })
@@ -68,7 +70,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             handleSelectManifestation={
               setSelectedManifestations
                 ? () => {
-                    setSelectedManifestations(arrayOfManifestations);
+                    setSelectedManifestations(manifestationsOfMaterialType);
                     setQueryParametersInUrl({
                       type: materialType
                     });

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   convertPostIdToFaustId,
+  getAllPids,
   getManifestationType
 } from "../../core/utils/helpers/general";
 import {
@@ -14,7 +15,6 @@ import { Manifestation } from "../../core/utils/types/entities";
 import {
   divideManifestationsByMaterialType,
   getAllIdentifiers,
-  getAllPids,
   getAllUniqueMaterialTypes
 } from "../../apps/material/helper";
 

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -45,7 +45,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
         const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
         const pids = getAllPids(manifestationsOfMaterialType);
-        const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
+        const faustIds = pids.map((pid) => convertPostIdToFaustId(pid)).sort();
         const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = manifestationsOfMaterialType
@@ -56,7 +56,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
 
         return (
           <AvailabilityLabel
-            key={materialType}
+            key={faustIds.join("-")}
             url={url}
             cursorPointer={cursorPointer}
             faustIds={faustIds}

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -12,8 +12,8 @@ import { useUrls } from "../../core/utils/url";
 import { AvailabilityLabel } from "./availability-label";
 import { Manifestation } from "../../core/utils/types/entities";
 import {
-  getAllIdentifiers,
-  getAllUniqueMaterialTypes
+  divideManifestationsByMaterialType,
+  getAllIdentifiers
 } from "../../apps/material/helper";
 
 export interface AvailabilityLabelsProps {
@@ -32,18 +32,9 @@ export const AvailabiltityLabels: React.FC<AvailabilityLabelsProps> = ({
   cursorPointer = false
 }) => {
   const { materialUrl } = useUrls();
-  const uniqueMaterialTypes = getAllUniqueMaterialTypes(manifestations);
   // Divide manifestations into array of arrays based on material type.
-  const manifestationsByMaterialType = uniqueMaterialTypes.map(
-    (uniqueMaterialType) => {
-      return manifestations.filter((manifest) => {
-        const manifestationMaterialTypes = manifest.materialTypes.map(
-          (materialType) => materialType.specific
-        );
-        return manifestationMaterialTypes.includes(uniqueMaterialType);
-      });
-    }
-  );
+  const manifestationsByMaterialType =
+    divideManifestationsByMaterialType(manifestations);
 
   // Map over the outer array and send array of faust IDs to availability label component.
   return (

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -14,6 +14,7 @@ import { Manifestation } from "../../core/utils/types/entities";
 import {
   divideManifestationsByMaterialType,
   getAllIdentifiers,
+  getAllPids,
   getAllUniqueMaterialTypes
 } from "../../apps/material/helper";
 
@@ -43,10 +44,8 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
       {allMaterialTypes.map((materialType) => {
         const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
-        const pidArray = manifestationsOfMaterialType.map(
-          (manifest) => manifest.pid
-        );
-        const faustIdArray = pidArray.map((pid) => convertPostIdToFaustId(pid));
+        const pids = getAllPids(manifestationsOfMaterialType);
+        const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
         const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = manifestationsOfMaterialType
@@ -60,7 +59,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             key={materialType}
             url={url}
             cursorPointer={cursorPointer}
-            faustIds={faustIdArray}
+            faustIds={faustIds}
             manifestText={materialType}
             accessTypes={accessTypesCodes}
             selected={

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {
   convertPostIdsToFaustIds,
   getAllPids,
-  getAllUniqueMaterialTypes
+  getMaterialTypes
 } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
@@ -33,7 +33,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
   cursorPointer = false
 }) => {
   const { materialUrl } = useUrls();
-  const allMaterialTypes = getAllUniqueMaterialTypes(manifestations);
+  const allMaterialTypes = getMaterialTypes(manifestations);
   const manifestationsByMaterialType =
     divideManifestationsByMaterialType(manifestations);
 
@@ -63,8 +63,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             accessTypes={accessTypesCodes}
             selected={
               selectedManifestations &&
-              materialType ===
-                getAllUniqueMaterialTypes(selectedManifestations)[0]
+              materialType === getMaterialTypes(selectedManifestations)[0]
             }
             handleSelectManifestation={
               setSelectedManifestations

--- a/src/components/find-on-shelf/FindOnShelfModal.dev.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.dev.tsx
@@ -84,7 +84,7 @@ const Template: ComponentStory<typeof FindOnShelfModal> = (
     <>
       <MaterialButtonsFindOnShelf
         size="small"
-        faustId={convertPostIdToFaustId(pid)}
+        faustIds={[convertPostIdToFaustId(pid)]}
       />
       <FindOnShelfModalWithConfigAndText {...args} />
     </>

--- a/src/components/find-on-shelf/FindOnShelfModal.dev.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.dev.tsx
@@ -84,7 +84,7 @@ const Template: ComponentStory<typeof FindOnShelfModal> = (
     <>
       <MaterialButtonsFindOnShelf
         size="small"
-        faustIds={[convertPostIdToFaustId(pid)]}
+        faustId={convertPostIdToFaustId(pid)}
       />
       <FindOnShelfModalWithConfigAndText {...args} />
     </>

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { FC } from "react";
 import { partition } from "lodash";
 import {
-  getAllPids,
   isAnyManifestationAvailableOnBranch,
   totalBranchesHaveMaterial
 } from "../../apps/material/helper";
@@ -12,6 +11,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
+  getAllPids,
   getManifestationsPids
 } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {
+  convertPostIdsToFaustIds,
   convertPostIdToFaustId,
   creatorsToString,
   filterCreators,
@@ -65,9 +66,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   const title = workTitles.join(", ");
   // If this modal is for all manifestations per material type, use all manifestations'
   // faust ids to create the modal id.
-  const faustIds = getAllPids(manifestations).map((pid) =>
-    convertPostIdToFaustId(pid)
-  );
+  const faustIds = convertPostIdsToFaustIds(getAllPids(manifestations));
   const modalId = `${findOnShelfModalId(faustIds)}`;
   const isPeriodical = manifestations.some((manifestation) => {
     return manifestation.materialTypes.some((materialType) => {

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -8,12 +8,11 @@ import {
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {
   constructModalId,
-  convertPostIdsToFaustIds,
   convertPostIdToFaustId,
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getAllPids,
+  getAllFaustIds,
   getManifestationsPids
 } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
@@ -66,7 +65,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   const title = workTitles.join(", ");
   // If this modal is for all manifestations per material type, use all manifestations'
   // faust ids to create the modal id.
-  const faustIds = convertPostIdsToFaustIds(getAllPids(manifestations));
+  const faustIds = getAllFaustIds(manifestations);
   const modalId = `${findOnShelfModalId(faustIds)}`;
   const isPeriodical = manifestations.some((manifestation) => {
     return manifestation.materialTypes.some((materialType) => {

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {
+  constructModalId,
   convertPostIdsToFaustIds,
   convertPostIdToFaustId,
   creatorsToString,
@@ -27,8 +28,7 @@ import { PeriodicalEdition } from "../material/periodical/helper";
 import { useConfig } from "../../core/utils/config";
 
 export const findOnShelfModalId = (faustIds: FaustId[]) => {
-  const sortedFaustIds = faustIds.sort();
-  return `find-on-shelf-modal-${sortedFaustIds.join("-")}`;
+  return constructModalId("find-on-shelf-modal", faustIds.sort());
 };
 
 export interface FindOnShelfModalProps {

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -33,6 +33,7 @@ export interface FindOnShelfModalProps {
   authors: Work["creators"];
   selectedPeriodical: PeriodicalEdition | null;
   setSelectedPeriodical: (selectedPeriodical: PeriodicalEdition) => void;
+  isPerMaterialType?: boolean;
 }
 
 const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
@@ -40,7 +41,8 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   workTitles,
   authors,
   selectedPeriodical,
-  setSelectedPeriodical
+  setSelectedPeriodical,
+  isPerMaterialType
 }) => {
   const config = useConfig();
   const blacklistBranches = config("blacklistedPickupBranchesConfig", {
@@ -60,9 +62,10 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
     t
   );
   const title = workTitles.join(", ");
-  const modalId = findOnShelfModalId(
+  // If this modal shows manifestations per material type, differentiate the ID
+  const modalId = `${findOnShelfModalId(
     convertPostIdToFaustId(manifestations[0].pid)
-  );
+  )}${isPerMaterialType ? "-main" : ""}`;
   const isPeriodical = manifestations.some((manifestation) => {
     return manifestation.materialTypes.some((materialType) => {
       return materialType.specific.includes("tidsskrift");

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -6,29 +6,27 @@ import MaterialAvailabilityTextOnline from "./online/MaterialAvailabilityTextOnl
 import MaterialAvailabilityTextPhysical from "./physical/MaterialAvailabilityTextPhysical";
 
 interface Props {
-  selectedManifestations: Manifestation[];
+  manifestations: Manifestation[];
 }
 
-const MaterialAvailabilityText: React.FC<Props> = ({
-  selectedManifestations
-}) => {
+const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
   return (
     <>
       {/* We use the first manifestation because accessType shouldn't change between manifestations of the same material type. */}
-      {selectedManifestations[0].accessTypes.map((accessType) => {
+      {manifestations[0].accessTypes.map((accessType) => {
         if (accessType.code === "PHYSICAL")
           return (
             <MaterialAvailabilityTextPhysical
-              pids={getAllPids(selectedManifestations)}
+              pids={getAllPids(manifestations)}
             />
           );
         if (
           accessType.code === "ONLINE" &&
-          getAllIdentifiers(selectedManifestations).length > 0
+          getAllIdentifiers(manifestations).length > 0
         )
           return (
             <MaterialAvailabilityTextOnline
-              isbn={getAllIdentifiers(selectedManifestations)[0]}
+              isbn={getAllIdentifiers(manifestations)[0]}
             />
           );
         return null;

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { getAllIdentifiers } from "../../../apps/material/helper";
+import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
 import { getAllPids } from "../../../core/utils/helpers/general";
 import { Manifestation } from "../../../core/utils/types/entities";
+import { hasCorrectAccessType } from "../material-buttons/helper";
 import MaterialAvailabilityTextOnline from "./online/MaterialAvailabilityTextOnline";
 import MaterialAvailabilityTextPhysical from "./physical/MaterialAvailabilityTextPhysical";
 
@@ -12,25 +14,15 @@ interface Props {
 const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
   return (
     <>
-      {/* We use the first manifestation because accessType shouldn't change between manifestations of the same material type. */}
-      {manifestations[0].accessTypes.map((accessType) => {
-        if (accessType.code === "PHYSICAL")
-          return (
-            <MaterialAvailabilityTextPhysical
-              pids={getAllPids(manifestations)}
-            />
-          );
-        if (
-          accessType.code === "ONLINE" &&
-          getAllIdentifiers(manifestations).length > 0
-        )
-          return (
-            <MaterialAvailabilityTextOnline
-              isbn={getAllIdentifiers(manifestations)[0]}
-            />
-          );
-        return null;
-      })}
+      {hasCorrectAccessType(AccessTypeCode.Physical, manifestations) && (
+        <MaterialAvailabilityTextPhysical pids={getAllPids(manifestations)} />
+      )}
+      {hasCorrectAccessType(AccessTypeCode.Online, manifestations) &&
+        !hasCorrectAccessType(AccessTypeCode.Online, manifestations) && (
+          <MaterialAvailabilityTextOnline
+            isbns={getAllIdentifiers(manifestations)}
+          />
+        )}
     </>
   );
 };

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { getAllIdentifiers, getAllPids } from "../../../apps/material/helper";
+import { getAllIdentifiers } from "../../../apps/material/helper";
+import { getAllPids } from "../../../core/utils/helpers/general";
 import { Manifestation } from "../../../core/utils/types/entities";
 import MaterialAvailabilityTextOnline from "./online/MaterialAvailabilityTextOnline";
 import MaterialAvailabilityTextPhysical from "./physical/MaterialAvailabilityTextPhysical";

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -18,7 +18,7 @@ const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
         <MaterialAvailabilityTextPhysical pids={getAllPids(manifestations)} />
       )}
       {hasCorrectAccessType(AccessTypeCode.Online, manifestations) &&
-        !hasCorrectAccessType(AccessTypeCode.Online, manifestations) && (
+        getAllIdentifiers(manifestations).length > 0 && (
           <MaterialAvailabilityTextOnline
             isbns={getAllIdentifiers(manifestations)}
           />

--- a/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
+++ b/src/components/material/MaterialAvailabilityText/online/MaterialAvailabilityTextOnline.tsx
@@ -7,12 +7,12 @@ import { useText } from "../../../../core/utils/text";
 import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
 
 interface MaterialAvailabilityTextOnlineProps {
-  isbn: string;
+  isbns: string[];
 }
 
 const MaterialAvailabilityTextOnline: React.FC<
   MaterialAvailabilityTextOnlineProps
-> = ({ isbn }) => {
+> = ({ isbns }) => {
   const t = useText();
   // TODO: Below there are 2 different isbn numbers that can be used in useGetV1ProductsIdentifier. with and without "blue title"
   // const costfreeID = "9788711321683";
@@ -29,7 +29,7 @@ const MaterialAvailabilityTextOnline: React.FC<
     data: productsData,
     isLoading: productsIsLoading,
     isError: productsIsError
-  } = useGetV1ProductsIdentifier(isbn);
+  } = useGetV1ProductsIdentifier(isbns[0]);
 
   if (productsIsLoading || productsIsError || !productsData) return null;
 

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { totalMaterials } from "../../../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
-import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
+import { convertPostIdsToFaustIds } from "../../../../core/utils/helpers/general";
 import { Pid } from "../../../../core/utils/types/ids";
 import StockAndReservationInfo from "../../StockAndReservationInfo";
 import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
@@ -13,7 +13,7 @@ interface MaterialAvailabilityTextPhysicalProps {
 const MaterialAvailabilityTextPhysical: React.FC<
   MaterialAvailabilityTextPhysicalProps
 > = ({ pids }) => {
-  const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
+  const faustIds = convertPostIdsToFaustIds(pids);
   const { data, isLoading, isError } = useGetHoldingsV3({
     recordid: faustIds
   });

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
-import { totalMaterials } from "../../../../apps/material/helper";
+import {
+  getTotalHoldings,
+  getTotalReservations
+} from "../../../../apps/material/helper";
 import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdsToFaustIds } from "../../../../core/utils/helpers/general";
 import { Pid } from "../../../../core/utils/types/ids";
@@ -20,12 +23,13 @@ const MaterialAvailabilityTextPhysical: React.FC<
 
   if (isLoading || isError || !data) return null;
 
-  const { reservations, holdings } = data[0];
+  const holdings = getTotalHoldings(data);
+  const reservations = getTotalReservations(data);
 
   return (
     <MaterialAvailabilityTextParagraph>
       <StockAndReservationInfo
-        stockCount={totalMaterials(holdings)}
+        stockCount={holdings}
         reservationCount={reservations}
       />
     </MaterialAvailabilityTextParagraph>

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -135,14 +135,12 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           <>
             <div className="material-header__button">
               <MaterialButtons
-                selectedManifestations={selectedManifestations}
+                manifestations={selectedManifestations}
                 workId={wid}
                 dataCy="material-header-buttons"
               />
             </div>
-            <MaterialAvailabilityText
-              selectedManifestations={selectedManifestations}
-            />
+            <MaterialAvailabilityText manifestations={selectedManifestations} />
           </>
         )}
       </div>

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { WorkId } from "../../core/utils/types/ids";
-import { AvailabiltityLabels } from "../availability-label/availability-labels";
+import { AvailabilityLabels } from "../availability-label/availability-labels";
 import ButtonFavourite, {
   ButtonFavouriteId
 } from "../button-favourite/button-favourite";
@@ -115,7 +115,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         <ButtonFavourite id={wid} addToListRequest={addToListRequest} />
         <MaterialHeaderText title={String(title)} author={author} />
         <div className="material-header__availability-label">
-          <AvailabiltityLabels
+          <AvailabilityLabels
             cursorPointer
             workId={wid}
             manifestations={manifestations}

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -26,6 +26,8 @@ import { PeriodicalEdition } from "./periodical/helper";
 import { useStatistics } from "../../core/statistics/useStatistics";
 import { statistics } from "../../core/statistics/statistics";
 import { getAllUniqueMaterialTypes } from "../../apps/material/helper";
+import { hasCorrectMaterialType } from "./material-buttons/helper";
+import MaterialType from "../../core/utils/types/material-type";
 
 interface MaterialHeaderProps {
   wid: WorkId;
@@ -64,13 +66,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     flattenCreators(filterCreators(creators, ["Person"])),
     t
   );
-  const isPeriodical = selectedManifestations.some((manifestation) => {
-    return manifestation.materialTypes.some(
-      (materialType: Manifestation["materialTypes"][0]) => {
-        return materialType.specific === "tidsskrift";
-      }
-    );
-  });
+  const isPeriodical = hasCorrectMaterialType(
+    MaterialType.magazine,
+    selectedManifestations
+  );
 
   const containsDanish = mainLanguages.some((language) =>
     language?.isoCode.toLowerCase().includes("dan")

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -138,6 +138,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
                 selectedManifestations={selectedManifestations}
                 workId={wid}
                 dataCy="material-header-buttons"
+                isMain
               />
             </div>
             <MaterialAvailabilityText

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -138,7 +138,6 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
                 selectedManifestations={selectedManifestations}
                 workId={wid}
                 dataCy="material-header-buttons"
-                isMain
               />
             </div>
             <MaterialAvailabilityText

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -8,7 +8,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getAllUniqueMaterialTypes,
+  getMaterialTypes,
   getManifestationPid
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
@@ -83,9 +83,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   const pid = getManifestationPid(manifestations);
   const { track } = useStatistics();
   // This is used to track whether the user is changing between material types or just clicking the same button over
-  const manifestationMaterialTypes = getAllUniqueMaterialTypes(
-    selectedManifestations
-  );
+  const manifestationMaterialTypes = getMaterialTypes(selectedManifestations);
 
   useDeepCompareEffect(() => {
     track("click", {

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -8,6 +8,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
+  getAllUniqueMaterialTypes,
   getManifestationPid
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
@@ -25,7 +26,6 @@ import { Manifestation, Work } from "../../core/utils/types/entities";
 import { PeriodicalEdition } from "./periodical/helper";
 import { useStatistics } from "../../core/statistics/useStatistics";
 import { statistics } from "../../core/statistics/statistics";
-import { getAllUniqueMaterialTypes } from "../../apps/material/helper";
 import { hasCorrectMaterialType } from "./material-buttons/helper";
 import MaterialType from "../../core/utils/types/material-type";
 

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -158,7 +158,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
       </div>
       <div className="material-manifestation-item__buttons">
         <MaterialButtons
-          selectedManifestations={[manifestation]}
+          manifestations={[manifestation]}
           size="small"
           workId={workId}
         />

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -117,7 +117,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           manifestText={materialTypes[0]?.specific}
           url={new URL("/", getCurrentLocation())} // TODO the correct link must be added
           faustIds={[faustId]}
-          isbn={identifiers?.[0]?.value ?? ""}
+          isbns={identifiers.map((identifier) => identifier.value)}
           accessTypes={accessTypesCodes}
         />
       </div>

--- a/src/components/material/digital-modal/DigitalModal.tsx
+++ b/src/components/material/digital-modal/DigitalModal.tsx
@@ -5,23 +5,21 @@ import { statistics } from "../../../core/statistics/statistics";
 import { useStatistics } from "../../../core/statistics/useStatistics";
 import Modal from "../../../core/utils/modal";
 import { useText } from "../../../core/utils/text";
-import { IssnId, Pid, WorkId } from "../../../core/utils/types/ids";
+import { Pid, WorkId } from "../../../core/utils/types/ids";
 import DigitalModalBody from "./DigitalModalBody";
 import DigitalModalFeedback from "./DigitalModalFeedback";
 import { createDigitalModalId } from "./helper";
 
 type DigitalModalProps = {
-  digitalArticleIssnIds: IssnId[];
   pid: Pid;
   workId: WorkId;
 };
 
 const DigitalModal: React.FunctionComponent<DigitalModalProps> = ({
-  digitalArticleIssnIds,
   pid,
   workId
 }) => {
-  const modalId = createDigitalModalId(digitalArticleIssnIds);
+  const modalId = createDigitalModalId(pid);
   const t = useText();
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const { track } = useStatistics();

--- a/src/components/material/digital-modal/helper.ts
+++ b/src/components/material/digital-modal/helper.ts
@@ -1,9 +1,8 @@
 import { DigitalArticleService } from "../../../core/dbc-gateway/generated/graphql";
 import { Manifestation } from "../../../core/utils/types/entities";
-import { IssnId } from "../../../core/utils/types/ids";
+import { IssnId, Pid } from "../../../core/utils/types/ids";
 
-export const createDigitalModalId = (digitalArticleIssnIds: IssnId[]) =>
-  `digital-modal-${digitalArticleIssnIds[0]}`;
+export const createDigitalModalId = (id: Pid) => `digital-modal-${id}`;
 
 export const getDigitalArticleIssnIds = (manifestations: Manifestation[]) => {
   const digitalArticles = manifestations.map(

--- a/src/components/material/infomedia/InfomediaModal.tsx
+++ b/src/components/material/infomedia/InfomediaModal.tsx
@@ -10,17 +10,17 @@ export const infomediaModalId = (pid: Pid) => `infomedia-modal-${pid}`;
 
 interface InfomediaModalProps {
   selectedManifestations: Manifestation[];
-  infoMediaIds: string[];
+  infoMediaId: string;
 }
 
 const InfomediaModal: React.FunctionComponent<InfomediaModalProps> = ({
   selectedManifestations,
-  infoMediaIds
+  infoMediaId
 }) => {
   const t = useText();
 
   const { data, error } = useGetInfomediaQuery({
-    id: infoMediaIds[0]
+    id: infoMediaId
   });
 
   if (!data || error) {

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import { FC } from "react";
 import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
-import {
-  convertPostIdsToFaustIds,
-  getAllPids
-} from "../../../core/utils/helpers/general";
+import { getAllFaustIds } from "../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../core/utils/types/button";
 import { Manifestation } from "../../../core/utils/types/entities";
 import { hasCorrectAccess, hasCorrectAccessType, isArticle } from "./helper";
@@ -26,7 +23,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   workId,
   dataCy = "material-buttons"
 }) => {
-  const faustIds = convertPostIdsToFaustIds(getAllPids(manifestations));
+  const faustIds = getAllFaustIds(manifestations);
   // We don't want to show physical buttons/find on shelf for articles because
   // articles appear as a part of journal/periodical publications and can't be
   // physically loaned for themseleves.

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -9,23 +9,23 @@ import { WorkId } from "../../../core/utils/types/ids";
 import MaterialButtonsOnline from "./online/MaterialButtonsOnline";
 import MaterialButtonsFindOnShelf from "./physical/MaterialButtonsFindOnShelf";
 import MaterialButtonsPhysical from "./physical/MaterialButtonsPhysical";
-import { getAllPids } from "../../../apps/material/helper";
 
 export interface MaterialButtonsProps {
   selectedManifestations: Manifestation[];
   size?: ButtonSize;
   workId: WorkId;
   dataCy?: string;
+  isMain?: boolean;
 }
 
 const MaterialButtons: FC<MaterialButtonsProps> = ({
   selectedManifestations,
   size,
   workId,
-  dataCy = "material-buttons"
+  dataCy = "material-buttons",
+  isMain
 }) => {
-  const pids = getAllPids(selectedManifestations);
-  const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
+  const faustId = convertPostIdToFaustId(selectedManifestations[0].pid);
 
   // We don't want to show physical buttons/find on shelf for articles because
   // articles appear as a part of journal/periodical publications and can't be
@@ -42,8 +42,9 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
             />
             <MaterialButtonsFindOnShelf
               size={size}
-              faustIds={faustIds}
+              faustId={faustId}
               dataCy={`${dataCy}-find-on-shelf`}
+              isMain={isMain}
             />
           </>
         )}

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -14,19 +14,19 @@ import MaterialButtonsFindOnShelf from "./physical/MaterialButtonsFindOnShelf";
 import MaterialButtonsPhysical from "./physical/MaterialButtonsPhysical";
 
 export interface MaterialButtonsProps {
-  selectedManifestations: Manifestation[];
+  manifestations: Manifestation[];
   size?: ButtonSize;
   workId: WorkId;
   dataCy?: string;
 }
 
 const MaterialButtons: FC<MaterialButtonsProps> = ({
-  selectedManifestations,
+  manifestations,
   size,
   workId,
   dataCy = "material-buttons"
 }) => {
-  const faustIds = getAllPids(selectedManifestations).map((pid) =>
+  const faustIds = getAllPids(manifestations).map((pid) =>
     convertPostIdToFaustId(pid)
   );
   // We don't want to show physical buttons/find on shelf for articles because
@@ -34,11 +34,11 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   // physically loaned for themseleves.
   return (
     <>
-      {hasCorrectAccessType(AccessTypeCode.Physical, selectedManifestations) &&
-        !isArticle(selectedManifestations) && (
+      {hasCorrectAccessType(AccessTypeCode.Physical, manifestations) &&
+        !isArticle(manifestations) && (
           <>
             <MaterialButtonsPhysical
-              selectedManifestations={selectedManifestations}
+              manifestations={manifestations}
               size={size}
               dataCy={`${dataCy}-physical`}
             />
@@ -49,10 +49,10 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
             />
           </>
         )}
-      {(hasCorrectAccessType(AccessTypeCode.Online, selectedManifestations) ||
-        hasCorrectAccess("DigitalArticleService", selectedManifestations)) && (
+      {(hasCorrectAccessType(AccessTypeCode.Online, manifestations) ||
+        hasCorrectAccess("DigitalArticleService", manifestations)) && (
         <MaterialButtonsOnline
-          selectedManifestations={selectedManifestations}
+          manifestations={manifestations}
           size={size}
           workId={workId}
           dataCy={`${dataCy}-online`}

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { FC } from "react";
 import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
 import {
-  convertPostIdToFaustId,
+  convertPostIdsToFaustIds,
   getAllPids
 } from "../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../core/utils/types/button";
@@ -26,9 +26,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   workId,
   dataCy = "material-buttons"
 }) => {
-  const faustIds = getAllPids(manifestations).map((pid) =>
-    convertPostIdToFaustId(pid)
-  );
+  const faustIds = convertPostIdsToFaustIds(getAllPids(manifestations));
   // We don't want to show physical buttons/find on shelf for articles because
   // articles appear as a part of journal/periodical publications and can't be
   // physically loaned for themseleves.

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { FC } from "react";
 import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
-import { convertPostIdToFaustId } from "../../../core/utils/helpers/general";
+import {
+  convertPostIdToFaustId,
+  getAllPids
+} from "../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../core/utils/types/button";
 import { Manifestation } from "../../../core/utils/types/entities";
 import { hasCorrectAccess, hasCorrectAccessType, isArticle } from "./helper";
@@ -9,7 +12,6 @@ import { WorkId } from "../../../core/utils/types/ids";
 import MaterialButtonsOnline from "./online/MaterialButtonsOnline";
 import MaterialButtonsFindOnShelf from "./physical/MaterialButtonsFindOnShelf";
 import MaterialButtonsPhysical from "./physical/MaterialButtonsPhysical";
-import { getAllPids } from "../../../apps/material/helper";
 
 export interface MaterialButtonsProps {
   selectedManifestations: Manifestation[];

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -39,6 +39,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
               selectedManifestations={selectedManifestations}
               size={size}
               dataCy={`${dataCy}-physical`}
+              isMain={isMain}
             />
             <MaterialButtonsFindOnShelf
               size={size}

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -9,24 +9,24 @@ import { WorkId } from "../../../core/utils/types/ids";
 import MaterialButtonsOnline from "./online/MaterialButtonsOnline";
 import MaterialButtonsFindOnShelf from "./physical/MaterialButtonsFindOnShelf";
 import MaterialButtonsPhysical from "./physical/MaterialButtonsPhysical";
+import { getAllPids } from "../../../apps/material/helper";
 
 export interface MaterialButtonsProps {
   selectedManifestations: Manifestation[];
   size?: ButtonSize;
   workId: WorkId;
   dataCy?: string;
-  isMain?: boolean;
 }
 
 const MaterialButtons: FC<MaterialButtonsProps> = ({
   selectedManifestations,
   size,
   workId,
-  dataCy = "material-buttons",
-  isMain
+  dataCy = "material-buttons"
 }) => {
-  const faustId = convertPostIdToFaustId(selectedManifestations[0].pid);
-
+  const faustIds = getAllPids(selectedManifestations).map((pid) =>
+    convertPostIdToFaustId(pid)
+  );
   // We don't want to show physical buttons/find on shelf for articles because
   // articles appear as a part of journal/periodical publications and can't be
   // physically loaned for themseleves.
@@ -39,13 +39,11 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
               selectedManifestations={selectedManifestations}
               size={size}
               dataCy={`${dataCy}-physical`}
-              isMain={isMain}
             />
             <MaterialButtonsFindOnShelf
               size={size}
-              faustId={faustId}
+              faustIds={faustIds}
               dataCy={`${dataCy}-find-on-shelf`}
-              isMain={isMain}
             />
           </>
         )}

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -1,3 +1,4 @@
+import { AvailabilityV3 } from "../../../core/fbs/model/availabilityV3";
 import {
   Access,
   AccessTypeCode
@@ -43,6 +44,14 @@ export const isArticle = (manifestations: Manifestation[]) => {
     hasCorrectMaterialType("tidsskriftsartikel", manifestations) ||
     hasCorrectMaterialType("avisartikel", manifestations)
   );
+};
+
+export const areAnyReservable = (availability: AvailabilityV3[]) => {
+  return availability.some((item) => item.reservable);
+};
+
+export const areAnyAvailable = (availability: AvailabilityV3[]) => {
+  return availability.some((item) => item.available);
 };
 
 export default {};

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
@@ -3,24 +3,20 @@ import { FC } from "react";
 import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { IssnId } from "../../../../core/utils/types/ids";
+import { Pid } from "../../../../core/utils/types/ids";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
 import { createDigitalModalId } from "../../digital-modal/helper";
 
 export interface MaterialButtonOnlineDigitalArticleProps {
-  digitalArticleIssnIds: IssnId[];
+  pid: Pid;
   size?: ButtonSize;
   dataCy?: string;
 }
 
 const MaterialButtonOnlineDigitalArticle: FC<
   MaterialButtonOnlineDigitalArticleProps
-> = ({
-  digitalArticleIssnIds,
-  size,
-  dataCy = "material-button-online-digital-article"
-}) => {
+> = ({ pid, size, dataCy = "material-button-online-digital-article" }) => {
   const { openGuarded } = useModalButtonHandler();
   const t = useText();
   const { authUrl } = useUrls();
@@ -28,7 +24,7 @@ const MaterialButtonOnlineDigitalArticle: FC<
   const onClick = () => {
     openGuarded({
       authUrl,
-      modalId: createDigitalModalId(digitalArticleIssnIds)
+      modalId: createDigitalModalId(pid)
     });
   };
 

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -17,7 +17,7 @@ export interface MaterialButtonOnlineExternalProps {
   origin: string;
   size?: ButtonSize;
   trackOnlineView: () => void;
-  selectedManifestations: Manifestation[];
+  manifestations: Manifestation[];
   dataCy?: string;
 }
 
@@ -43,7 +43,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   origin,
   size,
   trackOnlineView,
-  selectedManifestations,
+  manifestations,
   dataCy = "material-button-online-external"
 }) => {
   const [translatedUrl, setTranslatedUrl] = useState<URL>(new URL(externalUrl));
@@ -91,7 +91,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   return (
     <LinkNoStyle url={translatedUrl} dataCy={dataCy}>
       <Button
-        label={label(origin, getAllUniqueMaterialTypes(selectedManifestations))}
+        label={label(origin, getAllUniqueMaterialTypes(manifestations))}
         buttonType="external-link"
         variant="filled"
         disabled={false}

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -1,10 +1,10 @@
 import React, { useState, FC, useEffect } from "react";
-import { getAllUniqueMaterialTypes } from "../../../../apps/material/helper";
 import {
   AccessUrl,
   MaterialType
 } from "../../../../core/dbc-gateway/generated/graphql";
 import { useProxyUrlGET } from "../../../../core/dpl-cms/dpl-cms";
+import { getAllUniqueMaterialTypes } from "../../../../core/utils/helpers/general";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -4,7 +4,7 @@ import {
   MaterialType
 } from "../../../../core/dbc-gateway/generated/graphql";
 import { useProxyUrlGET } from "../../../../core/dpl-cms/dpl-cms";
-import { getAllUniqueMaterialTypes } from "../../../../core/utils/helpers/general";
+import { getMaterialTypes } from "../../../../core/utils/helpers/general";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
@@ -91,7 +91,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   return (
     <LinkNoStyle url={translatedUrl} dataCy={dataCy}>
       <Button
-        label={label(origin, getAllUniqueMaterialTypes(manifestations))}
+        label={label(origin, getMaterialTypes(manifestations))}
         buttonType="external-link"
         variant="filled"
         disabled={false}

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
@@ -10,7 +10,7 @@ import { infomediaModalId } from "../../infomedia/InfomediaModal";
 
 export interface MaterialButtonOnlineInfomediaArticleProps {
   size?: ButtonSize;
-  selectedManifestations: Manifestation[];
+  manifestations: Manifestation[];
   trackOnlineView: () => Promise<unknown>;
   dataCy?: string;
 }
@@ -19,7 +19,7 @@ const MaterialButtonOnlineInfomediaArticle: FC<
   MaterialButtonOnlineInfomediaArticleProps
 > = ({
   size,
-  selectedManifestations,
+  manifestations,
   trackOnlineView,
   dataCy = "material-button-online-infomedia-article"
 }) => {
@@ -30,7 +30,7 @@ const MaterialButtonOnlineInfomediaArticle: FC<
   const onClick = () => {
     openGuarded({
       authUrl,
-      modalId: infomediaModalId(selectedManifestations[0].pid),
+      modalId: infomediaModalId(manifestations[0].pid),
       trackOnlineView
     });
   };

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
@@ -27,6 +27,13 @@ const MaterialButtonOnlineInfomediaArticle: FC<
   const { openGuarded } = useModalButtonHandler();
   const { authUrl } = useUrls();
 
+  if (manifestations.length < 1) {
+    return null;
+  }
+
+  // Although we may be passed multiple manifestations, there is only one button
+  // and one infomedia article modal to open, as we only associate a singular article
+  // with a given work as of now.
   const onClick = () => {
     openGuarded({
       authUrl,

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -6,7 +6,7 @@ import { useStatistics } from "../../../../core/statistics/useStatistics";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import { WorkId } from "../../../../core/utils/types/ids";
-import { hasCorrectMaterialType } from "../helper";
+import { hasCorrectAccess, hasCorrectMaterialType } from "../helper";
 import MaterialButtonOnlineDigitalArticle from "./MaterialButtonOnlineDigitalArticle";
 import MaterialButtonOnlineExternal from "./MaterialButtonOnlineExternal";
 import MaterialButtonOnlineInfomediaArticle from "./MaterialButtonOnlineInfomediaArticle";
@@ -34,10 +34,12 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
   };
 
   const accessElement = manifestations[0].access[0];
-  const access = accessElement?.__typename;
 
   // If the access type is an external type we'll show corresponding button.
-  if (["Ereol", "AccessUrl"].includes(access)) {
+  if (
+    hasCorrectAccess("Ereol", manifestations) ||
+    hasCorrectAccess("AccessUrl", manifestations)
+  ) {
     const {
       origin,
       url: externalUrl,
@@ -59,7 +61,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
   }
 
   if (
-    access === "DigitalArticleService" &&
+    hasCorrectAccess("DigitalArticleService", manifestations) &&
     hasCorrectMaterialType("tidsskriftsartikel", manifestations)
   ) {
     return (
@@ -71,7 +73,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
     );
   }
 
-  if (access === "InfomediaService") {
+  if (hasCorrectAccess("InfomediaService", manifestations)) {
     return (
       <MaterialButtonOnlineInfomediaArticle
         size={size}

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -12,14 +12,14 @@ import MaterialButtonOnlineExternal from "./MaterialButtonOnlineExternal";
 import MaterialButtonOnlineInfomediaArticle from "./MaterialButtonOnlineInfomediaArticle";
 
 export interface MaterialButtonsOnlineProps {
-  selectedManifestations: Manifestation[];
+  manifestations: Manifestation[];
   size?: ButtonSize;
   workId: WorkId;
   dataCy?: string;
 }
 
 const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
-  selectedManifestations,
+  manifestations,
   size,
   workId,
   dataCy = "material-buttons-online"
@@ -33,7 +33,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
     });
   };
 
-  const accessElement = selectedManifestations[0].access[0];
+  const accessElement = manifestations[0].access[0];
   const access = accessElement?.__typename;
 
   // If the access type is an external type we'll show corresponding button.
@@ -52,7 +52,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
         origin={origin}
         size={size}
         trackOnlineView={trackOnlineView}
-        selectedManifestations={selectedManifestations}
+        manifestations={manifestations}
         dataCy={`${dataCy}-external`}
       />
     );
@@ -60,11 +60,11 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
 
   if (
     access === "DigitalArticleService" &&
-    hasCorrectMaterialType("tidsskriftsartikel", selectedManifestations)
+    hasCorrectMaterialType("tidsskriftsartikel", manifestations)
   ) {
     return (
       <MaterialButtonOnlineDigitalArticle
-        pid={selectedManifestations[0].pid}
+        pid={manifestations[0].pid}
         size={size}
         dataCy={`${dataCy}-digital-article`}
       />
@@ -75,7 +75,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
     return (
       <MaterialButtonOnlineInfomediaArticle
         size={size}
-        selectedManifestations={selectedManifestations}
+        manifestations={manifestations}
         trackOnlineView={trackOnlineView}
         dataCy={`${dataCy}-infomedia-article`}
       />

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -6,7 +6,6 @@ import { useStatistics } from "../../../../core/statistics/useStatistics";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import { WorkId } from "../../../../core/utils/types/ids";
-import { getDigitalArticleIssnIds } from "../../digital-modal/helper";
 import { hasCorrectMaterialType } from "../helper";
 import MaterialButtonOnlineDigitalArticle from "./MaterialButtonOnlineDigitalArticle";
 import MaterialButtonOnlineExternal from "./MaterialButtonOnlineExternal";
@@ -65,7 +64,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
   ) {
     return (
       <MaterialButtonOnlineDigitalArticle
-        digitalArticleIssnIds={getDigitalArticleIssnIds(selectedManifestations)}
+        pid={selectedManifestations[0].pid}
         size={size}
         dataCy={`${dataCy}-digital-article`}
       />

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -1,30 +1,28 @@
 import React, { FC } from "react";
 import { useDispatch } from "react-redux";
+import { reservationModalId } from "../../../../apps/material/helper";
 import { openModal } from "../../../../core/modal.slice";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { FaustId } from "../../../../core/utils/types/ids";
 import { Button } from "../../../Buttons/Button";
-import { reservationModalId } from "../../../reservation/ReservationModalBody";
 
 export interface MaterialButtonPhysicalProps {
   manifestationMaterialType: string;
   size?: ButtonSize;
   faustIds: FaustId[];
   dataCy?: string;
-  isMain?: boolean;
 }
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   manifestationMaterialType,
   faustIds,
   size,
-  dataCy = "material-button-physical",
-  isMain
+  dataCy = "material-button-physical"
 }) => {
   const t = useText();
   const dispatch = useDispatch();
-  const modalId = `${reservationModalId(faustIds[0])}${isMain ? "-main" : ""}`;
+  const modalId = reservationModalId(faustIds);
 
   const onClick = () => {
     dispatch(

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -12,21 +12,24 @@ export interface MaterialButtonPhysicalProps {
   size?: ButtonSize;
   faustIds: FaustId[];
   dataCy?: string;
+  isMain?: boolean;
 }
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   manifestationMaterialType,
   faustIds,
   size,
-  dataCy = "material-button-physical"
+  dataCy = "material-button-physical",
+  isMain
 }) => {
   const t = useText();
   const dispatch = useDispatch();
+  const modalId = `${reservationModalId(faustIds[0])}${isMain ? "-main" : ""}`;
 
   const onClick = () => {
     dispatch(
       openModal({
-        modalId: reservationModalId(faustIds[0])
+        modalId
       })
     );
   };

--- a/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { FC } from "react";
-import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
 import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -21,25 +20,15 @@ const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
 }) => {
   const t = useText();
   const { open } = useModalButtonHandler();
-  const { data, isLoading, isError } = useGetAvailabilityV3({
-    recordid: faustIds
-  });
-
   const onClick = () => {
     open(findOnShelfModalId(faustIds[0]));
   };
-
   // If element is currently focused on, we would like to let users open it using enter
   const onKeyUp = (key: string) => {
     if (key === "Enter") {
       onClick();
     }
   };
-
-  if (!data || isError || isLoading) {
-    // TODO: handle error here once we handle errors
-    return null;
-  }
 
   if (size !== "small") {
     return (

--- a/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
@@ -9,19 +9,22 @@ import { findOnShelfModalId } from "../../../find-on-shelf/FindOnShelfModal";
 
 export interface MaterialButtonsFindOnShelfProps {
   size?: ButtonSize;
-  faustIds: FaustId[];
+  faustId: FaustId;
   dataCy?: string;
+  isMain?: boolean;
 }
 
 const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
   size,
-  faustIds,
-  dataCy = "material-buttons-find-on-shelf"
+  faustId,
+  dataCy = "material-buttons-find-on-shelf",
+  isMain
 }) => {
   const t = useText();
   const { open } = useModalButtonHandler();
+  const modalId = `${findOnShelfModalId(faustId)}${isMain ? "-main" : ""}`;
   const onClick = () => {
-    open(findOnShelfModalId(faustIds[0]));
+    open(modalId);
   };
   // If element is currently focused on, we would like to let users open it using enter
   const onKeyUp = (key: string) => {

--- a/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
@@ -42,19 +42,6 @@ const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
   }
 
   if (size !== "small") {
-    if (!data[0].available) {
-      return (
-        <Button
-          label={t("materialIsLoanedOutText")}
-          buttonType="none"
-          variant="outline"
-          disabled
-          collapsible={false}
-          size="large"
-          dataCy={dataCy}
-        />
-      );
-    }
     return (
       <Button
         label={t("findOnBookshelfText")}
@@ -66,14 +53,6 @@ const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
         onClick={onClick}
         dataCy={dataCy}
       />
-    );
-  }
-
-  if (!data[0].available) {
-    return (
-      <span className="text-small-caption material-manifestation-item__find capitalize-all">
-        {t("materialIsLoanedOutText")}
-      </span>
     );
   }
 

--- a/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsFindOnShelf.tsx
@@ -9,20 +9,18 @@ import { findOnShelfModalId } from "../../../find-on-shelf/FindOnShelfModal";
 
 export interface MaterialButtonsFindOnShelfProps {
   size?: ButtonSize;
-  faustId: FaustId;
+  faustIds: FaustId[];
   dataCy?: string;
-  isMain?: boolean;
 }
 
 const MaterialButtonsFindOnShelf: FC<MaterialButtonsFindOnShelfProps> = ({
   size,
-  faustId,
-  dataCy = "material-buttons-find-on-shelf",
-  isMain
+  faustIds,
+  dataCy = "material-buttons-find-on-shelf"
 }) => {
   const t = useText();
   const { open } = useModalButtonHandler();
-  const modalId = `${findOnShelfModalId(faustId)}${isMain ? "-main" : ""}`;
+  const modalId = findOnShelfModalId(faustIds);
   const onClick = () => {
     open(modalId);
   };

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -13,17 +13,17 @@ import { areAnyReservable } from "../helper";
 import MaterialButtonReservePhysical from "./MaterialButtonPhysical";
 
 export interface MaterialButtonsPhysicalProps {
-  selectedManifestations: Manifestation[];
+  manifestations: Manifestation[];
   size?: ButtonSize;
   dataCy?: string;
 }
 
 const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
-  selectedManifestations,
+  manifestations,
   size,
   dataCy = "material-buttons-physical"
 }) => {
-  const pids = getAllPids(selectedManifestations);
+  const pids = getAllPids(manifestations);
   const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
   const { data, isLoading } = useGetAvailabilityV3({
     recordid: faustIds
@@ -50,8 +50,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   if (!isReservable) {
     return <MaterialButtonCantReserve size={size} />;
   }
-  const manifestationMaterialType =
-    selectedManifestations[0].materialTypes[0].specific;
+  const manifestationMaterialType = manifestations[0].materialTypes[0].specific;
 
   return (
     <MaterialButtonReservePhysical

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
 import {
-  convertPostIdToFaustId,
+  convertPostIdsToFaustIds,
   getAllPids
 } from "../../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -24,7 +24,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   dataCy = "material-buttons-physical"
 }) => {
   const pids = getAllPids(manifestations);
-  const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
+  const faustIds = convertPostIdsToFaustIds(pids);
   const { data, isLoading } = useGetAvailabilityV3({
     recordid: faustIds
   });

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -7,6 +7,7 @@ import { Manifestation } from "../../../../core/utils/types/entities";
 import MaterialButtonCantReserve from "../generic/MaterialButtonCantReserve";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonUserBlocked from "../generic/MaterialButtonUserBlocked";
+import { areAnyReservable } from "../helper";
 import MaterialButtonReservePhysical from "./MaterialButtonPhysical";
 
 export interface MaterialButtonsPhysicalProps {
@@ -42,8 +43,9 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonUserBlocked size={size} />;
   }
 
-  const manifestationAvailability = data[0];
-  if (!manifestationAvailability.reservable) {
+  const isReservable = areAnyReservable(data);
+
+  if (!isReservable) {
     return <MaterialButtonCantReserve size={size} />;
   }
   const manifestationMaterialType =

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -14,14 +14,12 @@ export interface MaterialButtonsPhysicalProps {
   selectedManifestations: Manifestation[];
   size?: ButtonSize;
   dataCy?: string;
-  isMain?: boolean;
 }
 
 const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   selectedManifestations,
   size,
-  dataCy = "material-buttons-physical",
-  isMain
+  dataCy = "material-buttons-physical"
 }) => {
   const pids = getAllPids(selectedManifestations);
   const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
@@ -59,7 +57,6 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
       manifestationMaterialType={manifestationMaterialType}
       faustIds={faustIds}
       size={size}
-      isMain={isMain}
     />
   );
 };

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -45,9 +45,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonUserBlocked size={size} />;
   }
 
-  const isReservable = areAnyReservable(data);
-
-  if (!isReservable) {
+  if (!areAnyReservable(data)) {
     return <MaterialButtonCantReserve size={size} />;
   }
   const manifestationMaterialType = manifestations[0].materialTypes[0].specific;

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
-import {
-  convertPostIdsToFaustIds,
-  getAllPids
-} from "../../../../core/utils/helpers/general";
+import { getAllFaustIds } from "../../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import MaterialButtonCantReserve from "../generic/MaterialButtonCantReserve";
@@ -23,8 +20,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   size,
   dataCy = "material-buttons-physical"
 }) => {
-  const pids = getAllPids(manifestations);
-  const faustIds = convertPostIdsToFaustIds(pids);
+  const faustIds = getAllFaustIds(manifestations);
   const { data, isLoading } = useGetAvailabilityV3({
     recordid: faustIds
   });

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { getAllPids } from "../../../../apps/material/helper";
 import { useGetAvailabilityV3 } from "../../../../core/fbs/fbs";
-import { convertPostIdToFaustId } from "../../../../core/utils/helpers/general";
+import {
+  convertPostIdToFaustId,
+  getAllPids
+} from "../../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import MaterialButtonCantReserve from "../generic/MaterialButtonCantReserve";

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -14,12 +14,14 @@ export interface MaterialButtonsPhysicalProps {
   selectedManifestations: Manifestation[];
   size?: ButtonSize;
   dataCy?: string;
+  isMain?: boolean;
 }
 
 const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   selectedManifestations,
   size,
-  dataCy = "material-buttons-physical"
+  dataCy = "material-buttons-physical",
+  isMain
 }) => {
   const pids = getAllPids(selectedManifestations);
   const faustIds = pids.map((pid) => convertPostIdToFaustId(pid));
@@ -57,6 +59,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
       manifestationMaterialType={manifestationMaterialType}
       faustIds={faustIds}
       size={size}
+      isMain={isMain}
     />
   );
 };

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -1,6 +1,9 @@
 import React from "react";
-import { getAllPids, reservationModalId } from "../../apps/material/helper";
-import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import { reservationModalId } from "../../apps/material/helper";
+import {
+  convertPostIdToFaustId,
+  getAllPids
+} from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { reservationModalId } from "../../apps/material/helper";
-import {
-  convertPostIdsToFaustIds,
-  getAllPids
-} from "../../core/utils/helpers/general";
+import { getAllFaustIds } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
@@ -22,8 +19,7 @@ const ReservationModal = ({
   work
 }: ReservationModalProps) => {
   const t = useText();
-  const pids = getAllPids(selectedManifestations);
-  const faustIds = convertPostIdsToFaustIds(pids);
+  const faustIds = getAllFaustIds(selectedManifestations);
 
   // If this modal shows all manifestations per material type, differentiate the ID
   return (

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { reservationModalId } from "../../apps/material/helper";
 import {
-  convertPostIdToFaustId,
+  convertPostIdsToFaustIds,
   getAllPids
 } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
@@ -23,9 +23,7 @@ const ReservationModal = ({
 }: ReservationModalProps) => {
   const t = useText();
   const pids = getAllPids(selectedManifestations);
-  const faustIds = pids.map((manifestationPid) =>
-    convertPostIdToFaustId(manifestationPid)
-  );
+  const faustIds = convertPostIdsToFaustIds(pids);
 
   // If this modal shows all manifestations per material type, differentiate the ID
   return (

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -1,39 +1,36 @@
 import React from "react";
+import { getAllPids, reservationModalId } from "../../apps/material/helper";
 import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { FaustId, WorkId } from "../../core/utils/types/ids";
+import { WorkId } from "../../core/utils/types/ids";
 import { PeriodicalEdition } from "../material/periodical/helper";
-import ReservationModalBody from "./ReservationModalBody";
-
-export const reservationModalId = (faustId: FaustId) =>
-  `reservation-modal-${faustId}`;
+import { ReservationModalBody } from "./ReservationModalBody";
 
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
   selectedPeriodical?: PeriodicalEdition | null;
   workId: WorkId;
   work: Work;
-  isPerMaterialType?: boolean;
 };
 
 const ReservationModal = ({
   selectedManifestations,
   selectedPeriodical = null,
   workId,
-  work,
-  isPerMaterialType
+  work
 }: ReservationModalProps) => {
   const t = useText();
-  const { pid } = selectedManifestations[0];
+  const pids = getAllPids(selectedManifestations);
+  const faustIds = pids.map((manifestationPid) =>
+    convertPostIdToFaustId(manifestationPid)
+  );
 
   // If this modal shows all manifestations per material type, differentiate the ID
   return (
     <Modal
-      modalId={`${reservationModalId(convertPostIdToFaustId(pid))}${
-        isPerMaterialType ? "-main" : ""
-      }`}
+      modalId={reservationModalId(faustIds)}
       screenReaderModalDescriptionText={t(
         "reservationModalScreenReaderModalDescriptionText"
       )}

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -11,34 +11,36 @@ export const reservationModalId = (faustId: FaustId) =>
   `reservation-modal-${faustId}`;
 
 type ReservationModalProps = {
-  mainManifestation: Manifestation;
-  parallelManifestations?: Manifestation[];
+  selectedManifestations: Manifestation[];
   selectedPeriodical?: PeriodicalEdition | null;
   workId: WorkId;
   work: Work;
+  isPerMaterialType?: boolean;
 };
 
 const ReservationModal = ({
-  mainManifestation,
-  mainManifestation: { pid },
-  parallelManifestations,
+  selectedManifestations,
   selectedPeriodical = null,
   workId,
-  work
+  work,
+  isPerMaterialType
 }: ReservationModalProps) => {
   const t = useText();
+  const { pid } = selectedManifestations[0];
 
+  // If this modal shows all manifestations per material type, differentiate the ID
   return (
     <Modal
-      modalId={reservationModalId(convertPostIdToFaustId(pid))}
+      modalId={`${reservationModalId(convertPostIdToFaustId(pid))}${
+        isPerMaterialType ? "-main" : ""
+      }`}
       screenReaderModalDescriptionText={t(
         "reservationModalScreenReaderModalDescriptionText"
       )}
       closeModalAriaLabelText={t("reservationModalCloseModalAriaLabelText")}
     >
       <ReservationModalBody
-        mainManifestation={mainManifestation}
-        parallelManifestations={parallelManifestations}
+        selectedManifestations={selectedManifestations}
         selectedPeriodical={selectedPeriodical}
         workId={workId}
         work={work}

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -4,21 +4,18 @@ import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
 import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { WorkId } from "../../core/utils/types/ids";
 import { PeriodicalEdition } from "../material/periodical/helper";
 import { ReservationModalBody } from "./ReservationModalBody";
 
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
   selectedPeriodical?: PeriodicalEdition | null;
-  workId: WorkId;
   work: Work;
 };
 
 const ReservationModal = ({
   selectedManifestations,
   selectedPeriodical = null,
-  workId,
   work
 }: ReservationModalProps) => {
   const t = useText();
@@ -39,7 +36,6 @@ const ReservationModal = ({
       <ReservationModalBody
         selectedManifestations={selectedManifestations}
         selectedPeriodical={selectedPeriodical}
-        workId={workId}
         work={work}
       />
     </Modal>

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -84,7 +84,7 @@ export const ReservationModalBody = ({
   const { track } = useStatistics();
   const { otherManifestationPreferred } = useAlternativeAvailableManifestation(
     work,
-    selectedManifestations[0].pid
+    allPids
   );
 
   // If we don't have all data for displaying the view render nothing.

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "react-query";
 import {
   convertPostIdsToFaustIds,
   getAllPids,
+  getAllUniqueMaterialTypes,
   getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
@@ -140,19 +141,20 @@ export const ReservationModalBody = ({
   const reservationResult = reservationResponse?.reservationResults[0]?.result;
   const reservationDetails =
     reservationResponse?.reservationResults[0]?.reservationDetails;
+  const manifestation = selectedManifestations[0];
 
   return (
     <>
       {!reservationResult && (
         <section className="reservation-modal">
           <header className="reservation-modal-header">
-            <Cover id={allPids[0]} size="medium" animate />
+            <Cover id={manifestation.pid} size="medium" animate />
             <div className="reservation-modal-description">
               <div className="reservation-modal-tag">
-                {selectedManifestations[0].materialTypes[0].specific}
+                {getAllUniqueMaterialTypes([manifestation])[0]}
               </div>
               <h2 className="text-header-h2 mt-22 mb-8">
-                {selectedManifestations[0].titles.main}
+                {manifestation.titles.main}
                 {selectedPeriodical && ` ${selectedPeriodical.displayText}`}
               </h2>
               {authorLine && (
@@ -185,7 +187,7 @@ export const ReservationModalBody = ({
                 title={t("editionText")}
                 text={
                   selectedPeriodical?.displayText ||
-                  selectedManifestations[0].edition?.summary ||
+                  manifestation.edition?.summary ||
                   ""
                 }
               />
@@ -222,7 +224,7 @@ export const ReservationModalBody = ({
       {reservationSuccess && reservationDetails && (
         <ReservationSucces
           modalId={reservationModalId(faustIds)}
-          title={selectedManifestations[0].titles.main[0]}
+          title={manifestation.titles.main[0]}
           preferredPickupBranch={getPreferredBranch(
             reservationDetails.pickupBranch,
             branches

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Various from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Various.svg";
 import { useQueryClient } from "react-query";
 import {
-  convertPostIdToFaustId,
+  convertPostIdsToFaustIds,
   getAllPids,
   getManifestationType,
   materialIsFiction
@@ -71,7 +71,7 @@ export const ReservationModalBody = ({
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
   const [selectedInterest, setSelectedInterest] = useState<number | null>(null);
   const allPids = getAllPids(selectedManifestations);
-  const faustIds = allPids.map((pid) => convertPostIdToFaustId(pid));
+  const faustIds = convertPostIdsToFaustIds(allPids);
   const { mutate } = useAddReservationsV2();
   const userResponse = useGetPatronInformationByPatronIdV2();
   const holdingsResponse = useGetHoldingsV3({

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -7,7 +7,7 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
-import { FaustId, WorkId } from "../../core/utils/types/ids";
+import { WorkId } from "../../core/utils/types/ids";
 import { Button } from "../Buttons/Button";
 import { Cover } from "../cover/cover";
 import ReservationFormListItem from "./ReservationFormListItem";
@@ -20,7 +20,11 @@ import {
 import UserListItems from "./UserListItems";
 import ReservationSucces from "./ReservationSucces";
 import ReservationError from "./ReservationError";
-import { getAllPids, totalMaterials } from "../../apps/material/helper";
+import {
+  getAllPids,
+  reservationModalId,
+  totalMaterials
+} from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,
@@ -44,9 +48,6 @@ import { statistics } from "../../core/statistics/statistics";
 import useAlternativeAvailableManifestation from "./useAlternativeAvailableManifestation";
 import PromoBar from "../promo-bar/PromoBar";
 
-export const reservationModalId = (faustId: FaustId) =>
-  `reservation-modal-${faustId}`;
-
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
   selectedPeriodical: PeriodicalEdition | null;
@@ -54,7 +55,7 @@ type ReservationModalProps = {
   work: Work;
 };
 
-const ReservationModalBody = ({
+export const ReservationModalBody = ({
   selectedManifestations,
   selectedPeriodical,
   workId,
@@ -221,7 +222,7 @@ const ReservationModalBody = ({
       )}
       {reservationSuccess && reservationDetails && (
         <ReservationSucces
-          modalId={reservationModalId(faustIds[0])}
+          modalId={reservationModalId(faustIds)}
           title={selectedManifestations[0].titles.main[0]}
           preferredPickupBranch={getPreferredBranch(
             reservationDetails.pickupBranch,

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -3,6 +3,7 @@ import Various from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/
 import { useQueryClient } from "react-query";
 import {
   convertPostIdToFaustId,
+  getAllPids,
   getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
@@ -19,11 +20,7 @@ import {
 import UserListItems from "./UserListItems";
 import ReservationSucces from "./ReservationSucces";
 import ReservationError from "./ReservationError";
-import {
-  getAllPids,
-  reservationModalId,
-  totalMaterials
-} from "../../apps/material/helper";
+import { reservationModalId, totalMaterials } from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -6,7 +6,6 @@ import {
   getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
-import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { FaustId, WorkId } from "../../core/utils/types/ids";
 import { Button } from "../Buttons/Button";
@@ -156,13 +155,7 @@ const ReservationModalBody = ({
     reservationResponse?.reservationResults[0]?.reservationDetails;
 
   return (
-    <Modal
-      modalId={reservationModalId(faustId)}
-      screenReaderModalDescriptionText={t(
-        "reservationModalScreenReaderModalDescriptionText"
-      )}
-      closeModalAriaLabelText={t("reservationModalCloseModalAriaLabelText")}
-    >
+    <>
       {!reservationResult && (
         <section className="reservation-modal">
           <header className="reservation-modal-header">
@@ -254,7 +247,7 @@ const ReservationModalBody = ({
           setReservationResponse={setReservationResponse}
         />
       )}
-    </Modal>
+    </>
   );
 };
 

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -64,7 +64,7 @@ export const ReservationModalBody = ({
   const branches = config<AgencyBranch[]>("branchesConfig", {
     transformer: "jsonParse"
   });
-  const mainManifestationType = getManifestationType(selectedManifestations[0]);
+  const mainManifestationType = getManifestationType(selectedManifestations);
   const { reservableManifestations } = UseReservableManifestations({
     manifestations: selectedManifestations,
     type: mainManifestationType

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -20,7 +20,11 @@ import {
 import UserListItems from "./UserListItems";
 import ReservationSucces from "./ReservationSucces";
 import ReservationError from "./ReservationError";
-import { reservationModalId, totalMaterials } from "../../apps/material/helper";
+import {
+  getTotalHoldings,
+  getTotalReservations,
+  reservationModalId
+} from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,
@@ -92,7 +96,8 @@ export const ReservationModalBody = ({
   const { data: holdingsData } = holdingsResponse as {
     data: HoldingsForBibliographicalRecordV3[];
   };
-  const { reservations, holdings } = holdingsData[0];
+  const holdings = getTotalHoldings(holdingsData);
+  const reservations = getTotalReservations(holdingsData);
   const { patron } = userData;
   const authorLine = getAuthorLine(selectedManifestations[0], t);
   const expiryDate = selectedInterest
@@ -159,7 +164,7 @@ export const ReservationModalBody = ({
             <div className="reservation-modal-submit">
               <MaterialAvailabilityTextParagraph>
                 <StockAndReservationInfo
-                  stockCount={totalMaterials(holdings)}
+                  stockCount={holdings}
                   reservationCount={reservations}
                 />
               </MaterialAvailabilityTextParagraph>

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -7,7 +7,6 @@ import {
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
-import { WorkId } from "../../core/utils/types/ids";
 import { Button } from "../Buttons/Button";
 import { Cover } from "../cover/cover";
 import ReservationFormListItem from "./ReservationFormListItem";
@@ -51,14 +50,12 @@ import PromoBar from "../promo-bar/PromoBar";
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
   selectedPeriodical: PeriodicalEdition | null;
-  workId: WorkId;
   work: Work;
 };
 
 export const ReservationModalBody = ({
   selectedManifestations,
   selectedPeriodical,
-  workId,
   work
 }: ReservationModalProps) => {
   const t = useText();
@@ -126,7 +123,7 @@ export const ReservationModalBody = ({
           track("click", {
             id: statistics.reservation.id,
             name: statistics.reservation.name,
-            trackedData: workId
+            trackedData: work.workId
           });
           // This state is used to show the success or error modal.
           setReservationResponse(res);

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "react-query";
 import {
   convertPostIdsToFaustIds,
   getAllPids,
-  getAllUniqueMaterialTypes,
+  getMaterialTypes,
   getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
@@ -151,7 +151,7 @@ export const ReservationModalBody = ({
             <Cover id={manifestation.pid} size="medium" animate />
             <div className="reservation-modal-description">
               <div className="reservation-modal-tag">
-                {getAllUniqueMaterialTypes([manifestation])[0]}
+                {getMaterialTypes([manifestation])[0]}
               </div>
               <h2 className="text-header-h2 mt-22 mb-8">
                 {manifestation.titles.main}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -4,7 +4,6 @@ import { closeModal } from "../../core/modal.slice";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 import StockAndReservationInfo from "../material/StockAndReservationInfo";
-import { HoldingsV3 } from "../../core/fbs/model";
 
 type ReservationSuccesProps = {
   title: string;
@@ -12,7 +11,7 @@ type ReservationSuccesProps = {
   modalId: string;
   numberInQueue?: number;
   reservationCount: number;
-  holdings: HoldingsV3[];
+  holdings: number;
 };
 
 const ReservationSucces: React.FC<ReservationSuccesProps> = ({
@@ -44,7 +43,7 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         className="text-body-medium-regular pb-24"
       >
         <StockAndReservationInfo
-          holdings={holdings}
+          stockCount={holdings}
           reservationCount={reservationCount}
           numberInQueue={numberInQueue}
         />

--- a/src/components/reservation/useAlternativeAvailableManifestation.ts
+++ b/src/components/reservation/useAlternativeAvailableManifestation.ts
@@ -1,9 +1,13 @@
 import { useState, useEffect } from "react";
 import { useGetAvailabilityV3 } from "../../core/fbs/fbs";
 import { AvailabilityV3 } from "../../core/fbs/model";
-import { convertPostIdToFaustId } from "../../core/utils/helpers/general";
+import {
+  convertPostIdsToFaustIds,
+  convertPostIdToFaustId,
+  getAllPids
+} from "../../core/utils/helpers/general";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { FaustId, Pid } from "../../core/utils/types/ids";
+import { Pid } from "../../core/utils/types/ids";
 
 type ManifestationWithAvailability = Manifestation & AvailabilityV3;
 
@@ -16,9 +20,9 @@ const useAlternativeAvailableManifestation = (
   const [otherManifestationPreferred, setOtherManifestationPreferred] =
     useState<ManifestationWithAvailability | null>(null);
 
-  const faustIds = work.manifestations.all.map((manifestation) =>
-    convertPostIdToFaustId(manifestation.pid as Pid)
-  ) as FaustId[];
+  const faustIds = convertPostIdsToFaustIds(
+    getAllPids(work.manifestations.all)
+  );
 
   const { data: availabilityData } = useGetAvailabilityV3({
     recordid: faustIds

--- a/src/components/reservation/useAlternativeAvailableManifestation.ts
+++ b/src/components/reservation/useAlternativeAvailableManifestation.ts
@@ -13,7 +13,7 @@ type ManifestationWithAvailability = Manifestation & AvailabilityV3;
 
 const useAlternativeAvailableManifestation = (
   work: Work,
-  currentManifestationPid: Pid
+  currentManifestationPids: Pid[]
 ) => {
   const [isOtherManifestationPreferred, setIsOtherManifestationPreferred] =
     useState(false);
@@ -55,7 +55,7 @@ const useAlternativeAvailableManifestation = (
         return;
       }
 
-      if (leastReservedManifestation.pid !== currentManifestationPid) {
+      if (!currentManifestationPids.includes(leastReservedManifestation.pid)) {
         setIsOtherManifestationPreferred(true);
         setOtherManifestationPreferred({
           ...leastReservedManifestation,
@@ -63,7 +63,7 @@ const useAlternativeAvailableManifestation = (
         });
       }
     }
-  }, [availabilityData, currentManifestationPid, work]);
+  }, [availabilityData, currentManifestationPids, work]);
 
   return { isOtherManifestationPreferred, otherManifestationPreferred };
 };

--- a/src/components/reservation/useAlternativeAvailableManifestation.ts
+++ b/src/components/reservation/useAlternativeAvailableManifestation.ts
@@ -1,11 +1,10 @@
 import { useState, useEffect } from "react";
+import {
+  getAllFaustIds,
+  convertPostIdToFaustId
+} from "../../core/utils/helpers/general";
 import { useGetAvailabilityV3 } from "../../core/fbs/fbs";
 import { AvailabilityV3 } from "../../core/fbs/model";
-import {
-  convertPostIdsToFaustIds,
-  convertPostIdToFaustId,
-  getAllPids
-} from "../../core/utils/helpers/general";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import { Pid } from "../../core/utils/types/ids";
 
@@ -20,9 +19,7 @@ const useAlternativeAvailableManifestation = (
   const [otherManifestationPreferred, setOtherManifestationPreferred] =
     useState<ManifestationWithAvailability | null>(null);
 
-  const faustIds = convertPostIdsToFaustIds(
-    getAllPids(work.manifestations.all)
-  );
+  const faustIds = getAllFaustIds(work.manifestations.all);
 
   const { data: availabilityData } = useGetAvailabilityV3({
     recordid: faustIds

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 import { useText } from "../../../core/utils/text";
 import { WorkId } from "../../../core/utils/types/ids";
 import Arrow from "../../atoms/icons/arrow/arrow";
-import { AvailabiltityLabels } from "../../availability-label/availability-labels";
+import { AvailabilityLabels } from "../../availability-label/availability-labels";
 import ButtonFavourite, {
   ButtonFavouriteId
 } from "../../button-favourite/button-favourite";
@@ -154,7 +154,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         data-cy="search-result-item-availability"
       >
         {showItem && (
-          <AvailabiltityLabels
+          <AvailabilityLabels
             cursorPointer
             workId={workId}
             manifestations={manifestations}

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -5,6 +5,9 @@ fragment ManifestationsSimple on Manifestations {
   latest {
     ...ManifestationsSimpleFields
   }
+  bestRepresentation {
+    ...ManifestationsSimpleFields
+  }
 }
 
 fragment ManifestationsSimpleFields on Manifestation {

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -723,6 +723,54 @@
             "deprecationReason": null
           },
           {
+            "name": "solrExecutionDurationInMs",
+            "description": "Time for execution on solr",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "solrFilter",
+            "description": "filter applied to the query",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "solrQuery",
+            "description": "the query being executed",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenizerDurationInMs",
+            "description": "Time to tokenize query",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "works",
             "description": "The works matching the given search query. Use offset and limit for pagination.",
             "args": [
@@ -5020,6 +5068,12 @@
             "deprecationReason": null
           },
           {
+            "name": "ERROR_NO_NAME_OR_EMAIL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ERROR_PID_NOT_RESERVABLE",
             "description": null,
             "isDeprecated": false,
@@ -5277,7 +5331,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -8267,6 +8321,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "CORPORATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "FICTIONAL_CHARACTER",
             "description": null,
             "isDeprecated": false,
@@ -8323,6 +8383,12 @@
           {
             "name": "NATIONAL_AGRICULTURAL_LIBRARY",
             "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PERSON",
+            "description": "added for manifestation.parts.creators/person - they get a type from small-rye",
             "isDeprecated": false,
             "deprecationReason": null
           },

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -128,6 +128,14 @@ export type ComplexSearchResponse = {
   errorMessage?: Maybe<Scalars["String"]>;
   /** Total number of works found. May be used for pagination. */
   hitcount: Scalars["Int"];
+  /** Time for execution on solr */
+  solrExecutionDurationInMs?: Maybe<Scalars["Int"]>;
+  /** filter applied to the query */
+  solrFilter?: Maybe<Scalars["String"]>;
+  /** the query being executed */
+  solrQuery?: Maybe<Scalars["String"]>;
+  /** Time to tokenize query */
+  tokenizerDurationInMs?: Maybe<Scalars["Int"]>;
   /** The works matching the given search query. Use offset and limit for pagination. */
   works: Array<Work>;
 };
@@ -743,6 +751,7 @@ export type PeriodicaArticleOrderResponse = {
 export enum PeriodicaArticleOrderStatus {
   ErrorAgencyNotSubscribed = "ERROR_AGENCY_NOT_SUBSCRIBED",
   ErrorInvalidPickupBranch = "ERROR_INVALID_PICKUP_BRANCH",
+  ErrorNoNameOrEmail = "ERROR_NO_NAME_OR_EMAIL",
   ErrorPidNotReservable = "ERROR_PID_NOT_RESERVABLE",
   ErrorUnauthorizedUser = "ERROR_UNAUTHORIZED_USER",
   Ok = "OK"
@@ -783,7 +792,7 @@ export type PhysicalDescription = {
   /** Number of pages of the manifestation as number */
   numberOfPages?: Maybe<Scalars["Int"]>;
   /** Number of units, like 3 cassettes, or 1 score etc. */
-  numberOfUnits?: Maybe<Scalars["Int"]>;
+  numberOfUnits?: Maybe<Scalars["String"]>;
   /** The playing time of the manifestation (e.g 2 hours 5 minutes) */
   playingTime?: Maybe<Scalars["String"]>;
   /** The necessary equipment to use the material */
@@ -1156,6 +1165,7 @@ export type SubjectText = Subject & {
 };
 
 export enum SubjectType {
+  Corporation = "CORPORATION",
   FictionalCharacter = "FICTIONAL_CHARACTER",
   FilmNationality = "FILM_NATIONALITY",
   Laesekompasset = "LAESEKOMPASSET",
@@ -1166,6 +1176,8 @@ export enum SubjectType {
   MusicCountryOfOrigin = "MUSIC_COUNTRY_OF_ORIGIN",
   MusicTimePeriod = "MUSIC_TIME_PERIOD",
   NationalAgriculturalLibrary = "NATIONAL_AGRICULTURAL_LIBRARY",
+  /** added for manifestation.parts.creators/person - they get a type from small-rye */
+  Person = "PERSON",
   TimePeriod = "TIME_PERIOD",
   Title = "TITLE",
   Topic = "TOPIC"
@@ -1589,6 +1601,85 @@ export type GetMaterialQuery = {
           shelfmark: string;
         } | null;
       };
+      bestRepresentation: {
+        __typename?: "Manifestation";
+        pid: string;
+        genreAndForm: Array<string>;
+        source: Array<string>;
+        titles: {
+          __typename?: "ManifestationTitles";
+          main: Array<string>;
+          original?: Array<string> | null;
+        };
+        fictionNonfiction?: {
+          __typename?: "FictionNonfiction";
+          display: string;
+          code: FictionNonfictionCode;
+        } | null;
+        materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+        creators: Array<
+          | { __typename: "Corporation"; display: string }
+          | { __typename: "Person"; display: string }
+        >;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          title: string;
+          creator?: string | null;
+          publisher?: string | null;
+          year?: {
+            __typename?: "PublicationYear";
+            year?: number | null;
+          } | null;
+        } | null;
+        languages?: {
+          __typename?: "Languages";
+          main?: Array<{ __typename?: "Language"; display: string }> | null;
+        } | null;
+        identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+        contributors: Array<
+          | { __typename?: "Corporation"; display: string }
+          | { __typename?: "Person"; display: string }
+        >;
+        edition?: {
+          __typename?: "Edition";
+          summary: string;
+          publicationYear?: {
+            __typename?: "PublicationYear";
+            display: string;
+          } | null;
+        } | null;
+        audience?: {
+          __typename?: "Audience";
+          generalAudience: Array<string>;
+        } | null;
+        physicalDescriptions: Array<{
+          __typename?: "PhysicalDescription";
+          numberOfPages?: number | null;
+        }>;
+        accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
+        access: Array<
+          | {
+              __typename: "AccessUrl";
+              origin: string;
+              url: string;
+              loginRequired: boolean;
+            }
+          | { __typename: "DigitalArticleService"; issn: string }
+          | {
+              __typename: "Ereol";
+              origin: string;
+              url: string;
+              canAlwaysBeLoaned: boolean;
+            }
+          | { __typename: "InfomediaService"; id: string }
+          | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+        >;
+        shelfmark?: {
+          __typename?: "Shelfmark";
+          postfix?: string | null;
+          shelfmark: string;
+        } | null;
+      };
     };
   } | null;
 };
@@ -1834,6 +1925,91 @@ export type SearchWithPaginationQuery = {
             shelfmark: string;
           } | null;
         };
+        bestRepresentation: {
+          __typename?: "Manifestation";
+          pid: string;
+          genreAndForm: Array<string>;
+          source: Array<string>;
+          titles: {
+            __typename?: "ManifestationTitles";
+            main: Array<string>;
+            original?: Array<string> | null;
+          };
+          fictionNonfiction?: {
+            __typename?: "FictionNonfiction";
+            display: string;
+            code: FictionNonfictionCode;
+          } | null;
+          materialTypes: Array<{
+            __typename?: "MaterialType";
+            specific: string;
+          }>;
+          creators: Array<
+            | { __typename: "Corporation"; display: string }
+            | { __typename: "Person"; display: string }
+          >;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            title: string;
+            creator?: string | null;
+            publisher?: string | null;
+            year?: {
+              __typename?: "PublicationYear";
+              year?: number | null;
+            } | null;
+          } | null;
+          languages?: {
+            __typename?: "Languages";
+            main?: Array<{ __typename?: "Language"; display: string }> | null;
+          } | null;
+          identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+          contributors: Array<
+            | { __typename?: "Corporation"; display: string }
+            | { __typename?: "Person"; display: string }
+          >;
+          edition?: {
+            __typename?: "Edition";
+            summary: string;
+            publicationYear?: {
+              __typename?: "PublicationYear";
+              display: string;
+            } | null;
+          } | null;
+          audience?: {
+            __typename?: "Audience";
+            generalAudience: Array<string>;
+          } | null;
+          physicalDescriptions: Array<{
+            __typename?: "PhysicalDescription";
+            numberOfPages?: number | null;
+          }>;
+          accessTypes: Array<{
+            __typename?: "AccessType";
+            code: AccessTypeCode;
+          }>;
+          access: Array<
+            | {
+                __typename: "AccessUrl";
+                origin: string;
+                url: string;
+                loginRequired: boolean;
+              }
+            | { __typename: "DigitalArticleService"; issn: string }
+            | {
+                __typename: "Ereol";
+                origin: string;
+                url: string;
+                canAlwaysBeLoaned: boolean;
+              }
+            | { __typename: "InfomediaService"; id: string }
+            | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+          >;
+          shelfmark?: {
+            __typename?: "Shelfmark";
+            postfix?: string | null;
+            shelfmark: string;
+          } | null;
+        };
       };
     }>;
   };
@@ -1995,6 +2171,82 @@ export type ManifestationsSimpleFragment = {
     } | null;
   }>;
   latest: {
+    __typename?: "Manifestation";
+    pid: string;
+    genreAndForm: Array<string>;
+    source: Array<string>;
+    titles: {
+      __typename?: "ManifestationTitles";
+      main: Array<string>;
+      original?: Array<string> | null;
+    };
+    fictionNonfiction?: {
+      __typename?: "FictionNonfiction";
+      display: string;
+      code: FictionNonfictionCode;
+    } | null;
+    materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+    creators: Array<
+      | { __typename: "Corporation"; display: string }
+      | { __typename: "Person"; display: string }
+    >;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      title: string;
+      creator?: string | null;
+      publisher?: string | null;
+      year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    } | null;
+    languages?: {
+      __typename?: "Languages";
+      main?: Array<{ __typename?: "Language"; display: string }> | null;
+    } | null;
+    identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+    contributors: Array<
+      | { __typename?: "Corporation"; display: string }
+      | { __typename?: "Person"; display: string }
+    >;
+    edition?: {
+      __typename?: "Edition";
+      summary: string;
+      publicationYear?: {
+        __typename?: "PublicationYear";
+        display: string;
+      } | null;
+    } | null;
+    audience?: {
+      __typename?: "Audience";
+      generalAudience: Array<string>;
+    } | null;
+    physicalDescriptions: Array<{
+      __typename?: "PhysicalDescription";
+      numberOfPages?: number | null;
+    }>;
+    accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
+    access: Array<
+      | {
+          __typename: "AccessUrl";
+          origin: string;
+          url: string;
+          loginRequired: boolean;
+        }
+      | { __typename: "DigitalArticleService"; issn: string }
+      | {
+          __typename: "Ereol";
+          origin: string;
+          url: string;
+          canAlwaysBeLoaned: boolean;
+        }
+      | { __typename: "InfomediaService"; id: string }
+      | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+    >;
+    shelfmark?: {
+      __typename?: "Shelfmark";
+      postfix?: string | null;
+      shelfmark: string;
+    } | null;
+  };
+  bestRepresentation: {
     __typename?: "Manifestation";
     pid: string;
     genreAndForm: Array<string>;
@@ -2350,6 +2602,82 @@ export type WorkSmallFragment = {
         shelfmark: string;
       } | null;
     };
+    bestRepresentation: {
+      __typename?: "Manifestation";
+      pid: string;
+      genreAndForm: Array<string>;
+      source: Array<string>;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      fictionNonfiction?: {
+        __typename?: "FictionNonfiction";
+        display: string;
+        code: FictionNonfictionCode;
+      } | null;
+      materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string }
+        | { __typename: "Person"; display: string }
+      >;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        title: string;
+        creator?: string | null;
+        publisher?: string | null;
+        year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{ __typename?: "Language"; display: string }> | null;
+      } | null;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | { __typename?: "Corporation"; display: string }
+        | { __typename?: "Person"; display: string }
+      >;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+      } | null;
+      physicalDescriptions: Array<{
+        __typename?: "PhysicalDescription";
+        numberOfPages?: number | null;
+      }>;
+      accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
+      access: Array<
+        | {
+            __typename: "AccessUrl";
+            origin: string;
+            url: string;
+            loginRequired: boolean;
+          }
+        | { __typename: "DigitalArticleService"; issn: string }
+        | {
+            __typename: "Ereol";
+            origin: string;
+            url: string;
+            canAlwaysBeLoaned: boolean;
+          }
+        | { __typename: "InfomediaService"; id: string }
+        | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+      >;
+      shelfmark?: {
+        __typename?: "Shelfmark";
+        postfix?: string | null;
+        shelfmark: string;
+      } | null;
+    };
   };
 };
 
@@ -2593,6 +2921,82 @@ export type WorkMediumFragment = {
         shelfmark: string;
       } | null;
     };
+    bestRepresentation: {
+      __typename?: "Manifestation";
+      pid: string;
+      genreAndForm: Array<string>;
+      source: Array<string>;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      fictionNonfiction?: {
+        __typename?: "FictionNonfiction";
+        display: string;
+        code: FictionNonfictionCode;
+      } | null;
+      materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string }
+        | { __typename: "Person"; display: string }
+      >;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        title: string;
+        creator?: string | null;
+        publisher?: string | null;
+        year?: { __typename?: "PublicationYear"; year?: number | null } | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{ __typename?: "Language"; display: string }> | null;
+      } | null;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | { __typename?: "Corporation"; display: string }
+        | { __typename?: "Person"; display: string }
+      >;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+      } | null;
+      physicalDescriptions: Array<{
+        __typename?: "PhysicalDescription";
+        numberOfPages?: number | null;
+      }>;
+      accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
+      access: Array<
+        | {
+            __typename: "AccessUrl";
+            origin: string;
+            url: string;
+            loginRequired: boolean;
+          }
+        | { __typename: "DigitalArticleService"; issn: string }
+        | {
+            __typename: "Ereol";
+            origin: string;
+            url: string;
+            canAlwaysBeLoaned: boolean;
+          }
+        | { __typename: "InfomediaService"; id: string }
+        | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+      >;
+      shelfmark?: {
+        __typename?: "Shelfmark";
+        postfix?: string | null;
+        shelfmark: string;
+      } | null;
+    };
   };
 };
 
@@ -2699,6 +3103,9 @@ export const ManifestationsSimpleFragmentDoc = `
     ...ManifestationsSimpleFields
   }
   latest {
+    ...ManifestationsSimpleFields
+  }
+  bestRepresentation {
     ...ManifestationsSimpleFields
   }
 }

--- a/src/core/publizon/mutator/fetcher.ts
+++ b/src/core/publizon/mutator/fetcher.ts
@@ -76,17 +76,8 @@ export const fetcher = async <ResponseType>({
     }
   );
 
-  // This code is handling if there is an error.
-  // If the code property is not present, it uses the statusText property as the error message.
-  // It then throws an error with the HTTP status code and error message, and sets the cause property of the error object to the value of the code property.
   if (!response.ok) {
-    const errorData = await response.json();
-    const errorMessage = errorData.code
-      ? errorData.message
-      : response.statusText;
-    throw new Error(`${response.status}: ${errorMessage}`, {
-      cause: errorData.code
-    });
+    throw new Error(`${response.status}: ${response.statusText}`);
   }
 
   try {

--- a/src/core/utils/UseReservableManifestations.tsx
+++ b/src/core/utils/UseReservableManifestations.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useState } from "react";
 import { filterManifestationsByType } from "../../apps/material/helper";
 import { getAvailabilityV3 } from "../fbs/fbs";
-import {
-  convertPostIdsToFaustIds,
-  convertPostIdToFaustId,
-  getAllPids
-} from "./helpers/general";
+import { convertPostIdToFaustId, getAllFaustIds } from "./helpers/general";
 import { Manifestation } from "./types/entities";
 
 const UseReservableManifestations = ({
@@ -15,7 +11,7 @@ const UseReservableManifestations = ({
   manifestations: Manifestation[];
   type?: string;
 }) => {
-  const faustIds = convertPostIdsToFaustIds(getAllPids(manifestations));
+  const faustIds = getAllFaustIds(manifestations);
 
   const [reservableManifestations, setReservableManifestations] = useState<
     Manifestation[] | null

--- a/src/core/utils/UseReservableManifestations.tsx
+++ b/src/core/utils/UseReservableManifestations.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import { filterManifestationsByType } from "../../apps/material/helper";
 import { getAvailabilityV3 } from "../fbs/fbs";
-import { convertPostIdToFaustId } from "./helpers/general";
+import {
+  convertPostIdsToFaustIds,
+  convertPostIdToFaustId,
+  getAllPids
+} from "./helpers/general";
 import { Manifestation } from "./types/entities";
 
 const UseReservableManifestations = ({
@@ -11,7 +15,7 @@ const UseReservableManifestations = ({
   manifestations: Manifestation[];
   type?: string;
 }) => {
-  const faustIds = manifestations.map(({ pid }) => convertPostIdToFaustId(pid));
+  const faustIds = convertPostIdsToFaustIds(getAllPids(manifestations));
 
   const [reservableManifestations, setReservableManifestations] = useState<
     Manifestation[] | null

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -339,4 +339,7 @@ export const getAllPids = (manifestations: Manifestation[]) => {
 
 export const dataIsNotEmpty = (data: unknown[]) => Boolean(data.length);
 
+export const constructModalId = (prefix: string, fragments: string[]) =>
+  `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
+
 export default {};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -321,7 +321,7 @@ export const filterLoansSoonOverdue = (loans: LoanType[]) => {
   });
 };
 
-export const getAllUniqueMaterialTypes = (manifestations: Manifestation[]) => {
+export const getMaterialTypes = (manifestations: Manifestation[]) => {
   const allMaterialTypes = manifestations
     .map((manifest) => manifest.materialTypes.map((type) => type.specific))
     .flat();
@@ -329,7 +329,7 @@ export const getAllUniqueMaterialTypes = (manifestations: Manifestation[]) => {
 };
 
 export const getManifestationType = (manifestations: Manifestation[]) => {
-  const uniqueTypes = getAllUniqueMaterialTypes(manifestations);
+  const uniqueTypes = getMaterialTypes(manifestations);
   return uniqueTypes[0];
 };
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -319,4 +319,8 @@ export const filterLoansSoonOverdue = (loans: LoanType[]) => {
 export const getManifestationType = (manifestation: Manifestation) =>
   manifestation.materialTypes[0].specific;
 
+export const getAllPids = (manifestations: Manifestation[]) => {
+  return manifestations.map((manifestation) => manifestation.pid);
+};
+
 export default {};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import dayjs from "dayjs";
+import { uniq } from "lodash";
 import { CoverProps } from "../../../components/cover/cover";
 import { UseTextFunction } from "../text";
 import configuration, {
@@ -320,8 +321,17 @@ export const filterLoansSoonOverdue = (loans: LoanType[]) => {
   });
 };
 
-export const getManifestationType = (manifestation: Manifestation) =>
-  manifestation.materialTypes[0].specific;
+export const getAllUniqueMaterialTypes = (manifestations: Manifestation[]) => {
+  const allMaterialTypes = manifestations
+    .map((manifest) => manifest.materialTypes.map((type) => type.specific))
+    .flat();
+  return uniq(allMaterialTypes);
+};
+
+export const getManifestationType = (manifestations: Manifestation[]) => {
+  const uniqueTypes = getAllUniqueMaterialTypes(manifestations);
+  return uniqueTypes[0];
+};
 
 export const getAllPids = (manifestations: Manifestation[]) => {
   return manifestations.map((manifestation) => manifestation.pid);

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -337,6 +337,10 @@ export const getAllPids = (manifestations: Manifestation[]) => {
   return manifestations.map((manifestation) => manifestation.pid);
 };
 
+export const getAllFaustIds = (manifestations: Manifestation[]) => {
+  return convertPostIdsToFaustIds(getAllPids(manifestations));
+};
+
 export const dataIsNotEmpty = (data: unknown[]) => Boolean(data.length);
 
 export const constructModalId = (prefix: string, fragments: string[]) =>

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -39,7 +39,6 @@ export const filterCreators = (
   filterBy: ["Person" | "Corporation"]
 ) =>
   creators.filter((creator: Work["creators"][0]) => {
-    // eslint-disable-next-line no-underscore-dangle
     return creator.__typename && filterBy.includes(creator.__typename);
   });
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -157,6 +157,10 @@ export const convertPostIdToFaustId = (postId: Pid) => {
   throw new Error(`Unable to extract faust id from post id "${postId}"`);
 };
 
+export const convertPostIdsToFaustIds = (postIds: Pid[]) => {
+  return postIds.map((pid) => convertPostIdToFaustId(pid));
+};
+
 // Get params if they are defined as props use those
 // otherwise try to fetch them from the url.
 export const getParams = <T, K extends keyof T>(props: T) => {

--- a/src/core/utils/types/entities.ts
+++ b/src/core/utils/types/entities.ts
@@ -13,5 +13,6 @@ export type Work = Omit<WorkMediumFragment, "workId" | "manifestations"> & {
     all: Manifestation[];
     first: Manifestation;
     latest: Manifestation;
+    bestRepresentation: Manifestation;
   };
 };

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -9,7 +9,8 @@ const enum MaterialType {
   newspaperArticle = "tidsskriftsartikel",
   earticle = "artikel",
   boardGame = "spil",
-  cdRom = "cd"
+  cdRom = "cd",
+  magazine = "tidsskrift"
 }
 
 export default MaterialType;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-10

#### Description
This PR makes it possible to only render one availability label per manifestation on the search result page and the material page, instead of rendering one per every work manifestation. The PR is quite extensive as it changes core logic - the currently selected manifestation can now be more manifestations at once. 


#### Screenshot of the result
before: 
![image](https://user-images.githubusercontent.com/28546954/211304520-892e7d91-499e-44d5-90fa-eb0d8b779de7.png)

after:
![image](https://user-images.githubusercontent.com/28546954/210064379-61b7a213-418e-43d7-9938-864f38ce9143.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
I would suggest the reviewers look through files changed instead of per commit review.