### PR TITLE
Introduce lazy loading of search results

### DIFF
--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -28,6 +28,7 @@ import { guardedRequest } from "../../../core/guardedRequests.slice";
 import { Work } from "../../../core/utils/types/entities";
 import { useStatistics } from "../../../core/statistics/useStatistics";
 import { statistics } from "../../../core/statistics/statistics";
+import { useItemHasBeenVisible } from "../../../core/utils/helpers/lazy-load";
 
 export interface SearchResultListItemProps {
   item: Work;
@@ -59,6 +60,9 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   const { title: seriesTitle, numberInSeries } = firstInSeries || {};
   const materialFullUrl = constructMaterialUrl(materialUrl, workId as WorkId);
   const { track } = useStatistics();
+  // We use hasBeenVisible to determine if the search result
+  // is, or has been, visible in the viewport.
+  const { itemRef, hasBeenVisible: showItem } = useItemHasBeenVisible();
 
   const handleClick = useCallback(() => {
     track("click", {
@@ -83,32 +87,38 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   };
 
   return (
-    // We know that is not following a11y recommendations to have an onclick handler
-    // on a noninteractive element.
+    // We know that is not following a11y recommendations to have an onclick
+    // handler on a non-interactive element.
+    //
     // The reason why this is implemented:
-    // We have interactive elements within each search result: the favourite button,
-    // which must react to clicks
-    // while we also want the entire search result to be clickable.
-    // You cannot have nested links so onClick handlers
-    // and stopping event propagation is necessary.
+    // We have interactive elements within each search result
+    // namely the the favorite button, which must react to clicks while we also want the
+    // entire search result to be clickable.
+    // You cannot have nested links so onClick handlers and stopping event propagation
+    // is necessary.
     //
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <article
+      ref={itemRef}
       className="search-result-item arrow arrow__hover--right-small"
       onClick={handleClick}
       onKeyUp={(e) => e.key === "Enter" && handleClick}
     >
       <div className="search-result-item__cover">
-        <SearchResultListItemCover
-          id={manifestationPid}
-          description={String(fullTitle)}
-          url={materialFullUrl}
-          tint={coverTint}
-        />
+        {showItem && (
+          <SearchResultListItemCover
+            id={manifestationPid}
+            description={String(fullTitle)}
+            url={materialFullUrl}
+            tint={coverTint}
+          />
+        )}
       </div>
       <div className="search-result-item__text">
         <div className="search-result-item__meta">
-          <ButtonFavourite id={workId} addToListRequest={addToListRequest} />
+          {showItem && (
+            <ButtonFavourite id={workId} addToListRequest={addToListRequest} />
+          )}
           {numberInSeries && seriesTitle && (
             <HorizontalTermLine
               title={`${t("numberDescriptionText")} ${
@@ -143,11 +153,13 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         className="search-result-item__availability"
         data-cy="search-result-item-availability"
       >
-        <AvailabiltityLabels
-          cursorPointer
-          workId={workId}
-          manifestations={manifestations}
-        />
+        {showItem && (
+          <AvailabiltityLabels
+            cursorPointer
+            workId={workId}
+            manifestations={manifestations}
+          />
+        )}
       </div>
       <Arrow />
     </article>

--- a/src/core/utils/helpers/lazy-load.ts
+++ b/src/core/utils/helpers/lazy-load.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react";
+import { useIntersection } from "react-use";
+
+export const useItemHasBeenVisible = () => {
+  const itemRef = useRef(null);
+  const intersection = useIntersection(itemRef, {
+    root: null,
+    rootMargin: "0%",
+    threshold: 0
+  });
+  const isInViewPort = Boolean(intersection?.isIntersecting);
+  const [hasBeenVisible, setHasBeenVisible] = useState<boolean>(false);
+
+  // We need to track if the item has been visible already
+  // in order to prevent rerunning setHasBeenVisible again.
+  useEffect(() => {
+    if (hasBeenVisible) {
+      return;
+    }
+
+    if (isInViewPort) {
+      setHasBeenVisible(true);
+    }
+  }, [hasBeenVisible, isInViewPort]);
+
+  return { itemRef, hasBeenVisible: isInViewPort || hasBeenVisible };
+};
+
+export default {};


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-356

#### Description

By using the Intersection Observer API
we can distinguish between search result items that the intersecting with the viewport
and thereby change the behaviour depending on the visibility.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
