### PR TITLE
add material label to aria string

### DIFF
--- a/src/apps/loan-list/list/loan-list.dev.tsx
+++ b/src/apps/loan-list/list/loan-list.dev.tsx
@@ -133,7 +133,7 @@ export default {
       control: {
         type: "text"
       },
-      defaultValue: "Select material for renewal"
+      defaultValue: "Select @label for renewal"
     },
     loanListMaterialLateFeeText: {
       control: {

--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -28,7 +28,7 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
 }) => {
   const t = useText();
   const { dueDate, faust, identifier, loanId } = loan;
-  const { authors = "", materialType, year = "", title } = material || {};
+  const { authors = "", materialType, year = "", title = "" } = material || {};
 
   const openLoanDetailsModalHandler = useCallback(() => {
     if (faust) {
@@ -47,24 +47,20 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
         }`}
       >
         <div className="mr-32">
-          {faust && onChecked && loanId && (
+          {faust && onChecked && loanId && title && (
             <CheckBox
               onChecked={() => onChecked(loanId)}
               id={faust}
               selected={Boolean(materialsToRenew?.indexOf(loanId) > -1)}
               disabled={disabled}
-              label={t("groupModalHiddenLabelCheckboxOnMaterialText")}
+              label={t("groupModalHiddenLabelCheckboxOnMaterialText", {
+                placeholders: { "@label": title }
+              })}
               hideLabel
             />
           )}
           {isDigital(loan) && identifier && (
-            <CheckBox
-              selected={false}
-              id={identifier}
-              disabled
-              label={t("groupModalHiddenLabelCheckboxOnMaterialText")}
-              hideLabel
-            />
+            <CheckBox selected={false} id={identifier} disabled />
           )}
         </div>
         <div className="list-materials__content">

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -3,7 +3,7 @@ import IconCheckbox from "../icon-checkbox/icon-checkbox";
 
 interface CheckBoxProps {
   id: string;
-  label: string | ReactNode;
+  label?: string | ReactNode;
   hideLabel?: boolean;
   selected?: boolean;
   disabled?: boolean;
@@ -46,13 +46,15 @@ const CheckBox: FC<CheckBoxProps> = ({
         <span className="checkbox__icon">
           <IconCheckbox />
         </span>
-        <span
-          className={`checkbox__text text-small-caption color-secondary-gray ${
-            hideLabel ? "checkbox__text--hide-visually" : ""
-          }`}
-        >
-          {label}
-        </span>
+        {label && (
+          <span
+            className={`checkbox__text text-small-caption color-secondary-gray ${
+              hideLabel ? "checkbox__text--hide-visually" : ""
+            }`}
+          >
+            {label}
+          </span>
+        )}
       </label>
     </div>
   );


### PR DESCRIPTION
#### Link to issue

na

#### Description

Include titel of material in aria label

#### Screenshot of the result

<img width="268" alt="image" src="https://user-images.githubusercontent.com/15377965/214582257-2f0c9f46-bbaa-4f0a-a640-c9d900f08e22.png">

:)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
