### PR TITLE
5555: add color-secondary-gray to elements

### DIFF
--- a/src/apps/loan-list/materials/stackable-material/material-info.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-info.tsx
@@ -37,7 +37,7 @@ const MaterialInfo: FC<MaterialInfoProps> = ({
           </div>
         </div>
         <div className="list-reservation__about">
-          <h3 className="text-header-h4">{title}</h3>
+          <h3 className="text-header-h4 color-secondary-gray">{title}</h3>
           <p className="text-small-caption color-secondary-gray">
             {/* todo consolidate author/year in a component 
              other files: reservartion/helper.ts, search-result-list-item.tsx */}

--- a/src/apps/loan-list/materials/stackable-material/material-status.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-status.tsx
@@ -28,7 +28,7 @@ const MaterialStatus: FC<MaterialStatusProps> = ({ loan, children }) => {
             dangerText={t("loanListStatusBadgeDangerText")}
             warningText={t("loanListStatusBadgeWarningText")}
           />
-          <p className="text-small-caption" id="due-date">
+          <p className="text-small-caption color-secondary-gray" id="due-date">
             {isDigital(loan)
               ? t("loanListToBeDeliveredDigitalMaterialText", {
                   placeholders: { "@date": formatDate(dueDate) }

--- a/src/apps/loan-list/materials/utils/status-circle.tsx
+++ b/src/apps/loan-list/materials/utils/status-circle.tsx
@@ -30,14 +30,14 @@ const StatusCircle: FC<StatusCircleProps> = ({ loanDate, dueDate }) => {
 
   return (
     <StatusCircleIcon percent={percent} color={color as string}>
-      <span className="counter__value">
+      <span className="counter__value color-secondary-gray">
         {/* I am not using string interpolation here because of styling */}
         {/* if somehow it is possible to break text in one div into two lines */}
         {/* where the first line has another font size AND is only the first "word" */}
         {/* then this should be changed to do that */}
         {daysBetweenTodayAndDue > 0 ? daysBetweenTodayAndDue : 0}{" "}
       </span>
-      <span className="counter__label">
+      <span className="counter__label color-secondary-gray">
         {daysBetweenTodayAndDue === 1
           ? t("loanListMaterialDayText")
           : t("loanListMaterialDaysText")}

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -60,9 +60,9 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
         infoLabel={readyForPickupLabel}
         label={[pickupLibrary, pickupNumber || ""]}
       >
-        <div className="counter__value" aria-hidden="true">
+        <div className="counter__value color-secondary-gray">
           <img src={check} alt="" />
-          <span className="counter__label">
+          <span className="counter__label color-secondary-gray">
             {t("reservationListReadyText")}
           </span>
         </div>
@@ -89,10 +89,10 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
         {/* if somehow it is possible to break text in one div into two lines */}
         {/* where the first line has another font size AND is only the first "word" */}
         {/* then this should be changed to do that */}
-        <span className="counter__value" aria-hidden="true">
+        <span className="counter__value color-secondary-gray">
           {numberInQueue}
         </span>
-        <span className="counter__label" aria-hidden="true">
+        <span className="counter__label color-secondary-gray">
           {t("reservationListInQueueText")}
         </span>
       </ReservationStatus>
@@ -108,7 +108,7 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
           placeholders: { "@count": daysBetweenTodayAndDate(pickupDeadline) }
         })}
       >
-        <span className="counter__value" aria-hidden="true">
+        <span className="counter__value color-secondary-gray">
           {/* I am not using string interpolation here because of styling */}
           {/* if somehow it is possible to break text in one div into two lines */}
           {/* where the first line has another font size AND is only the first "word" */}
@@ -117,7 +117,7 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
             ? daysBetweenTodayAndPickup
             : 0}{" "}
         </span>
-        <span className="counter__label" aria-hidden="true">
+        <span className="counter__label color-secondary-gray">
           {daysBetweenTodayAndPickup === 1
             ? t("reservationListDayText")
             : t("reservationListDaysText")}

--- a/src/apps/reservation-list/reservation-material/reservation-status.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-status.tsx
@@ -18,7 +18,7 @@ const ReservationStatus: FC<ReservationStatusProps> = ({
 }) => {
   return (
     <div className="list-reservation__status">
-      <div className="list-reservation__counter">
+      <div className="list-reservation__counter color-secondary-gray">
         <StatusCircleIcon color={color} percent={percent}>
           {children}
         </StatusCircleIcon>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5555

#### Description

Set color explicitly, due to ios default colors
Removed some aria hiddens that are not supposed to be there 

#### Screenshot of the result

Before: 

<img width="1448" alt="image" src="https://user-images.githubusercontent.com/15377965/210361915-dea7da44-36c4-4bda-b654-431f2bbe709c.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
