### PR TITLE
Remove hitcount from search header when loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-b7f5caa23580a00859acdfcf292439e365b26660",
+    "@danskernesdigitalebibliotek/dpl-design-system": "npm:@reload/dpl-design-system@0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "npm:@reload/dpl-design-system@0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-e43f02e0957b2c36c77cd256f481bc1c47f178df",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -165,7 +165,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
 
   return (
     <div className="search-result-page">
-      <SearchResultHeader hitcount={String(hitcount)} q={q} />
+      <SearchResultHeader hitcount={hitcount} q={q} />
       <FacetLine q={q} filters={filters} filterHandler={filteringHandler} />
       {campaignData && campaignData.data && (
         <Campaign campaignData={campaignData.data} />

--- a/src/components/search-bar/search-result-header/SearchResultHeader.tsx
+++ b/src/components/search-bar/search-result-header/SearchResultHeader.tsx
@@ -1,8 +1,9 @@
+import clsx from "clsx";
 import * as React from "react";
 import { useText } from "../../../core/utils/text";
 
 export interface SearchResultHeaderProps {
-  hitcount: string;
+  hitcount: number;
   q: string;
 }
 
@@ -11,13 +12,15 @@ const SearchResultHeader: React.FC<SearchResultHeaderProps> = ({
   q
 }) => {
   const t = useText();
+  const hasResults = Boolean(hitcount);
+  const classes = clsx(["text-header-h2", "mb-16", "search-result-title"], {
+    "text-loading": !hasResults
+  });
 
   return (
-    <h1
-      className="text-header-h2 mb-16 search-result-title"
-      data-cy="search-result-title"
-    >
-      {`${t("showingResultsForText")} “${q}” (${hitcount})`}
+    <h1 className={classes} data-cy="search-result-title">
+      {hasResults && `${t("showingResultsForText")} “${q}” (${hitcount})`}
+      {!hasResults && `${t("showingResultsForText")} “${q}”`}
     </h1>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,10 +1754,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@npm:@reload/dpl-design-system@0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f":
-  version "0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f"
-  resolved "https://npm.pkg.github.com/download/@reload/dpl-design-system/0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f/45e6679badc5e1c0e155ae5d78c1ef7c0c4e3500#45e6679badc5e1c0e155ae5d78c1ef7c0c4e3500"
-  integrity sha512-nu3JWroeYC/vd7TTeTEHTBBV3EYmbn9DUvB0qywugSYXMrDpYUI3UxUiZrb23dEWfiONRR2/IJvJH2k6pq2FdA==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-e43f02e0957b2c36c77cd256f481bc1c47f178df":
+  version "0.0.0-e43f02e0957b2c36c77cd256f481bc1c47f178df"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-e43f02e0957b2c36c77cd256f481bc1c47f178df/4a08435598308248c3f65acfae35df00c6bc2c89#4a08435598308248c3f65acfae35df00c6bc2c89"
+  integrity sha512-ZsEPXKylicGxkSsy4tgstIwYgMjlczsRAYASQJboqFSWsixs/4Hcv5YLcyX3CtmM+UrCuwXlm/q9jA1qo7sHAg==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,10 +1754,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-b7f5caa23580a00859acdfcf292439e365b26660":
-  version "0.0.0-b7f5caa23580a00859acdfcf292439e365b26660"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-b7f5caa23580a00859acdfcf292439e365b26660/477ea708a0679d53038ca3f8bb29d803e0af40fb#477ea708a0679d53038ca3f8bb29d803e0af40fb"
-  integrity sha512-9AcMD63fA2UvSXObYT8sRenFNNT9Cy+AyQxKaWUdjKIT83PsXzdWX6lKsSbbeKvC9DF5+BSyUSvBRYo0nu7ZpQ==
+"@danskernesdigitalebibliotek/dpl-design-system@npm:@reload/dpl-design-system@0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f":
+  version "0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f"
+  resolved "https://npm.pkg.github.com/download/@reload/dpl-design-system/0.0.0-58c156e1e0fc725aecd1e7f2bf6d9a8a28dcbe1f/45e6679badc5e1c0e155ae5d78c1ef7c0c4e3500#45e6679badc5e1c0e155ae5d78c1ef7c0c4e3500"
+  integrity sha512-nu3JWroeYC/vd7TTeTEHTBBV3EYmbn9DUvB0qywugSYXMrDpYUI3UxUiZrb23dEWfiONRR2/IJvJH2k6pq2FdA==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-371

#### Description
Remove hitcount from search header when loading and add "text-loading" class for animation.

#### Screenshot of the result

![ezgif-5-91673e5f53](https://user-images.githubusercontent.com/998889/211194628-c58a3d29-f4e8-45e0-bd8b-2f4b704901ca.gif)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Depends on:
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/180

There is a loan list test in Cypress that is failing. But as far as I can see it has nothing to do with this PR.