### PR TITLE
Update FBI API with latest schema changes for JED 0.8

### DIFF
--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -3,8 +3,12 @@
     "work": {
       "workId": "work-of:870970-basis:52557240",
       "titles": {
-        "full": ["De syv søstre : Maias historie"],
-        "original": []
+        "full": [
+          "De syv søstre : Maias historie"
+        ],
+        "original": [
+          "The seven sisters"
+        ]
       },
       "abstract": [
         "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav"
@@ -17,19 +21,21 @@
       ],
       "series": [
         {
-          "title": "De syv søstre-serien",
+          "title": "Cicero favorit",
           "isPopular": null,
-          "numberInSeries": {
-            "display": "1",
-            "number": [1]
-          },
+          "numberInSeries": null,
           "readThisFirst": null,
           "readThisWhenever": null
         },
         {
-          "title": "Cicero favorit",
+          "title": "De syv søstre-serien",
           "isPopular": null,
-          "numberInSeries": null,
+          "numberInSeries": {
+            "display": "1",
+            "number": [
+              1
+            ]
+          },
           "readThisFirst": null,
           "readThisWhenever": null
         }
@@ -38,76 +44,132 @@
         {
           "workId": "work-of:870970-basis:52557240",
           "titles": {
-            "main": ["De syv søstre"],
-            "full": ["De syv søstre : Maias historie"],
-            "original": []
+            "main": [
+              "De syv søstre"
+            ],
+            "full": [
+              "De syv søstre : Maias historie"
+            ],
+            "original": [
+              "The seven sisters"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:52970628",
           "titles": {
-            "main": ["Stormsøsteren"],
-            "full": ["Stormsøsteren : Allys historie"],
-            "original": []
+            "main": [
+              "Stormsøsteren"
+            ],
+            "full": [
+              "Stormsøsteren : Allys historie"
+            ],
+            "original": [
+              "The storm sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:53280749",
           "titles": {
-            "main": ["Skyggesøsteren"],
-            "full": ["Skyggesøsteren : Stars historie"],
-            "original": []
+            "main": [
+              "Skyggesøsteren"
+            ],
+            "full": [
+              "Skyggesøsteren : Stars historie"
+            ],
+            "original": [
+              "The shadow sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:53802001",
           "titles": {
-            "main": ["Perlesøsteren"],
-            "full": ["Perlesøsteren : CeCes historie"],
-            "original": []
+            "main": [
+              "Perlesøsteren"
+            ],
+            "full": [
+              "Perlesøsteren : CeCes historie"
+            ],
+            "original": [
+              "The pearl sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:54189141",
           "titles": {
-            "main": ["Månesøsteren"],
-            "full": ["Månesøsteren : Tiggys historie"],
-            "original": []
+            "main": [
+              "Månesøsteren"
+            ],
+            "full": [
+              "Månesøsteren : Tiggys historie"
+            ],
+            "original": [
+              "The moon sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:46656172",
           "titles": {
-            "main": ["Solsøsteren"],
-            "full": ["Solsøsteren : Electras historie"],
-            "original": ["The sun sister"]
+            "main": [
+              "Solsøsteren"
+            ],
+            "full": [
+              "Solsøsteren : Electras historie"
+            ],
+            "original": [
+              "The sun sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:38500775",
           "titles": {
-            "main": ["Den forsvundne søster"],
-            "full": ["Den forsvundne søster"],
-            "original": ["The missing sister"]
+            "main": [
+              "Den forsvundne søster"
+            ],
+            "full": [
+              "Den forsvundne søster"
+            ],
+            "original": [
+              "The missing sister"
+            ]
           }
         }
       ],
-      "genreAndForm": ["slægtsromaner"],
+      "workYear": null,
+      "genreAndForm": [
+        "roman",
+        "slægtsromaner",
+        "romaner"
+      ],
       "manifestations": {
         "all": [
           {
             "pid": "870970-basis:46615743",
-            "genreAndForm": ["slægtsromaner"],
-            "source": ["Bibliotekskatalog"],
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner",
+              "romaner"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
+              "display": "skønlitteratur",
               "code": "FICTION"
             },
-
             "materialTypes": [
               {
                 "specific": "bog"
@@ -138,7 +200,7 @@
               }
             ],
             "edition": {
-              "summary": "3. udgave, 1. oplag (2019)",
+              "summary": "3. udgave, 2019",
               "publicationYear": {
                 "display": "2019"
               }
@@ -148,7 +210,7 @@
             },
             "physicalDescriptions": [
               {
-                "numberOfPages": null
+                "numberOfPages": 523
               }
             ],
             "accessTypes": [
@@ -162,21 +224,192 @@
                 "loanIsPossible": true
               }
             ],
-            "shelfmark": null
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
+          },
+          {
+            "pid": "870970-basis:53292968",
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner",
+              "romaner"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
+            },
+            "fictionNonfiction": {
+              "display": "skønlitteratur",
+              "code": "FICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
+            ],
+            "hostPublication": null,
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788763849630"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen"
+              }
+            ],
+            "edition": {
+              "summary": "2. udgave, 2017",
+              "publicationYear": {
+                "display": "2017"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 523
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
+          },
+          {
+            "pid": "870970-basis:53200346",
+            "genreAndForm": [
+              "roman"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
+            },
+            "fictionNonfiction": {
+              "display": "skønlitteratur",
+              "code": "FICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
+            ],
+            "hostPublication": null,
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788703079875"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen"
+              }
+            ],
+            "edition": {
+              "summary": "1. bogklubudgave, 2017",
+              "publicationYear": {
+                "display": "2017"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 523
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
           },
           {
             "pid": "870970-basis:52557240",
-            "genreAndForm": ["slægtsromaner"],
-            "source": ["Bibliotekskatalog"],
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
+              "display": "skønlitteratur",
               "code": "FICTION"
             },
-
             "materialTypes": [
               {
                 "specific": "bog"
@@ -207,7 +440,7 @@
               }
             ],
             "edition": {
-              "summary": "1. udgave, 3. oplag (2018)",
+              "summary": "1. udgave, 2016",
               "publicationYear": {
                 "display": "2016"
               }
@@ -217,7 +450,7 @@
             },
             "physicalDescriptions": [
               {
-                "numberOfPages": null
+                "numberOfPages": 523
               }
             ],
             "accessTypes": [
@@ -231,166 +464,31 @@
                 "loanIsPossible": true
               }
             ],
-            "shelfmark": null
-          },
-          {
-            "pid": "870970-basis:52590302",
-            "genreAndForm": ["slægtsromaner"],
-            "source": ["eReolen"],
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
-              "code": "FICTION"
-            },
-
-            "materialTypes": [
-              {
-                "specific": "ebog"
-              }
-            ],
-            "creators": [
-              {
-                "display": "Lucinda Riley",
-                "__typename": "Person"
-              }
-            ],
-            "hostPublication": null,
-            "languages": {
-              "main": [
-                {
-                  "display": "dansk"
-                }
-              ]
-            },
-            "identifiers": [
-              {
-                "value": "9788763844123"
-              },
-              {
-                "value": "https://ereolen.dk/ting/object/870970-basis:52590302"
-              }
-            ],
-            "contributors": [
-              {
-                "display": "Ulla Lauridsen"
-              }
-            ],
-            "edition": {
-              "summary": "1. eBogsudgave",
-              "publicationYear": {
-                "display": "2016"
-              }
-            },
-            "audience": {
-              "generalAudience": []
-            },
-            "physicalDescriptions": [],
-            "accessTypes": [
-              {
-                "code": "ONLINE"
-              }
-            ],
-            "access": [
-              {
-                "__typename": "AccessUrl",
-                "origin": "ereolen.dk",
-                "url": "https://ereolen.dk/ting/object/870970-basis:52590302"
-              },
-              {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": false
-              }
-            ],
-            "shelfmark": null
-          },
-          {
-            "pid": "870970-basis:52643414",
-            "genreAndForm": ["slægtsromaner"],
-            "source": ["Bibliotekskatalog"],
-            "titles": {
-              "main": ["De syv søstre (mp3)"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
-              "code": "FICTION"
-            },
-
-            "materialTypes": [
-              {
-                "specific": "lydbog (cd-mp3)"
-              }
-            ],
-            "creators": [
-              {
-                "display": "Lucinda Riley",
-                "__typename": "Person"
-              }
-            ],
-            "hostPublication": null,
-            "languages": {
-              "main": [
-                {
-                  "display": "dansk"
-                }
-              ]
-            },
-            "identifiers": [
-              {
-                "value": "9788763850636"
-              }
-            ],
-            "contributors": [
-              {
-                "display": "Maria Stokholm"
-              },
-              {
-                "display": "Ulla Lauridsen"
-              }
-            ],
-            "edition": {
-              "summary": "1. lydbogsudgave",
-              "publicationYear": {
-                "display": "2016"
-              }
-            },
-            "audience": {
-              "generalAudience": []
-            },
-            "physicalDescriptions": [
-              {
-                "numberOfPages": null
-              }
-            ],
-            "accessTypes": [
-              {
-                "code": "PHYSICAL"
-              }
-            ],
-            "access": [
-              {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": true
-              }
-            ],
-            "shelfmark": null
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
           },
           {
             "pid": "870970-basis:52643503",
-            "genreAndForm": ["slægtsromaner"],
-            "source": ["Bibliotekskatalog"],
+            "genreAndForm": [
+              "roman"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
+              "display": "skønlitteratur",
               "code": "FICTION"
             },
-
             "materialTypes": [
               {
                 "specific": "lydbog (net)"
@@ -424,6 +522,7 @@
               }
             ],
             "edition": {
+              "summary": "2016",
               "publicationYear": {
                 "display": "2016"
               }
@@ -441,30 +540,35 @@
                 "code": "ONLINE"
               }
             ],
-            "access": [
-              {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": false
-              }
-            ],
-            "shelfmark": null
+            "access": [],
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
           },
           {
-            "pid": "870970-basis:53200346",
-            "genreAndForm": [],
-            "source": ["Bibliotekskatalog"],
+            "pid": "870970-basis:52643414",
+            "genreAndForm": [
+              "roman"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre (mp3)"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
+              "display": "skønlitteratur",
               "code": "FICTION"
             },
-
             "materialTypes": [
               {
-                "specific": "bog"
+                "specific": "lydbog (cd-mp3)"
               }
             ],
             "creators": [
@@ -483,18 +587,21 @@
             },
             "identifiers": [
               {
-                "value": "9788703079875"
+                "value": "9788763850636"
               }
             ],
             "contributors": [
+              {
+                "display": "Maria Stokholm"
+              },
               {
                 "display": "Ulla Lauridsen"
               }
             ],
             "edition": {
-              "summary": "1. bogklubudgave, 1. oplag (2017)",
+              "summary": "1. lydbogsudgave, 2016",
               "publicationYear": {
-                "display": "2017"
+                "display": "2016"
               }
             },
             "audience": {
@@ -516,24 +623,35 @@
                 "loanIsPossible": true
               }
             ],
-            "shelfmark": null
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
           },
           {
-            "pid": "870970-basis:53292968",
-            "genreAndForm": ["slægtsromaner"],
-            "source": ["Bibliotekskatalog"],
+            "pid": "870970-basis:52590302",
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner"
+            ],
+            "source": [
+              "eReolen"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
-              "display": "SKOENLITTERATUR",
+              "display": "skønlitteratur",
               "code": "FICTION"
             },
-
             "materialTypes": [
               {
-                "specific": "bog"
+                "specific": "ebog"
               }
             ],
             "creators": [
@@ -552,7 +670,10 @@
             },
             "identifiers": [
               {
-                "value": "9788763849630"
+                "value": "9788763844123"
+              },
+              {
+                "value": "9788763844123"
               }
             ],
             "contributors": [
@@ -561,46 +682,56 @@
               }
             ],
             "edition": {
-              "summary": "2. udgave, 11. oplag (2021)",
+              "summary": "1. eBogsudgave, 2016",
               "publicationYear": {
-                "display": "2017"
+                "display": "2016"
               }
             },
             "audience": {
               "generalAudience": []
             },
-            "physicalDescriptions": [
-              {
-                "numberOfPages": null
-              }
-            ],
+            "physicalDescriptions": [],
             "accessTypes": [
               {
-                "code": "PHYSICAL"
+                "code": "ONLINE"
               }
             ],
             "access": [
               {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": true
+                "__typename": "Ereol",
+                "origin": "eReolen",
+                "url": "https://ereolen.dk/ting/object/870970-basis:52590302",
+                "canAlwaysBeLoaned": false
               }
             ],
-            "shelfmark": null
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            }
           }
         ],
         "latest": {
           "pid": "870970-basis:46615743",
-          "genreAndForm": ["slægtsromaner"],
-          "source": ["Bibliotekskatalog"],
+          "genreAndForm": [
+            "roman",
+            "slægtsromaner",
+            "romaner"
+          ],
+          "source": [
+            "Bibliotekskatalog"
+          ],
           "titles": {
-            "main": ["De syv søstre"],
-            "original": ["The seven sisters"]
+            "main": [
+              "De syv søstre"
+            ],
+            "original": [
+              "The seven sisters"
+            ]
           },
           "fictionNonfiction": {
-            "display": "SKOENLITTERATUR",
+            "display": "skønlitteratur",
             "code": "FICTION"
           },
-
           "materialTypes": [
             {
               "specific": "bog"
@@ -631,7 +762,7 @@
             }
           ],
           "edition": {
-            "summary": "3. udgave, 1. oplag (2019)",
+            "summary": "3. udgave, 2019",
             "publicationYear": {
               "display": "2019"
             }
@@ -641,7 +772,7 @@
           },
           "physicalDescriptions": [
             {
-              "numberOfPages": null
+              "numberOfPages": 523
             }
           ],
           "accessTypes": [
@@ -655,21 +786,21 @@
               "loanIsPossible": true
             }
           ],
-          "shelfmark": null
+          "shelfmark": {
+            "postfix": "Riley",
+            "shelfmark": "83"
+          }
         }
       },
       "materialTypes": [
         {
-          "specific": "lydbog (net)"
-        },
-        {
           "specific": "bog"
         },
         {
-          "specific": "ebog"
+          "specific": "lydbog (net)"
         },
         {
-          "specific": "punktskrift"
+          "specific": "ebog"
         },
         {
           "specific": "lydbog (cd-mp3)"
@@ -696,9 +827,6 @@
             "display": "slægtsromaner"
           },
           {
-            "display": "romaner"
-          },
-          {
             "display": "kærleiki"
           },
           {
@@ -709,37 +837,10 @@
           },
           {
             "display": "ættarsøgur"
-          },
-          {
-            "display": "kærlighed."
-          },
-          {
-            "display": "adoption."
-          },
-          {
-            "display": "familien."
-          },
-          {
-            "display": "slægtsromaner."
-          },
-          {
-            "display": "fao"
           }
         ]
       },
       "reviews": [
-        {
-          "__typename": "ExternalReview",
-          "author": "Lene Jensen",
-          "date": "2016-09-12",
-          "rating": null,
-          "urls": [
-            {
-              "origin": "litteratursiden.dk",
-              "url": "http://www.litteratursiden.dk/anmeldelser/syv-soestre-af-lucinda-riley"
-            }
-          ]
-        },
         {
           "__typename": "LibrariansReview",
           "author": "Dorthe Marlene Jørgensen",
@@ -763,16 +864,23 @@
             {
               "code": "OTHER",
               "heading": "Andre bøger om samme emne",
-              "text": ""
+              "text": "Lucinda Riley har senest udgivet"
+            },
+            {
+              "code": "OTHER",
+              "heading": "Andre bøger om samme emne",
+              "text": ". Skrivestilen ligner Rileys tidligere udgivelser"
             }
           ]
         }
       ],
       "fictionNonfiction": {
-        "display": "SKOENLITTERATUR",
+        "display": "skønlitteratur",
         "code": "FICTION"
       },
