### PR TITLE
Add data-cy property for cypress testing to search header components

### DIFF
--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -12,6 +12,7 @@ export interface AutosuggestCategoryProps {
   highlightedIndex: number;
   textAndMaterialDataLength: number;
   autosuggestCategoryList: { render: string; type: string }[];
+  dataCy?: string;
 }
 
 const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
@@ -19,7 +20,8 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
   getItemProps,
   highlightedIndex,
   textAndMaterialDataLength,
-  autosuggestCategoryList
+  autosuggestCategoryList,
+  dataCy = "autosuggest-category-item"
 }) => {
   const t = useText();
   return (
@@ -41,7 +43,7 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
               )}`}
               key={item}
               {...getItemProps({ item, index })}
-              data-cy="autosuggest-category-item"
+              data-cy={dataCy}
             >
               {`${item.term} ${t("inText")}`}
               <div className="boxed-text text-tags noselect ml-8">

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -41,6 +41,7 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
               )}`}
               key={item}
               {...getItemProps({ item, index })}
+              data-cy="autosuggest-category-item"
             >
               {`${item.term} ${t("inText")}`}
               <div className="boxed-text text-tags noselect ml-8">

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -15,13 +15,15 @@ export interface AutosuggestMaterialProps {
   getItemProps: UseComboboxPropGetters<Suggestion>["getItemProps"];
   highlightedIndex: number;
   textDataLength: number;
+  dataCy?: string;
 }
 
 const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
   materialData,
   getItemProps,
   highlightedIndex,
-  textDataLength
+  textDataLength,
+  dataCy = "autosuggest-material-item"
 }) => {
   const t = useText();
   return (
@@ -52,7 +54,7 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
               }`}
               key={item.work?.workId}
               {...getItemProps({ item, index })}
-              data-cy="autosuggest-material-item"
+              data-cy={dataCy}
             >
               {/* eslint-enable react/jsx-props-no-spreading */}
               <div className="autosuggest__material__content">

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -52,6 +52,7 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
               }`}
               key={item.work?.workId}
               {...getItemProps({ item, index })}
+              data-cy="autosuggest-material-item"
             >
               {/* eslint-enable react/jsx-props-no-spreading */}
               <div className="autosuggest__material__content">

--- a/src/components/autosuggest-text/autosuggest-text-item.tsx
+++ b/src/components/autosuggest-text/autosuggest-text-item.tsx
@@ -12,6 +12,7 @@ export interface AutosuggestTextItemProps {
   index: number;
   generateItemId: (objectItem: Suggestion) => string;
   getItemProps: UseComboboxPropGetters<Suggestion>["getItemProps"];
+  dataCy?: string;
 }
 
 const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
@@ -19,7 +20,8 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
   item,
   index,
   generateItemId,
-  getItemProps
+  getItemProps,
+  dataCy = "autosuggest-text-item"
 }) => {
   const t = useText();
   return (
@@ -30,7 +32,7 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
         className={classes.textSuggestion}
         key={generateItemId(item)}
         {...getItemProps({ item, index })}
-        data-cy="autosuggest-text-item"
+        data-cy={dataCy}
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
         {item.type === SuggestionType.Creator

--- a/src/components/autosuggest-text/autosuggest-text-item.tsx
+++ b/src/components/autosuggest-text/autosuggest-text-item.tsx
@@ -30,6 +30,7 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
         className={classes.textSuggestion}
         key={generateItemId(item)}
         {...getItemProps({ item, index })}
+        data-cy="autosuggest-text-item"
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
         {item.type === SuggestionType.Creator

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -35,7 +35,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
 
   if (isLoading && !textData) {
     return (
-      <ul className="autosuggest pb-16">
+      <ul className="autosuggest pb-16" data-cy="autosuggest">
         <li className="ml-24">{t("LoadingText")}</li>
       </ul>
     );
@@ -49,6 +49,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
         className="autosuggest pb-16"
         {...getMenuProps()}
         style={!isOpen ? { display: "none" } : {}}
+        data-cy="autosuggest"
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
 

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -18,6 +18,7 @@ export interface AutosuggestProps {
   categoryData?: SuggestionsFromQueryStringQuery["suggest"]["result"];
   autosuggestCategoryList: { render: string; type: string }[];
   isLoading: boolean;
+  dataCy?: string;
 }
 
 export const Autosuggest: React.FC<AutosuggestProps> = ({
@@ -29,13 +30,14 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
   isOpen,
   categoryData,
   autosuggestCategoryList,
-  isLoading
+  isLoading,
+  dataCy = "autosuggest"
 }) => {
   const t = useText();
 
   if (isLoading && !textData) {
     return (
-      <ul className="autosuggest pb-16" data-cy="autosuggest">
+      <ul className="autosuggest pb-16" data-cy={dataCy}>
         <li className="ml-24">{t("LoadingText")}</li>
       </ul>
     );
@@ -49,7 +51,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
         className="autosuggest pb-16"
         {...getMenuProps()}
         style={!isOpen ? { display: "none" } : {}}
-        data-cy="autosuggest"
+        data-cy={dataCy}
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
 

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -6,11 +6,13 @@ import { useText } from "../../core/utils/text";
 export interface SearchBarProps {
   getInputProps: UseComboboxPropGetters<unknown>["getInputProps"];
   getLabelProps: UseComboboxPropGetters<unknown>["getLabelProps"];
+  dataCy?: string;
 }
 
 const SearchBar: React.FC<SearchBarProps> = ({
   getInputProps,
-  getLabelProps
+  getLabelProps,
+  dataCy = "search-header-input"
 }) => {
   const t = useText();
   return (
@@ -24,7 +26,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
       <input
         name="q"
         className="header__menu-search-input text-body-medium-regular"
-        data-cy="search-header-input"
+        data-cy={dataCy}
         type="text"
         autoComplete="off"
         placeholder={t("inputPlaceholderText")}

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -24,6 +24,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
       <input
         name="q"
         className="header__menu-search-input text-body-medium-regular"
+        data-cy="search-header-input"
         type="text"
         autoComplete="off"
         placeholder={t("inputPlaceholderText")}


### PR DESCRIPTION
#### Link to issue
[DDFSOEG-307](https://reload.atlassian.net/browse/DDFSOEG-307)

#### Description
This PR adds data-cy property for cypress testing to search header components so that they can be easily targeted in our cypress tests moving forward. (Prompted by [this PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/216) )

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
-