### PR TITLE
Sorted the editions by the specific material type

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -175,15 +175,19 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         disclosureIconExpandAltText=""
         dataCy="material-editions-disclosure"
       >
-        {manifestations.map((manifestation: Manifestation) => {
-          return (
-            <MaterialMainfestationItem
-              key={manifestation.pid}
-              manifestation={manifestation}
-              workId={wid}
-            />
-          );
-        })}
+        {manifestations
+          .sort((a, b) =>
+            a.materialTypes[0].specific > b.materialTypes[0].specific ? 1 : -1
+          )
+          .map((manifestation: Manifestation) => {
+            return (
+              <MaterialMainfestationItem
+                key={manifestation.pid}
+                manifestation={manifestation}
+                workId={wid}
+              />
+            );
+          })}
       </Disclosure>
       <Disclosure
         mainIconPath={Receipt}
@@ -232,14 +236,12 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           />
         </>
       ))}
-
       {infomediaId && (
         <InfomediaModal
           mainManifestation={currentManifestation}
           infoMediaId={infomediaId}
         />
       )}
-
       {hasCorrectAccess("DigitalArticleService", currentManifestation) && (
         <DigitalModal
           digitalArticleIssn={getDigitalArticleIssn(currentManifestation)}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-25

#### This pull request makes a change to the way the manifestations are displayed in the editions disclosure. 
The manifestations are now sorted by the specific material type, resulting in a more organized and intuitive display for users. This change should improve the user experience when viewing the editions of a work

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/49920322/212688458-d89d2c9e-e219-4ddd-a5b8-694f1f0180e9.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.