-      "workYear": null
+      "dk5MainEntry": {
+        "display": "Skønlitteratur"
+      }
     }
   }
 }

--- a/cypress/fixtures/material/infomedia-fbi-api.json
+++ b/cypress/fixtures/material/infomedia-fbi-api.json
@@ -2,109 +2,244 @@
   "data": {
     "work": {
       "workId": "work-of:870971-avis:35731733",
-      "titles": { "full": ["Butlerens utrolige historie"], "original": [] },
+      "titles": {
+        "full": [
+          "Butlerens utrolige historie"
+        ],
+        "original": []
+      },
       "abstract": [
         "Filmen ' The Butler' tager afsæt i en avisartikel, der blev til under usædvanlige omstændigheder. Politiken har talt med Wil Haygood, Washington Post-journalisten, der gik på jagt efter en person, der havde arbejdet i Det Hvide Hus i raceadskillelsens tid - og fandt Eugene Allen"
       ],
       "creators": [
-        { "display": "Jakob Nielsen", "__typename": "Person" },
-        { "display": "Will Haygood", "__typename": "Person" }
+        {
+          "display": "Jakob Nielsen",
+          "__typename": "Person"
+        },
+        {
+          "display": "Will Haygood",
+          "__typename": "Person"
+        }
       ],
       "series": [],
       "seriesMembers": [],
+      "workYear": null,
       "genreAndForm": [],
       "manifestations": {
         "all": [
           {
             "pid": "870971-avis:35731733",
             "genreAndForm": [],
-            "source": ["Avisartikler"],
+            "source": [
+              "Avisartikler"
+            ],
             "titles": {
-              "main": ["Butlerens utrolige historie"],
+              "main": [
+                "Butlerens utrolige historie"
+              ],
               "original": []
             },
             "fictionNonfiction": {
-              "display": "FAGLITTERATUR",
+              "display": "faglitteratur",
               "code": "NONFICTION"
             },
-            "materialTypes": [{ "specific": "avisartikel" }],
+            "materialTypes": [
+              {
+                "specific": "avisartikel"
+              }
+            ],
             "creators": [
-              { "display": "Jakob Nielsen", "__typename": "Person" },
-              { "display": "Will Haygood", "__typename": "Person" }
+              {
+                "display": "Jakob Nielsen",
+                "__typename": "Person"
+              },
+              {
+                "display": "Will Haygood",
+                "__typename": "Person"
+              }
             ],
             "hostPublication": {
-              "title": "Politiken, 2013-09-19",
+              "title": "Politiken",
               "creator": null,
               "publisher": null,
-              "year": null
+              "year": {
+                "year": 2013
+              }
             },
-            "languages": { "main": [{ "display": "dansk" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
             "identifiers": [],
             "contributors": [],
             "edition": {
-              "publicationYear": { "display": "2013" }
+              "summary": "2013",
+              "publicationYear": {
+                "display": "2013"
+              }
             },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [{ "numberOfPages": null }],
-            "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
-            "access": [
-              { "__typename": "InfomediaService", "id": "e3fba430" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 16
+              }
             ],
-            "shelfmark": null
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              },
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InfomediaService",
+                "id": "e3fba430"
+              },
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Butlerens",
+              "shelfmark": "99.4 Allen, Eugene"
+            }
           }
         ],
         "latest": {
           "pid": "870971-avis:35731733",
           "genreAndForm": [],
-          "source": ["Avisartikler"],
-          "titles": { "main": ["Butlerens utrolige historie"], "original": [] },
+          "source": [
+            "Avisartikler"
+          ],
+          "titles": {
+            "main": [
+              "Butlerens utrolige historie"
+            ],
+            "original": []
+          },
           "fictionNonfiction": {
-            "display": "FAGLITTERATUR",
+            "display": "faglitteratur",
             "code": "NONFICTION"
           },
-          "materialTypes": [{ "specific": "avisartikel" }],
+          "materialTypes": [
+            {
+              "specific": "avisartikel"
+            }
+          ],
           "creators": [
-            { "display": "Jakob Nielsen", "__typename": "Person" },
-            { "display": "Will Haygood", "__typename": "Person" }
+            {
+              "display": "Jakob Nielsen",
+              "__typename": "Person"
+            },
+            {
+              "display": "Will Haygood",
+              "__typename": "Person"
+            }
           ],
           "hostPublication": {
-            "title": "Politiken, 2013-09-19",
+            "title": "Politiken",
             "creator": null,
             "publisher": null,
-            "year": null
+            "year": {
+              "year": 2013
+            }
           },
-          "languages": { "main": [{ "display": "dansk" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk"
+              }
+            ]
+          },
           "identifiers": [],
           "contributors": [],
           "edition": {
-            "publicationYear": { "display": "2013" }
+            "summary": "2013",
+            "publicationYear": {
+              "display": "2013"
+            }
           },
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
-          "access": [
-            { "__typename": "InfomediaService", "id": "e3fba430" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": []
+          },
+          "physicalDescriptions": [
+            {
+              "numberOfPages": 16
+            }
           ],
-          "shelfmark": null
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            },
+            {
+              "code": "ONLINE"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "InfomediaService",
+              "id": "e3fba430"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Butlerens",
+            "shelfmark": "99.4 Allen, Eugene"
+          }
         }
       },
-      "materialTypes": [{ "specific": "Avisartikel" }],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "materialTypes": [
+        {
+          "specific": "avisartikel"
+        }
+      ],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "Eugene Allen" },
-          { "display": "hvide" },
-          { "display": "raceadskillelse" },
-          { "display": "sorte" },
-          { "display": "USA" },
-          { "display": "Det Hvide Hus" }
+          {
+            "display": "USA"
+          },
+          {
+            "display": "Det Hvide Hus"
+          },
+          {
+            "display": "sorte"
+          },
+          {
+            "display": "hvide"
+          },
+          {
+            "display": "raceadskillelse"
+          },
+          {
+            "display": "Eugene Allen"
+          }
         ]
       },
       "reviews": [],
