### PR TITLE
5575: add aria label and missing strings in entry

### DIFF
--- a/src/apps/loan-list/list/loan-list.dev.tsx
+++ b/src/apps/loan-list/list/loan-list.dev.tsx
@@ -356,6 +356,10 @@ export default {
       defaultValue: "Go to material details",
       control: { type: "text" }
     },
+    groupModalGoToMaterialAriaLabelText: {
+      defaultValue: "Go to @label material details",
+      control: { type: "text" }
+    },
     groupModalReturnLibraryText: {
       defaultValue: "Can be returned to all branches of Samsøs libraries",
       control: { type: "text" }

--- a/src/apps/loan-list/list/loan-list.entry.tsx
+++ b/src/apps/loan-list/list/loan-list.entry.tsx
@@ -74,6 +74,12 @@ export interface LoanListEntryTextProps {
   showMoreText: string;
   groupModalReturnLibraryText: string;
   materialDetailsGoToEreolenText: string;
+  loanListMaterialLateFeeText: string;
+  loanListMaterialDayText: string;
+  loanListStatusCircleAriaLabelText: string;
+  materialDetailsDigitalDueDateLabelText: string;
+  groupModalGoToMaterialText: string;
+  groupModalGoToMaterialAriaLabelText: string;
 }
 
 export interface LoanListEntryWithPageSizeProps

--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -93,6 +93,13 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
               type="button"
               className="list-reservation__note"
               onClick={openLoanDetailsModalHandler}
+              aria-label={
+                title
+                  ? t("groupModalGoToMaterialAriaLabelText", {
+                      placeholders: { "@label": title }
+                    })
+                  : ""
+              }
             >
               {t("groupModalGoToMaterialText")}
             </button>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5575

#### Description

Aria label to make links/buttons distinguishable

#### Screenshot of the result

<img width="179" alt="image" src="https://user-images.githubusercontent.com/15377965/214839164-0953d971-6ba0-468c-b7f1-a778497743b7.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
