### PR TITLE
Fix accessibility for reservation modal

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -6,7 +6,6 @@ import {
   getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
-import Modal from "../../core/utils/modal";
 import { useText } from "../../core/utils/text";
 import { FaustId, WorkId } from "../../core/utils/types/ids";
 import { Button } from "../Buttons/Button";
@@ -156,13 +155,7 @@ const ReservationModalBody = ({
     reservationResponse?.reservationResults[0]?.reservationDetails;
 
   return (
-    <Modal
-      modalId={reservationModalId(faustId)}
-      screenReaderModalDescriptionText={t(
-        "reservationModalScreenReaderModalDescriptionText"
-      )}
-      closeModalAriaLabelText={t("reservationModalCloseModalAriaLabelText")}
-    >
+    <>
       {!reservationResult && (
         <section className="reservation-modal">
           <header className="reservation-modal-header">
@@ -254,7 +247,7 @@ const ReservationModalBody = ({
           setReservationResponse={setReservationResponse}
         />
       )}
-    </Modal>
+    </>
   );
 };
 

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -72,12 +72,12 @@ function Modal({
           classNames
         )}
         role="dialog"
-        aria-labelledby={`modal-${modalId}`}
+        aria-labelledby={`modal-${modalId}-description`}
         data-cy={dataCy}
       >
         <div
           className="modal__screen-reader-description"
-          id={`modal-${modalId}`}
+          id={`modal-${modalId}-description`}
         >
           {screenReaderModalDescriptionText}
         </div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-372

#### Description
This PR fixes a Pa11y accessibility issue for the reservation modal - not all the IDs are unique. Turns out there were two modal components rendered for every single reservation modal - so when the modal opens there would be a modal inside a modal.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/211339242-750cfc8f-5fe1-49be-82f9-1ae797a8504f.png)

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Please only review the last 3 commits (with my face on them)
Disregard FBI API changes ( #302 )