-      "fictionNonfiction": { "display": "NONFIKTION", "code": "NONFICTION" },
-      "workYear": null
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "99.4 , Eugene"
+      }
     }
   }
 }

--- a/cypress/fixtures/material/order-digital-copy/order-digital-fbi-api.json
+++ b/cypress/fixtures/material/order-digital-copy/order-digital-fbi-api.json
@@ -76,6 +76,7 @@
           }
         }
       ],
+      "workYear": null,
       "genreAndForm": [],
       "manifestations": {
         "all": [
@@ -134,7 +135,7 @@
             },
             "physicalDescriptions": [
               {
-                "numberOfPages": null
+                "numberOfPages": 21
               }
             ],
             "accessTypes": [
@@ -152,7 +153,10 @@
                 "loanIsPossible": true
               }
             ],
-            "shelfmark": null
+            "shelfmark": {
+              "postfix": "Faglig",
+              "shelfmark": "19.1"
+            }
           }
         ],
         "latest": {
@@ -210,7 +214,7 @@
           },
           "physicalDescriptions": [
             {
-              "numberOfPages": null
+              "numberOfPages": 21
             }
           ],
           "accessTypes": [
@@ -228,7 +232,10 @@
               "loanIsPossible": true
             }
           ],
-          "shelfmark": null
+          "shelfmark": {
+            "postfix": "Faglig",
+            "shelfmark": "19.1"
+          }
         }
       },
       "materialTypes": [
@@ -266,7 +273,6 @@
         "display": "faglitteratur",
         "code": "NONFICTION"
       },
-      "workYear": null,
       "dk5MainEntry": {
         "display": "19.1 Forskningsteknik i alm."
       }

--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -2,81 +2,182 @@
   "data": {
     "work": {
       "workId": "work-of:870970-basis:06373674",
-      "titles": { "full": ["Alt for damerne"], "original": [] },
+      "titles": {
+        "full": [
+          "Alt for damerne"
+        ],
+        "original": []
+      },
       "abstract": [],
       "creators": [],
       "series": [],
       "seriesMembers": [],
-      "genreAndForm": [],
+      "workYear": null,
+      "genreAndForm": [
+        "tidsskrift",
+        "tíðarrit"
+      ],
       "manifestations": {
         "all": [
           {
             "pid": "870970-basis:06373674",
-            "genreAndForm": [],
-            "source": ["Bibliotekskatalog"],
-            "titles": { "main": ["Alt for damerne"], "original": [] },
+            "genreAndForm": [
+              "tidsskrift"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Alt for damerne"
+              ],
+              "original": []
+            },
             "fictionNonfiction": {
-              "display": "FAGLITTERATUR",
+              "display": "nonfiktion",
               "code": "NONFICTION"
             },
-            "materialTypes": [{ "specific": "tidsskrift" }],
+            "materialTypes": [
+              {
+                "specific": "tidsskrift"
+              }
+            ],
             "creators": [],
             "hostPublication": null,
-            "languages": { "main": [{ "display": "dansk" }] },
-            "identifiers": [{ "value": "0002-6506" }],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "0002-6506"
+              }
+            ],
             "contributors": [],
             "edition": {
-              "publicationYear": { "display": "1946" }
+              "summary": "1946- ",
+              "publicationYear": {
+                "display": "1946- "
+              }
             },
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": []
+            },
             "physicalDescriptions": [],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "DigitalArticleService", "issn": "00026506" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
             ],
-            "shelfmark": null
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Alt",
+              "shelfmark": "05.6"
+            }
           }
         ],
         "latest": {
           "pid": "870970-basis:06373674",
-          "genreAndForm": [],
-          "source": ["Bibliotekskatalog"],
-          "titles": { "main": ["Alt for damerne"], "original": [] },
+          "genreAndForm": [
+            "tidsskrift"
+          ],
+          "source": [
+            "Bibliotekskatalog"
+          ],
+          "titles": {
+            "main": [
+              "Alt for damerne"
+            ],
+            "original": []
+          },
           "fictionNonfiction": {
-            "display": "FAGLITTERATUR",
+            "display": "nonfiktion",
             "code": "NONFICTION"
           },
-          "materialTypes": [{ "specific": "tidsskrift" }],
+          "materialTypes": [
+            {
+              "specific": "tidsskrift"
+            }
+          ],
           "creators": [],
           "hostPublication": null,
-          "languages": { "main": [{ "display": "dansk" }] },
-          "identifiers": [{ "value": "0002-6506" }],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk"
+              }
+            ]
+          },
+          "identifiers": [
+            {
+              "value": "0002-6506"
+            }
+          ],
           "contributors": [],
           "edition": {
-          "publicationYear": { "display": "1946" }
+            "summary": "1946- ",
+            "publicationYear": {
+              "display": "1946- "
+            }
           },
-          "audience": { "generalAudience": [] },
+          "audience": {
+            "generalAudience": []
+          },
           "physicalDescriptions": [],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "00026506" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
           ],
-          "shelfmark": null
+          "access": [
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Alt",
+            "shelfmark": "05.6"
+          }
         }
       },
-      "materialTypes": [{ "specific": "Tidsskrift" }],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "materialTypes": [
+        {
+          "specific": "tidsskrift"
+        }
+      ],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "dame- og mandeblade" },
-          { "display": "Viborg amtskommune" }
+          {
+            "display": "Viborg amtskommune"
+          },
+          {
+            "display": "dame- og mandeblade"
+          }
         ]
       },
       "reviews": [],
-      "fictionNonfiction": { "display": "NONFIKTION", "code": "NONFICTION" },
-      "workYear": null
+      "fictionNonfiction": {
+        "display": "nonfiktion",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "05.6 Aviser. Periodica af blandet indhold. Danmark"
+      }
     }
   }
 }

