### PR TITLE
Settimeout on app mount

### DIFF
--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -46,7 +46,7 @@ function mount(context) {
     }
   }
 
-  appContainers.forEach(mountApp);
+  appContainers.forEach((app) => setTimeout(() => mountApp(app), 0));
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-356

#### Description

We noticed in the Chrome performance tab that the mounting of the different apps are being run in the same task which exceeds the 50ms limit. This breaks up the app mounts in chunks.


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

