### PR TITLE
Change incorrect value for coverTints

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-6eb64fbe2d1cccf4301cc9cd2e9d348922b8f96e",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-6a45fda9027b9d3d431d774cd6b1751575096d3a",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/cover/cover.tsx
+++ b/src/components/cover/cover.tsx
@@ -43,8 +43,8 @@ export const Cover = ({
   const tintClasses: TintClassesType = {
     default: "bg-identity-tint-120",
     "120": "bg-identity-tint-120",
+    "100": "bg-identity-tint-100",
     "80": "bg-identity-tint-80",
-    "60": "bg-identity-tint-60",
     "40": "bg-identity-tint-40",
     "20": "bg-identity-tint-20"
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,10 +1754,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-6eb64fbe2d1cccf4301cc9cd2e9d348922b8f96e":
-  version "0.0.0-6eb64fbe2d1cccf4301cc9cd2e9d348922b8f96e"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-6eb64fbe2d1cccf4301cc9cd2e9d348922b8f96e/cedca817517e293da8ad7017b67e5bdd8e645bb5#cedca817517e293da8ad7017b67e5bdd8e645bb5"
-  integrity sha512-HYpOdnzq0FJYKT4sUQKp4fd6EzT79Q5IZ5dXRfE9IW3+JdVj2kLURZ+nyeXRemvnUP053+8QgjcLCH1ZRguQZg==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-6a45fda9027b9d3d431d774cd6b1751575096d3a":
+  version "0.0.0-6a45fda9027b9d3d431d774cd6b1751575096d3a"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-6a45fda9027b9d3d431d774cd6b1751575096d3a/36959488655d7449fe4ae7ece99ac3f55e0c6b1a#36959488655d7449fe4ae7ece99ac3f55e0c6b1a"
+  integrity sha512-+8wkoeuJvu7rXjx+FlnPVMVqFI/R19C+4uugxldwC8UhTbUkleZgu2CCTJQRFQ8EW+kH8pJeqV4U8TWytAZVBA==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-389

#### Change incorrect value for coverTints
There was an issue with one of the values for the coverTints css class, which was set to 100. However, there is no css class that fits a tint value of 100. I assume that it should be 60 instead. because it was missing.

![image](https://user-images.githubusercontent.com/49920322/212899564-c55634e8-0a96-4ee9-a317-a1ba4ee5238a.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.