--- a/cypress/fixtures/search-result/fbi-api.json
+++ b/cypress/fixtures/search-result/fbi-api.json
@@ -5,7 +5,9 @@
       "works": [
         {
           "workId": "work-of:870970-basis:22629344",
-          "workYear": "1839",
+          "workYear": {
+            "year": "1839"
+          },
           "titles": {
             "full": ["Dummy Some Title: Full"],
             "original": ["Dummy Some Title Origintal"]
@@ -1398,7 +1400,9 @@
         },
         {
           "workId": "work-of:870970-basis:25807995",
-          "workYear": "1839",
+          "workYear": {
+            "year": "1839"
+          },
           "titles": {
             "full": ["Dummy Some Title: Full"],
             "original": ["Dummy Some Title Origintal"]

--- a/cypress/fixtures/search-result/fbi-api.json
+++ b/cypress/fixtures/search-result/fbi-api.json
@@ -1,2247 +1,2252 @@
 {
   "data": {
     "search": {
-      "hitcount": 9486,
+      "hitcount": 722,
       "works": [
         {
-          "workId": "work-of:870970-basis:22629344",
-          "workYear": {
-            "year": "1839"
-          },
+          "workId": "work-of:870970-basis:54129807",
           "titles": {
-            "full": ["Dummy Some Title: Full"],
-            "original": ["Dummy Some Title Origintal"]
+            "full": [
+              "Harry : samtaler med prinsen"
+            ],
+            "original": [
+              "Harry (engelsk)"
+            ]
           },
-          "abstract": ["Dummy The abstract"],
+          "abstract": [
+            "Gennem samtaler gives et portræt af den engelske prins Harry. Der åbnes med forlovelsen mellem Harry (f. 1984) og Meghan Markle (f. 1981). Samtalerne kredser om de store emner i Harrys liv, bl.a. prinsesse Dianas alt for tidlige død"
+          ],
           "creators": [
             {
-              "display": "Dummy Jens Jensen",
+              "display": "Angela Levin",
               "__typename": "Person"
-            },
-            {
-              "display": "Dummy Some Corporation",
-              "__typename": "Corporation"
             }
           ],
-          "series": [
-            {
-              "title": "Dummy Some Series",
-              "isPopular": true,
-              "numberInSeries": {
-                "display": "Dummy number one",
-                "number": [1]
-              },
-              "readThisFirst": true,
-              "readThisWhenever": false
-            },
-            {
-              "title": "Dummy Some Series",
-              "isPopular": false,
-              "numberInSeries": {
-                "display": "Dummy number one",
-                "number": [1]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
-          "seriesMembers": [
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            }
+          "series": [],
+          "seriesMembers": [],
+          "workYear": null,
+          "genreAndForm": [
+            "biografier"
           ],
           "manifestations": {
             "all": [
               {
-                "pid": "870970-basis:22629344",
+                "pid": "870970-basis:54129807",
+                "genreAndForm": [
+                  "biografier"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry"
+                  ],
+                  "original": [
+                    "Harry (engelsk)"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "faglitteratur",
+                  "code": "NONFICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Angela Levin",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788793681088"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Birgitte Brix"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "1. udgave, 2018",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2018"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 301
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Levin",
+                  "shelfmark": "99.4 Henry"
+                }
               },
               {
-                "pid": "870970-basis:22252852",
+                "pid": "870970-basis:54175183",
+                "genreAndForm": [],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry (mp3)"
+                  ],
+                  "original": [
+                    "Harry (engelsk)"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "faglitteratur",
+                  "code": "NONFICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "lydbog (cd-mp3)"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Angela Levin",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788793681231"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Randi Winther"
+                  },
+                  {
+                    "display": "Birgitte Brix"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "2018",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2018"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
                     "numberOfPages": null
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Levin",
+                  "shelfmark": "99.4 Henry"
+                }
               },
               {
-                "pid": "870970-basis:22441671",
+                "pid": "870970-basis:54168446",
+                "genreAndForm": [],
+                "source": [
+                  "Netlydbog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry"
+                  ],
+                  "original": [
+                    "Harry (engelsk)"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "faglitteratur",
+                  "code": "NONFICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "lydbog (net)"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Angela Levin",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788793681132"
+                  },
+                  {
+                    "value": "9788793681132"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Randi Winther"
+                  },
+                  {
+                    "display": "Birgitte Brix"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "2018",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2018"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
                     "numberOfPages": null
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "ONLINE"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "Ereol",
+                    "origin": "eReolen",
+                    "url": "https://ereolen.dk/ting/object/870970-basis:54168446",
+                    "canAlwaysBeLoaned": false
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Levin",
+                  "shelfmark": "99.4 Henry"
+                }
               },
               {
-                "pid": "870970-basis:23148048",
+                "pid": "870970-basis:54129793",
+                "genreAndForm": [
+                  "biografier"
+                ],
+                "source": [
+                  "eReolen"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry"
+                  ],
+                  "original": [
+                    "Harry (engelsk)"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "faglitteratur",
+                  "code": "NONFICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "ebog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Angela Levin",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:27638708",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
+                    "value": "9788793681095"
                   },
                   {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788793681095"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Birgitte Brix"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "1. udgave, 2018",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2018"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
-                "physicalDescriptions": [
+                "physicalDescriptions": [],
+                "accessTypes": [
                   {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:38289977",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
+                    "code": "ONLINE"
                   }
                 ],
-                "creators": [
+                "access": [
                   {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
+                    "__typename": "Ereol",
+                    "origin": "eReolen",
+                    "url": "https://ereolen.dk/ting/object/870970-basis:54129793",
+                    "canAlwaysBeLoaned": false
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:51989252",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:54871910",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:22513354",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:24168638",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:23108283",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:23195151",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:24343081",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:23862476",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:26178533",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:23819104",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:25194853",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:46018869",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:29317038",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
-              },
-              {
-                "pid": "870970-basis:51980247",
-                "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
-                },
-                "materialTypes": [
-                  {
-                    "specific": "Dummy bog"
-                  }
-                ],
-                "creators": [
-                  {
-                    "display": "Dummy Jens Jensen",
-                    "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
-                  }
-                ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
-                "languages": {
-                  "main": [
-                    {
-                      "display": "Dummy dansk"
-                    }
-                  ]
-                },
-                "identifiers": [
-                  {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
-                "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
-                  "publicationYear": {
-                    "display": "Dummy 1839"
-                  }
-                },
-                "audience": {
-                  "generalAudience": ["Dummy general audience"]
-                },
-                "physicalDescriptions": [
-                  {
-                    "numberOfPages": null
-                  }
-                ]
+                "shelfmark": {
+                  "postfix": "Levin",
+                  "shelfmark": "99.4 Henry"
+                }
               }
-            ]
+            ],
+            "latest": {
+              "pid": "870970-basis:54175183",
+              "genreAndForm": [],
+              "source": [
+                "Bibliotekskatalog"
+              ],
+              "titles": {
+                "main": [
+                  "Harry (mp3)"
+                ],
+                "original": [
+                  "Harry (engelsk)"
+                ]
+              },
+              "fictionNonfiction": {
+                "display": "faglitteratur",
+                "code": "NONFICTION"
+              },
+              "materialTypes": [
+                {
+                  "specific": "lydbog (cd-mp3)"
+                }
+              ],
+              "creators": [
+                {
+                  "display": "Angela Levin",
+                  "__typename": "Person"
+                }
+              ],
+              "hostPublication": null,
+              "languages": {
+                "main": [
+                  {
+                    "display": "dansk"
+                  }
+                ]
+              },
+              "identifiers": [
+                {
+                  "value": "9788793681231"
+                }
+              ],
+              "contributors": [
+                {
+                  "display": "Randi Winther"
+                },
+                {
+                  "display": "Birgitte Brix"
+                }
+              ],
+              "edition": {
+                "summary": "2018",
+                "publicationYear": {
+                  "display": "2018"
+                }
+              },
+              "audience": {
+                "generalAudience": []
+              },
+              "physicalDescriptions": [
+                {
+                  "numberOfPages": null
+                }
+              ],
+              "accessTypes": [
+                {
+                  "code": "PHYSICAL"
+                }
+              ],
+              "access": [
+                {
+                  "__typename": "InterLibraryLoan",
+                  "loanIsPossible": true
+                }
+              ],
+              "shelfmark": {
+                "postfix": "Levin",
+                "shelfmark": "99.4 Henry"
+              }
+            }
           }
         },
         {
-          "workId": "work-of:870970-basis:25807995",
-          "workYear": {
-            "year": "1839"
-          },
+          "workId": "work-of:870970-basis:22629344",
           "titles": {
-            "full": ["Dummy Some Title: Full"],
-            "original": ["Dummy Some Title Origintal"]
+            "full": [
+              "Harry Potter og de vises sten"
+            ],
+            "original": [
+              "Harry Potter and the philosopher's stone"
+            ]
           },
-          "abstract": ["Dummy The abstract"],
+          "abstract": [
+            "Flot og gennemillustreret udgave af historien om Harry Potter, der har trolddomsblod i årerne og bliver elev på Hogwarts skole for magi. For både nye og gamle Harry Potter-fans fra 11 til 99 år og egnet til højtlæsning for børn fra ca. 8-9 år"
+          ],
           "creators": [
             {
-              "display": "Dummy Jens Jensen",
+              "display": "Joanne K. Rowling",
               "__typename": "Person"
-            },
-            {
-              "display": "Dummy Some Corporation",
-              "__typename": "Corporation"
             }
           ],
-          "series": [
-            {
-              "title": "Dummy Some Series",
-              "isPopular": true,
-              "numberInSeries": {
-                "display": "Dummy number one",
-                "number": [1]
-              },
-              "readThisFirst": true,
-              "readThisWhenever": false
-            },
-            {
-              "title": "Dummy Some Series",
-              "isPopular": false,
-              "numberInSeries": {
-                "display": "Dummy number one",
-                "number": [1]
-              },
-              "readThisFirst": null,
-              "readThisWhenever": null
-            }
-          ],
+          "series": [],
           "seriesMembers": [
             {
+              "workId": "work-of:870970-basis:22629344",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og de vises sten"
+                ],
+                "full": [
+                  "Harry Potter og de vises sten"
+                ],
+                "original": [
+                  "Harry Potter and the philosopher's stone"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:22677780",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og Hemmelighedernes Kammer"
+                ],
+                "full": [
+                  "Harry Potter og Hemmelighedernes Kammer"
+                ],
+                "original": [
+                  "Harry Potter and the Chamber of Secrets"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:22995154",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og fangen fra Azkaban"
+                ],
+                "full": [
+                  "Harry Potter og fangen fra Azkaban"
+                ],
+                "original": [
+                  "Harry Potter and the prisoner of Azkaban"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:23540703",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og Flammernes Pokal"
+                ],
+                "full": [
+                  "Harry Potter og Flammernes Pokal"
+                ],
+                "original": [
+                  "Harry Potter and the goblet of fire"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:25245784",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og Fønixordenen"
+                ],
+                "full": [
+                  "Harry Potter og Fønixordenen"
+                ],
+                "original": [
+                  "Harry Potter and the Order of the Phoenix"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:25807995",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og halvblodsprinsen"
+                ],
+                "full": [
+                  "Harry Potter og halvblodsprinsen"
+                ],
+                "original": [
+                  "Harry Potter and the half-blood prince"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:27267912",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og dødsregalierne"
+                ],
+                "full": [
+                  "Harry Potter og dødsregalierne"
+                ],
+                "original": [
+                  "Harry Potter and the deathly hallows"
+                ]
               }
             },
             {
+              "workId": "work-of:870970-basis:52646251",
               "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
-              }
-            },
-            {
-              "titles": {
-                "main": ["Dummy Some Title"],
-                "full": ["Dummy Some Title: Full"],
-                "original": ["Dummy Some Title Origintal"]
+                "main": [
+                  "Harry Potter og det forbandede barn"
+                ],
+                "full": [
+                  "Harry Potter og det forbandede barn : del et & to"
+                ],
+                "original": [
+                  "Harry Potter and the cursed child"
+                ]
               }
             }
+          ],
+          "workYear": {
+            "year": 1997
+          },
+          "genreAndForm": [
+            "roman",
+            "fantasy",
+            "romaner",
+            "eventyrlige fortællinger",
+            "patent"
           ],
           "manifestations": {
             "all": [
               {
-                "pid": "870970-basis:25807995",
+                "pid": "870970-basis:38289977",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy",
+                  "romaner"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og de vises sten (ill. MinaLima)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788702301588"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Hanna Lützen"
+                  },
+                  {
+                    "display": "MinaLima (firma)"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "9. udgave, 2020",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2020"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": [
+                    "Højtlæsning fra 8 år. Selvlæsning fra 11 år",
+                    "for højtlæsning"
+                  ]
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 356
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:25998960",
+                "pid": "870970-basis:54871910",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy",
+                  "romaner"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og de vises sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788702272451"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Hanna Lützen"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "8. udgave, 2018",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2018"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 355
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:26056829",
+                "pid": "870970-basis:51989252",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og de vises sten (ill. Jim Kay)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788702179859"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Jim Kay"
+                  },
+                  {
+                    "display": "Hanna Lützen"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "1. illustrerede udgave, 7. udgave, 2015",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2015"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 246
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:26137276",
+                "pid": "870970-basis:51980247",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788702173222"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Hanna Lützen"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "6 udgave, 2015",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2015"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 355
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:27639674",
+                "pid": "870970-basis:29317038",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788702113990"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Hanna Lützen"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "5. udgave, 2012",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2012"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 303
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:54872003",
+                "pid": "870970-basis:46018869",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "9788700774636"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Hanna Lützen"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "Særudgave, 2008",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2008"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 303
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:25771893",
+                "pid": "870970-basis:26178533",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
+                    "value": "9788703011714"
+                  },
                   {
-                    "display": "Dummy Jens Jensen"
+                    "value": "87-03-01171-2"
                   }
                 ],
+                "contributors": [],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "2. bogklubudgave, 2006",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2006"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 303
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:26068053",
+                "pid": "870970-basis:25194853",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "87-02-02769-0"
                   }
                 ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
+                "contributors": [],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "3. udgave, 2004",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2004"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 303
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:26285240",
+                "pid": "870970-basis:22629344",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
-                  }
-                ],
-                "contributors": [
+                    "value": "9788700398368"
+                  },
                   {
-                    "display": "Dummy Jens Jensen"
+                    "value": "87-00-39836-5"
                   }
                 ],
+                "contributors": [],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "2. udgave, 1999",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "1999"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 303
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:29317100",
+                "pid": "870970-basis:22441671",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "87-00-63162-0"
                   }
                 ],
-                "contributors": [
-                  {
-                    "display": "Dummy Jens Jensen"
-                  }
-                ],
+                "contributors": [],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "1. bogklubudgave, 2002",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2002"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
-                    "numberOfPages": null
+                    "numberOfPages": 303
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               },
               {
-                "pid": "870970-basis:51980212",
+                "pid": "870970-basis:22252852",
+                "genreAndForm": [
+                  "roman",
+                  "fantasy"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
                 "titles": {
-                  "main": ["Dummy Some Title"],
-                  "original": ["Dummy Some Title: Original"]
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
                 },
                 "materialTypes": [
                   {
-                    "specific": "Dummy bog"
+                    "specific": "bog"
                   }
                 ],
                 "creators": [
                   {
-                    "display": "Dummy Jens Jensen",
+                    "display": "Joanne K. Rowling",
                     "__typename": "Person"
-                  },
-                  {
-                    "display": "Dummy Some Corporation",
-                    "__typename": "Corporation"
                   }
                 ],
-                "hostPublication": {
-                  "title": "Dummy Årsskrift / Carlsbergfondet",
-                  "creator": "Dummy Some Creator",
-                  "publisher": "Dummy Some Publisher",
-                  "year": {
-                    "year": 2006
-                  }
-                },
+                "hostPublication": null,
                 "languages": {
                   "main": [
                     {
-                      "display": "Dummy dansk"
+                      "display": "dansk"
                     }
                   ]
                 },
                 "identifiers": [
                   {
-                    "value": "Dummy 1234567891234"
+                    "value": "87-00-34654-3"
+                  }
+                ],
+                "contributors": [],
+                "edition": {
+                  "summary": "1998",
+                  "publicationYear": {
+                    "display": "1998"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": 303
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:27638708",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten (Ved Jesper Christensen, mp3)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "lydbog (cd-mp3)"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "9788702075380"
                   }
                 ],
                 "contributors": [
                   {
-                    "display": "Dummy Jens Jensen"
+                    "display": "Jesper Christensen (f. 1948)"
                   }
                 ],
                 "edition": {
-                  "summary": "Dummy 3. i.e. 2 udgave, 2005",
+                  "summary": "2009",
                   "publicationYear": {
-                    "display": "Dummy 1839"
+                    "display": "2009"
                   }
                 },
                 "audience": {
-                  "generalAudience": ["Dummy general audience"]
+                  "generalAudience": []
                 },
                 "physicalDescriptions": [
                   {
                     "numberOfPages": null
                   }
-                ]
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:24343081",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten (Ved Jesper Christensen)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "lydbog (cd)"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "87-00-69610-2"
+                  }
+                ],
+                "contributors": [
+                  {
+                    "display": "Jesper Christensen (f. 1948)"
+                  }
+                ],
+                "edition": {
+                  "summary": "Bogklubudgave, 2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:24168638",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten (Ved Jesper Christensen)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "lydbog (cd)"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "87-02-01276-6"
+                  }
+                ],
+                "contributors": [
+                  {
+                    "display": "Jesper Christensen (f. 1948)"
+                  }
+                ],
+                "edition": {
+                  "summary": "2002",
+                  "publicationYear": {
+                    "display": "2002"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:23862476",
+                "genreAndForm": [
+                  "roman",
+                  "eventyrlige fortællinger"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten (2. udgave)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "diskette"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "Best.nr. wp 400037"
+                  },
+                  {
+                    "value": "Best.nr. ascii 500037"
+                  },
+                  {
+                    "value": "Best.nr. html 600037"
+                  }
+                ],
+                "contributors": [],
+                "edition": {
+                  "summary": "2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:23819104",
+                "genreAndForm": [
+                  "roman",
+                  "eventyrlige fortællinger"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "diskette"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "Best.nr. wp 400037"
+                  },
+                  {
+                    "value": "Best.nr. ascii 500037"
+                  }
+                ],
+                "contributors": [],
+                "edition": {
+                  "summary": "2001",
+                  "publicationYear": {
+                    "display": "2001"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:23195151",
+                "genreAndForm": [],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten (Ved Henrik Emmer)"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "lydbog (cd)"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "87-605-7377-5"
+                  }
+                ],
+                "contributors": [],
+                "edition": {
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:23148048",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "lydbog (bånd)"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "Best.nr. 13256"
+                  }
+                ],
+                "contributors": [
+                  {
+                    "display": "Henrik Emmer"
+                  },
+                  {
+                    "display": "Henrik Emmer"
+                  }
+                ],
+                "edition": {
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:23108283",
+                "genreAndForm": [
+                  "roman"
+                ],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "punktskrift"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "Best.nr. 100029"
+                  }
+                ],
+                "contributors": [],
+                "edition": {
+                  "summary": "2000",
+                  "publicationYear": {
+                    "display": "2000"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": 7
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
+              },
+              {
+                "pid": "870970-basis:22513354",
+                "genreAndForm": [],
+                "source": [
+                  "Bibliotekskatalog"
+                ],
+                "titles": {
+                  "main": [
+                    "Harry Potter og De Vises Sten"
+                  ],
+                  "original": [
+                    "Harry Potter and the philosopher's stone"
+                  ]
+                },
+                "fictionNonfiction": {
+                  "display": "skønlitteratur",
+                  "code": "FICTION"
+                },
+                "materialTypes": [
+                  {
+                    "specific": "lydbog (bånd)"
+                  }
+                ],
+                "creators": [
+                  {
+                    "display": "Joanne K. Rowling",
+                    "__typename": "Person"
+                  }
+                ],
+                "hostPublication": null,
+                "languages": {
+                  "main": [
+                    {
+                      "display": "dansk"
+                    }
+                  ]
+                },
+                "identifiers": [
+                  {
+                    "value": "87-605-8571-4"
+                  }
+                ],
+                "contributors": [],
+                "edition": {
+                  "summary": "1999",
+                  "publicationYear": {
+                    "display": "1999"
+                  }
+                },
+                "audience": {
+                  "generalAudience": []
+                },
+                "physicalDescriptions": [
+                  {
+                    "numberOfPages": null
+                  }
+                ],
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
+                "access": [
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
+                ],
+                "shelfmark": {
+                  "postfix": "Rowling",
+                  "shelfmark": "83"
+                }
               }
-            ]
+            ],
+            "latest": {
+              "pid": "870970-basis:38289977",
+              "genreAndForm": [
+                "roman",
+                "fantasy",
+                "romaner"
+              ],
+              "source": [
+                "Bibliotekskatalog"
+              ],
+              "titles": {
+                "main": [
+                  "Harry Potter og de vises sten (ill. MinaLima)"
+                ],
+                "original": [
+                  "Harry Potter and the philosopher's stone"
+                ]
+              },
+              "fictionNonfiction": {
+                "display": "skønlitteratur",
+                "code": "FICTION"
+              },
+              "materialTypes": [
+                {
+                  "specific": "bog"
+                }
+              ],
+              "creators": [
+                {
+                  "display": "Joanne K. Rowling",
+                  "__typename": "Person"
+                }
+              ],
+              "hostPublication": null,
+              "languages": {
+                "main": [
+                  {
+                    "display": "dansk"
+                  }
+                ]
+              },
+              "identifiers": [
+                {
+                  "value": "9788702301588"
+                }
+              ],
+              "contributors": [
+                {
+                  "display": "Hanna Lützen"
+                },
+                {
+                  "display": "MinaLima (firma)"
+                }
+              ],
+              "edition": {
+                "summary": "9. udgave, 2020",
+                "publicationYear": {
+                  "display": "2020"
+                }
+              },
+              "audience": {
+                "generalAudience": [
+                  "Højtlæsning fra 8 år. Selvlæsning fra 11 år",
+                  "for højtlæsning"
+                ]
+              },
+              "physicalDescriptions": [
+                {
+                  "numberOfPages": 356
+                }
+              ],
+              "accessTypes": [
+                {
+                  "code": "PHYSICAL"
+                }
+              ],
+              "access": [
+                {
+                  "__typename": "InterLibraryLoan",
+                  "loanIsPossible": true
+                }
+              ],
+              "shelfmark": {
+                "postfix": "Rowling",
+                "shelfmark": "83"
+              }
+            }
           }
         }
       ]

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -77,7 +77,7 @@ export const getWorkDescriptionListData = ({
     { label: t("contributorsText"), value: creatorsText, type: "link" },
     {
       label: t("originalTitleText"),
-      value: titles && workYear ? `${titles?.original} ${workYear}` : "",
+      value: titles && workYear ? `${titles?.original} ${workYear.year}` : "",
       type: "standard"
     },
     {

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -41,7 +41,7 @@ describe("Material", () => {
 
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
 
-    cy.getBySel("material-description-series-0")
+    cy.getBySel("material-description-series-1")
       .should("be.visible")
       .and("contain.text", "Nr. 1  in seriesDe syv søstre-serien");
   });

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -8,7 +8,7 @@ describe("Search Result", () => {
   });
 
   it("Check search title", () => {
-    cy.contains("Showing results for “harry” (9486)");
+    cy.contains("Showing results for “harry” (722)");
   });
 
   it("Check length of search result list", () => {
@@ -27,29 +27,17 @@ describe("Search Result", () => {
     ).should("have.attr", "aria-label", "Add to favorites");
   });
 
-  it("Does the search result have a series line?", () => {
-    cy.get(
-      ".search-result-page__list .search-result-item .horizontal-term-line"
-    ).should(
-      "contain.text",
-      // TODO: The series string being rendered makes no sense with the dummy data given
-      // and the (lack) of knowledge of which properties to use and how to combine them.
-      // Therefor when data is in place we can revisit this part of the test.
-      "Nr. 1  in seriesDummy Some SeriesNr. 1  in seriesDummy Some Series"
-    );
-  });
-
   it("Does the search result have titles?", () => {
     cy.get(".search-result-page__list .search-result-item h2").should(
       "contain.text",
-      "Dummy Some Title: Full"
+      "Harry : samtaler med prinsen"
     );
   });
 
   it("Does the search result have authors?", () => {
     cy.get(".search-result-page__list .search-result-item").should(
       "contain.text",
-      "By Dummy Jens Jensen (1839)"
+      "By Angela Levin"
     );
   });
 
@@ -58,14 +46,14 @@ describe("Search Result", () => {
       .eq(0)
       .find(".search-result-item__availability")
       .find("a")
-      .should("have.length", 20);
+      .should("have.length", 4);
   });
 
   // TODO: When the pager bug has been solved, this test can be re-enabled.
   it("Do we have a pager?", () => {
     cy.get(".result-pager__title").should(
       "contain.text",
-      "Showing 2 out of 9486 results"
+      "Showing 2 out of 722 results"
     );
   });
 
@@ -84,7 +72,7 @@ describe("Search Result", () => {
   it("The pager info should also have been updated.", () => {
     cy.get(".result-pager__title").should(
       "contain.text",
-      "Showing 4 out of 9486 results"
+      "Showing 4 out of 722 results"
     );
   });
 

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -8,7 +8,9 @@ describe("Search Result", () => {
   });
 
   it("Check search title", () => {
-    cy.contains("Showing results for “harry” (722)");
+    cy.getBySel("search-result-title")
+      .should("be.visible")
+      .and("contain", "Showing results for “harry” (722)");
   });
 
   it("Check length of search result list", () => {
@@ -28,25 +30,25 @@ describe("Search Result", () => {
   });
 
   it("Does the search result have titles?", () => {
-    cy.get(".search-result-page__list .search-result-item h2").should(
-      "contain.text",
-      "Harry : samtaler med prinsen"
-    );
+    cy.getBySel("search-result-item-title")
+      .first()
+      .should("be.visible")
+      .and("contain", "Harry : samtaler med prinsen");
   });
 
   it("Does the search result have authors?", () => {
-    cy.get(".search-result-page__list .search-result-item").should(
-      "contain.text",
-      "By Angela Levin"
-    );
+    cy.getBySel("search-result-item-author")
+      .first()
+      .should("be.visible")
+      .and("contain.text", "By Angela Levin");
   });
 
   it("Does a search result have the expected number of availibility labels?", () => {
-    cy.get("article")
-      .eq(0)
-      .find(".search-result-item__availability")
+    cy.getBySel("search-result-item-availability")
+      .first()
       .find("a")
-      .should("have.length", 4);
+      .should("be.visible")
+      .and("have.length", 4);
   });
 
   // TODO: When the pager bug has been solved, this test can be re-enabled.

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -23,14 +23,13 @@ export interface MaterialButtonsOnlineProps {
 
 const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
   manifestation,
-  manifestation: {
-    access: [accessElement],
-    access: [{ __typename: accessType }]
-  },
   size,
   workId,
   dataCy = "material-buttons-online"
 }) => {
+  const accessElement = manifestation.access.shift();
+  const accessType = accessElement?.__typename || "";
+
   const { track } = useStatistics();
   const trackOnlineView = () => {
     return track("click", {

--- a/src/components/search-bar/search-result-header/SearchResultHeader.tsx
+++ b/src/components/search-bar/search-result-header/SearchResultHeader.tsx
@@ -13,7 +13,10 @@ const SearchResultHeader: React.FC<SearchResultHeaderProps> = ({
   const t = useText();
 
   return (
-    <h1 className="text-header-h2 mb-16 search-result-title">
+    <h1
+      className="text-header-h2 mb-16 search-result-title"
+      data-cy="search-result-title"
+    >
       {`${t("showingResultsForText")} “${q}” (${hitcount})`}
     </h1>
   );

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -132,7 +132,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         {author && (
           <p className="text-small-caption">
             {`${t("byAuthorText")} ${author}`}
-            {workYear && ` (${workYear})`}
+            {workYear && ` (${workYear.year})`}
           </p>
         )}
       </div>

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -125,18 +125,24 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
           )}
         </div>
 
-        <h2 className="search-result-item__title text-header-h4">
+        <h2
+          className="search-result-item__title text-header-h4"
+          data-cy="search-result-item-title"
+        >
           <Link href={materialFullUrl}>{fullTitle}</Link>
         </h2>
 
         {author && (
-          <p className="text-small-caption">
+          <p className="text-small-caption" data-cy="search-result-item-author">
             {`${t("byAuthorText")} ${author}`}
             {workYear && ` (${workYear.year})`}
           </p>
         )}
       </div>
-      <div className="search-result-item__availability">
+      <div
+        className="search-result-item__availability"
+        data-cy="search-result-item-availability"
+      >
         <AvailabiltityLabels
           cursorPointer
           workId={workId}

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -124,7 +124,9 @@ fragment WorkSmall on Work {
       original
     }
   }
-  workYear
+  workYear {
+    year
+  }
   genreAndForm
   manifestations {
     ...ManifestationsSimple

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -172,6 +172,18 @@
             "deprecationReason": null
           },
           {
+            "name": "type",
+            "description": "The type of content that can be found at this URL",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "AccessUrlType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": "The url where manifestation is located",
             "args": [],
@@ -191,6 +203,53 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AccessUrlType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "IMAGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OTHER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESOURCE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SAMPLE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TABLE_OF_CONTENTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "THUMBNAIL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -469,6 +528,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dk5Heading",
+            "description": "The dk5Heading for the classification (DK5 only)",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1340,6 +1411,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "dk5Heading",
+            "description": "The dk5Heading for the classification",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1449,6 +1536,18 @@
           {
             "name": "edition",
             "description": "The edition number and name",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "note",
+            "description": "A note about this specific edition",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -1569,6 +1668,12 @@
             "deprecationReason": null
           },
           {
+            "name": "NATIONAL_BIBLIOGRAPHY_ADDITIONAL_ENTRY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "NATIONAL_BIBLIOGRAPHY_ENTRY",
             "description": null,
             "isDeprecated": false,
@@ -1594,6 +1699,18 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "note",
+            "description": "Notes for the resource",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2813,6 +2930,26 @@
             "deprecationReason": null
           },
           {
+            "name": "notes",
+            "description": "Notes of the languages that describe subtitles, spoken/written (original, dubbed/synchonized), visual interpretation, parallel (notes are written in Danish)",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "original",
             "description": "Original language of this manifestation",
             "args": [],
@@ -3343,6 +3480,18 @@
             "deprecationReason": null
           },
           {
+            "name": "dateFirstEdition",
+            "description": "The year for the publication of the first edition for this work ",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PublicationYear",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "edition",
             "description": "Edition details for this manifestation",
             "args": [],
@@ -3511,6 +3660,22 @@
             "deprecationReason": null
           },
           {
+            "name": "ownerWork",
+            "description": "The work that this manifestation is part of",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Work",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "physicalDescriptions",
             "description": "Physical description of this manifestation like extent (pages/minutes), illustrations etc.",
             "args": [],
@@ -3631,6 +3796,18 @@
             "deprecationReason": null
           },
           {
+            "name": "review",
+            "description": "Some review data, if this manifestation is a review",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ManifestationReview",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "series",
             "description": "Series for this work",
             "args": [],
@@ -3735,6 +3912,18 @@
             "deprecationReason": null
           },
           {
+            "name": "universe",
+            "description": "Universe for this work",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Universe",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "volume",
             "description": "Information about on which volume this manifestation is in multi volume work",
             "args": [],
@@ -3775,8 +3964,8 @@
             "description": "The year this work was originally published or produced",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "OBJECT",
+              "name": "PublicationYear",
               "ofType": null
             },
             "isDeprecated": false,
@@ -3861,6 +4050,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "playingTime",
+            "description": "The playing time for this specific part (i.e. the duration of a music track) ",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3993,6 +4194,45 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "ManifestationPartType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ManifestationReview",
+        "description": null,
+        "fields": [
+          {
+            "name": "rating",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reviewByLibrarians",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ReviewElement",
                 "ofType": null
               }
             },
@@ -4268,6 +4508,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "mostRelevant",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4475,12 +4739,6 @@
           },
           {
             "name": "DISSERTATION",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "LANGUAGE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -6837,6 +7095,122 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ReviewElement",
+        "description": null,
+        "fields": [
+          {
+            "name": "content",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "heading",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "manifestations",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Manifestation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ReviewElementType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ReviewElementType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ABSTRACT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ACQUISITION_RECOMMENDATIONS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "AUDIENCE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CONCLUSION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESCRIPTION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EVALUATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SIMILAR_MATERIALS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Role",
         "description": null,
         "fields": [
@@ -7845,6 +8219,18 @@
             "deprecationReason": null
           },
           {
+            "name": "language",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Language",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "type",
             "description": null,
             "args": [],
@@ -8256,7 +8642,7 @@
         "fields": [
           {
             "name": "title",
-            "description": "Literary/movie universe this work is part of e.g. Wizarding World, Marvel Universe",
+            "description": "Literary/movie universe this work is part of e.g. Wizarding World, Marvel Cinematic Universe",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8614,8 +9000,8 @@
             "description": "The year this work was originally published or produced",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
+              "kind": "OBJECT",
+              "name": "PublicationYear",
               "ofType": null
             },
             "isDeprecated": false,

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -52,9 +52,20 @@ export type AccessUrl = {
   note?: Maybe<Scalars["String"]>;
   /** The origin, e.g. "DBC Webarkiv" */
   origin: Scalars["String"];
+  /** The type of content that can be found at this URL */
+  type?: Maybe<AccessUrlType>;
   /** The url where manifestation is located */
   url: Scalars["String"];
 };
+
+export enum AccessUrlType {
+  Image = "IMAGE",
+  Other = "OTHER",
+  Resource = "RESOURCE",
+  Sample = "SAMPLE",
+  TableOfContents = "TABLE_OF_CONTENTS",
+  Thumbnail = "THUMBNAIL"
+}
 
 export type Audience = {
   __typename?: "Audience";
@@ -93,6 +104,8 @@ export type Classification = {
   code: Scalars["String"];
   /** Descriptive text for the classification code (DK5 only) */
   display: Scalars["String"];
+  /** The dk5Heading for the classification (DK5 only) */
+  dk5Heading?: Maybe<Scalars["String"]>;
   /** For DK5 only. The DK5 entry type: main entry, national entry, or additional entry */
   entryType?: Maybe<EntryType>;
   /** Name of the classification system */
@@ -206,6 +219,8 @@ export type Dk5MainEntry = {
   code: Scalars["String"];
   /** Displayable main DK5 classification */
   display: Scalars["String"];
+  /** The dk5Heading for the classification */
+  dk5Heading: Scalars["String"];
 };
 
 export type DidYouMean = {
@@ -228,6 +243,8 @@ export type Edition = {
   contributors: Array<Scalars["String"]>;
   /** The edition number and name */
   edition?: Maybe<Scalars["String"]>;
+  /** A note about this specific edition */
+  note?: Maybe<Scalars["String"]>;
   /** A year as displayable text and as number */
   publicationYear?: Maybe<PublicationYear>;
   /** Properties 'edition', 'contributorsToEdition' and 'publicationYear' as one string, e.g.: '3. udgave, revideret af Hugin Eide, 2005' */
@@ -247,6 +264,7 @@ export type ElbaServicesPlaceCopyRequestArgs = {
 export enum EntryType {
   AdditionalEntry = "ADDITIONAL_ENTRY",
   MainEntry = "MAIN_ENTRY",
+  NationalBibliographyAdditionalEntry = "NATIONAL_BIBLIOGRAPHY_ADDITIONAL_ENTRY",
   NationalBibliographyEntry = "NATIONAL_BIBLIOGRAPHY_ENTRY"
 }
 
@@ -254,6 +272,8 @@ export type Ereol = {
   __typename?: "Ereol";
   /** Is this a manifestation that always can be loaned on ereolen.dk even if you've run out of loans this month */
   canAlwaysBeLoaned: Scalars["Boolean"];
+  /** Notes for the resource */
+  note?: Maybe<Scalars["String"]>;
   /** The origin, e.g. "Ereolen" or "Ereolen Go" */
   origin: Scalars["String"];
   /** The url where manifestation is located */
@@ -454,6 +474,8 @@ export type Languages = {
   abstract?: Maybe<Array<Language>>;
   /** Main language of this manifestation */
   main?: Maybe<Array<Language>>;
+  /** Notes of the languages that describe subtitles, spoken/written (original, dubbed/synchonized), visual interpretation, parallel (notes are written in Danish) */
+  notes?: Maybe<Array<Scalars["String"]>>;
   /** Original language of this manifestation */
   original?: Maybe<Array<Language>>;
   /** Parallel languages of this manifestation, if more languages are printed in the same book */
@@ -520,6 +542,8 @@ export type Manifestation = {
   creators: Array<Creator>;
   /** Additional creators of this manifestation as described on the publication. E.g. 'tekst af William Warren' */
   creatorsFromDescription: Array<Scalars["String"]>;
+  /** The year for the publication of the first edition for this work  */
+  dateFirstEdition?: Maybe<PublicationYear>;
   /** Edition details for this manifestation */
   edition?: Maybe<Edition>;
   /** Overall literary category/genre of this manifestation. e.g. fiction or nonfiction. In Danish skønlitteratur/faglitteratur for literature, fiktion/nonfiktion for other types. */
@@ -540,6 +564,8 @@ export type Manifestation = {
   materialTypes: Array<MaterialType>;
   /** Notes about the manifestation */
   notes: Array<Note>;
+  /** The work that this manifestation is part of */
+  ownerWork: Work;
   /** Physical description of this manifestation like extent (pages/minutes), illustrations etc. */
   physicalDescriptions: Array<PhysicalDescription>;
   /** Unique identification of the manifestation e.g 870970-basis:54029519 */
@@ -552,6 +578,8 @@ export type Manifestation = {
   relatedPublications: Array<RelatedPublication>;
   /** Relations to other manifestations */
   relations: Relations;
+  /** Some review data, if this manifestation is a review */
+  review?: Maybe<ManifestationReview>;
   /** Series for this work */
   series: Array<Series>;
   /** Information about on which shelf in the library this manifestation can be found */
@@ -564,12 +592,14 @@ export type Manifestation = {
   tableOfContents?: Maybe<TableOfContent>;
   /** Different kinds of titles for this work */
   titles: ManifestationTitles;
+  /** Universe for this work */
+  universe?: Maybe<Universe>;
   /** Information about on which volume this manifestation is in multi volume work */
   volume?: Maybe<Scalars["String"]>;
   /** Worktypes for this manifestations work */
   workTypes: Array<WorkType>;
   /** The year this work was originally published or produced */
-  workYear?: Maybe<Scalars["String"]>;
+  workYear?: Maybe<PublicationYear>;
 };
 
 export type ManifestationPart = {
@@ -580,6 +610,8 @@ export type ManifestationPart = {
   creators: Array<Creator>;
   /** Additional creator or contributor to this entry (music track or literary analysis) as described on the publication. E.g. 'arr.: H. Cornell' */
   creatorsFromDescription: Array<Scalars["String"]>;
+  /** The playing time for this specific part (i.e. the duration of a music track)  */
+  playingTime?: Maybe<Scalars["String"]>;
   /** Subjects of this entry (music track or literary analysis) */
   subjects?: Maybe<Array<Subject>>;
   /** The title of the entry (music track or title of a literary analysis) */
@@ -601,6 +633,12 @@ export type ManifestationParts = {
   parts: Array<ManifestationPart>;
   /** The type of manifestation parts, is this music tracks, book parts etc. */
   type: ManifestationPartType;
+};
+
+export type ManifestationReview = {
+  __typename?: "ManifestationReview";
+  rating?: Maybe<Scalars["String"]>;
+  reviewByLibrarians?: Maybe<Array<Maybe<ReviewElement>>>;
 };
 
 export type ManifestationTitles = {
@@ -631,6 +669,7 @@ export type Manifestations = {
   bestRepresentation: Manifestation;
   first: Manifestation;
   latest: Manifestation;
+  mostRelevant: Array<Manifestation>;
 };
 
 export type MaterialType = {
@@ -666,7 +705,6 @@ export enum NoteType {
   ConnectionToOtherWorks = "CONNECTION_TO_OTHER_WORKS",
   DescriptionOfMaterial = "DESCRIPTION_OF_MATERIAL",
   Dissertation = "DISSERTATION",
-  Language = "LANGUAGE",
   MusicalEnsembleOrCast = "MUSICAL_ENSEMBLE_OR_CAST",
   NotSpecified = "NOT_SPECIFIED",
   OccasionForPublication = "OCCASION_FOR_PUBLICATION",
@@ -964,6 +1002,24 @@ export type Review = {
   date?: Maybe<Scalars["String"]>;
 };
 
+export type ReviewElement = {
+  __typename?: "ReviewElement";
+  content?: Maybe<Scalars["String"]>;
+  heading?: Maybe<Scalars["String"]>;
+  manifestations?: Maybe<Array<Maybe<Manifestation>>>;
+  type?: Maybe<ReviewElementType>;
+};
+
+export enum ReviewElementType {
+  Abstract = "ABSTRACT",
+  AcquisitionRecommendations = "ACQUISITION_RECOMMENDATIONS",
+  Audience = "AUDIENCE",
+  Conclusion = "CONCLUSION",
+  Description = "DESCRIPTION",
+  Evaluation = "EVALUATION",
+  SimilarMaterials = "SIMILAR_MATERIALS"
+}
+
 export type Role = {
   __typename?: "Role";
   /** The type of creator/contributor as text in singular and plural in Danish, e.g. forfatter/forfattere, komponist/komponister etc */
@@ -1095,6 +1151,7 @@ export type SubjectContainer = {
 export type SubjectText = Subject & {
   __typename?: "SubjectText";
   display: Scalars["String"];
+  language?: Maybe<Language>;
   type: SubjectType;
 };
 
@@ -1160,7 +1217,7 @@ export type Translation = {
 
 export type Universe = {
   __typename?: "Universe";
-  /** Literary/movie universe this work is part of e.g. Wizarding World, Marvel Universe */
+  /** Literary/movie universe this work is part of e.g. Wizarding World, Marvel Cinematic Universe */
   title: Scalars["String"];
 };
 
@@ -1199,7 +1256,7 @@ export type Work = {
   /** Worktypes for this work - 'none' replaced by 'other' */
   workTypes: Array<WorkType>;
   /** The year this work was originally published or produced */
-  workYear?: Maybe<Scalars["String"]>;
+  workYear?: Maybe<PublicationYear>;
 };
 
 export type WorkTitles = {
@@ -1286,7 +1343,6 @@ export type GetMaterialQuery = {
     __typename?: "Work";
     workId: string;
     abstract?: Array<string> | null;
-    workYear?: string | null;
     genreAndForm: Array<string>;
     materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
     mainLanguages: Array<{
@@ -1372,6 +1428,7 @@ export type GetMaterialQuery = {
         original?: Array<string> | null;
       };
     }>;
+    workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
     manifestations: {
       __typename?: "Manifestations";
       all: Array<{
@@ -1569,7 +1626,6 @@ export type SearchWithPaginationQuery = {
       __typename?: "Work";
       workId: string;
       abstract?: Array<string> | null;
-      workYear?: string | null;
       genreAndForm: Array<string>;
       titles: {
         __typename?: "WorkTitles";
@@ -1602,6 +1658,10 @@ export type SearchWithPaginationQuery = {
           original?: Array<string> | null;
         };
       }>;
+      workYear?: {
+        __typename?: "PublicationYear";
+        year?: number | null;
+      } | null;
       manifestations: {
         __typename?: "Manifestations";
         all: Array<{
@@ -2103,7 +2163,6 @@ export type WorkSmallFragment = {
   __typename?: "Work";
   workId: string;
   abstract?: Array<string> | null;
-  workYear?: string | null;
   genreAndForm: Array<string>;
   titles: {
     __typename?: "WorkTitles";
@@ -2136,6 +2195,7 @@ export type WorkSmallFragment = {
       original?: Array<string> | null;
     };
   }>;
+  workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
   manifestations: {
     __typename?: "Manifestations";
     all: Array<{
@@ -2297,7 +2357,6 @@ export type WorkMediumFragment = {
   __typename?: "Work";
   workId: string;
   abstract?: Array<string> | null;
-  workYear?: string | null;
   genreAndForm: Array<string>;
   materialTypes: Array<{ __typename?: "MaterialType"; specific: string }>;
   mainLanguages: Array<{
@@ -2379,6 +2438,7 @@ export type WorkMediumFragment = {
       original?: Array<string> | null;
     };
   }>;
+  workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
   manifestations: {
     __typename?: "Manifestations";
     all: Array<{
@@ -2666,7 +2726,9 @@ export const WorkSmallFragmentDoc = `
       original
     }
   }
-  workYear
+  workYear {
+    year
+  }
   genreAndForm
   manifestations {
     ...ManifestationsSimple


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DSC-16

#### Description

DBC has updated the schema at [fbi-api.dbc.dk/](https://fbi-api.dbc.dk/) for [JED 0.8](https://danbib.dk/broend3_formater). The update contains some breaking changes which forces us to update our client and code accordingly. Key changes for us are related to `workYear`.

The primary purpose of this PR is to update the generated code and updates our code and Cypress fixtures accordingly.

The PR also contains two other changes:

1. We now see empty `access` properties. The code has been updated to handle this case.
2. The search result test has been updated to use `cy` data attributes.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.