### PR TITLE
use 'getNumberedSeries' to render series on manifestation and search results 

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -350,3 +350,18 @@ export const getBestMaterialTypeForWork = (work: Work) => {
 export const reservationModalId = (faustIds: FaustId[]) => {
   return constructModalId("reservation-modal", faustIds.sort());
 };
+
+export const getNumberedSeries = (series: Work["series"]) => {
+  // Filter out series that don't have a 'numberInSeries' property
+  const seriesWithNumber = series.filter(
+    (serie) => serie.numberInSeries?.number
+  );
+
+  // Sort the series based on their 'numberInSeries' property
+  return seriesWithNumber.sort((a, b) => {
+    if (a?.numberInSeries?.number && b?.numberInSeries?.number) {
+      return Number(a.numberInSeries.number) - Number(b.numberInSeries.number);
+    }
+    return 0;
+  });
+};

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -352,15 +352,4 @@ export const reservationModalId = (faustIds: FaustId[]) => {
 };
 
 export const getNumberedSeries = (series: Work["series"]) =>
-  series
-    // Filter out series that don't have a 'numberInSeries' property
-    .filter((serie) => serie.numberInSeries?.number)
-    // Sort the list in chronological order to prioritize the most representative series items first.
-    .sort((a, b) => {
-      if (a?.numberInSeries?.number && b?.numberInSeries?.number) {
-        return (
-          Number(a.numberInSeries.number) - Number(b.numberInSeries.number)
-        );
-      }
-      return 0;
-    });
+  series.filter((serie) => serie.numberInSeries?.number);

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -352,4 +352,4 @@ export const reservationModalId = (faustIds: FaustId[]) => {
 };
 
 export const getNumberedSeries = (series: Work["series"]) =>
-  series.filter((serie) => serie.numberInSeries?.number);
+  series.filter((seriesEntry) => seriesEntry.numberInSeries?.number);

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -351,17 +351,16 @@ export const reservationModalId = (faustIds: FaustId[]) => {
   return constructModalId("reservation-modal", faustIds.sort());
 };
 
-export const getNumberedSeries = (series: Work["series"]) => {
-  // Filter out series that don't have a 'numberInSeries' property
-  const seriesWithNumber = series.filter(
-    (serie) => serie.numberInSeries?.number
-  );
-
-  // Sort the series based on their 'numberInSeries' property
-  return seriesWithNumber.sort((a, b) => {
-    if (a?.numberInSeries?.number && b?.numberInSeries?.number) {
-      return Number(a.numberInSeries.number) - Number(b.numberInSeries.number);
-    }
-    return 0;
-  });
-};
+export const getNumberedSeries = (series: Work["series"]) =>
+  series
+    // Filter out series that don't have a 'numberInSeries' property
+    .filter((serie) => serie.numberInSeries?.number)
+    // Sort the list in chronological order to prioritize the most representative series items first.
+    .sort((a, b) => {
+      if (a?.numberInSeries?.number && b?.numberInSeries?.number) {
+        return (
+          Number(a.numberInSeries.number) - Number(b.numberInSeries.number)
+        );
+      }
+      return 0;
+    });

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -33,7 +33,7 @@ describe("Material", () => {
     );
   });
 
-  it("Renders horizontal lines", () => {
+  it("Renders series horizontal lines", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -41,7 +41,7 @@ describe("Material", () => {
 
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
 
-    cy.getBySel("material-description-series-1")
+    cy.getBySel("material-description-series-0")
       .should("be.visible")
       .and("contain.text", "Nr. 1  in seriesDe syv søstre-serien");
   });

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
+import { hasNumberInSeries } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
   constructSearchUrl
@@ -17,20 +18,23 @@ export interface MaterialDescriptionProps {
 const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
   const t = useText();
   const { searchUrl, materialUrl } = useUrls();
-  const inSeries = work.series;
-  const seriesMembersList = work.seriesMembers.map((item) => {
+  const { fictionNonfiction, series, subjects, seriesMembers } = work;
+
+  const seriesList = hasNumberInSeries(series);
+
+  const seriesMembersList = seriesMembers.map((item) => {
     return {
       url: constructMaterialUrl(materialUrl, item.workId as WorkId),
       term: item.titles.main[0]
     };
   });
-  const subjectsList = work.subjects.all.map((item) => {
+
+  const subjectsList = subjects.all.map((item) => {
     return {
       url: constructSearchUrl(searchUrl, item.display),
       term: item.display
     };
   });
-  const { fictionNonfiction } = work;
 
   return (
     <section className="material-description">
@@ -41,25 +45,22 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
         </p>
       )}
       <div className="material-description__links mt-32">
-        {inSeries &&
-          inSeries.map((seriesItem, i) => {
-            return (
-              <HorizontalTermLine
-                title={`${t("numberDescriptionText")} ${
-                  seriesItem.numberInSeries?.number
-                }`}
-                subTitle={t("inSeriesText")}
-                linkList={[
-                  {
-                    url: constructSearchUrl(searchUrl, seriesItem.title),
-                    term: seriesItem.title
-                  }
-                ]}
-                dataCy={`material-description-series-${i}`}
-              />
-            );
-          })}
-        {seriesMembersList && (
+        {seriesList.map((item, i) => (
+          <HorizontalTermLine
+            title={`${t("numberDescriptionText")} ${
+              item.numberInSeries?.number
+            }`}
+            subTitle={t("inSeriesText")}
+            linkList={[
+              {
+                url: constructSearchUrl(searchUrl, item.title),
+                term: item.title
+              }
+            ]}
+            dataCy={`material-description-series-${i}`}
+          />
+        ))}
+        {seriesMembersList.length > 0 && (
           <HorizontalTermLine
             title={t("inSameSeriesText")}
             linkList={seriesMembersList}

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,6 +1,6 @@
 import React from "react";
+import { getNumberedSeries } from "../../apps/material/helper";
 import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
-import { getNumberedSeries } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
   constructSearchUrl

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { WorkMediumFragment } from "../../core/dbc-gateway/generated/graphql";
-import { hasNumberInSeries } from "../../core/utils/helpers/general";
+import { getNumberedSeries } from "../../core/utils/helpers/general";
 import {
   constructMaterialUrl,
   constructSearchUrl
@@ -20,7 +20,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
   const { searchUrl, materialUrl } = useUrls();
   const { fictionNonfiction, series, subjects, seriesMembers } = work;
 
-  const seriesList = hasNumberInSeries(series);
+  const seriesList = getNumberedSeries(series);
 
   const seriesMembersList = seriesMembers.map((item) => {
     return {

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -13,7 +13,8 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getManifestationPid
+  getManifestationPid,
+  hasNumberInSeries
 } from "../../../core/utils/helpers/general";
 import SearchResultListItemCover from "./search-result-list-item-cover";
 import HorizontalTermLine from "../../horizontal-term-line/HorizontalTermLine";
@@ -56,8 +57,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     t
   );
   const manifestationPid = getManifestationPid(manifestations);
-  const firstInSeries = series?.[0];
-  const { title: seriesTitle, numberInSeries } = firstInSeries || {};
+  const firstItemInSeries = hasNumberInSeries(series)[0];
   const materialFullUrl = constructMaterialUrl(materialUrl, workId as WorkId);
   const { track } = useStatistics();
   // We use hasBeenVisible to determine if the search result
@@ -119,16 +119,16 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
           {showItem && (
             <ButtonFavourite id={workId} addToListRequest={addToListRequest} />
           )}
-          {numberInSeries && seriesTitle && (
+          {firstItemInSeries && (
             <HorizontalTermLine
               title={`${t("numberDescriptionText")} ${
-                numberInSeries.number?.[0]
+                firstItemInSeries.numberInSeries?.number
               }`}
               subTitle={t("inSeriesText")}
               linkList={[
                 {
-                  url: constructSearchUrl(searchUrl, seriesTitle),
-                  term: seriesTitle
+                  url: constructSearchUrl(searchUrl, firstItemInSeries.title),
+                  term: firstItemInSeries.title
                 }
               ]}
             />

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -57,7 +57,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     t
   );
   const manifestationPid = getManifestationPid(manifestations);
-  const firstItemInSeries = hasNumberInSeries(series)[0];
+  const firstItemInSeries = hasNumberInSeries(series).shift();
   const materialFullUrl = constructMaterialUrl(materialUrl, workId as WorkId);
   const { track } = useStatistics();
   // We use hasBeenVisible to determine if the search result

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -14,7 +14,7 @@ import {
   filterCreators,
   flattenCreators,
   getManifestationPid,
-  hasNumberInSeries
+  getNumberedSeries
 } from "../../../core/utils/helpers/general";
 import SearchResultListItemCover from "./search-result-list-item-cover";
 import HorizontalTermLine from "../../horizontal-term-line/HorizontalTermLine";
@@ -57,7 +57,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     t
   );
   const manifestationPid = getManifestationPid(manifestations);
-  const firstItemInSeries = hasNumberInSeries(series).shift();
+  const firstItemInSeries = getNumberedSeries(series).shift();
   const materialFullUrl = constructMaterialUrl(materialUrl, workId as WorkId);
   const { track } = useStatistics();
   // We use hasBeenVisible to determine if the search result

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -13,8 +13,7 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getManifestationPid,
-  getNumberedSeries
+  getManifestationPid
 } from "../../../core/utils/helpers/general";
 import SearchResultListItemCover from "./search-result-list-item-cover";
 import HorizontalTermLine from "../../horizontal-term-line/HorizontalTermLine";
@@ -30,6 +29,7 @@ import { Work } from "../../../core/utils/types/entities";
 import { useStatistics } from "../../../core/statistics/useStatistics";
 import { statistics } from "../../../core/statistics/statistics";
 import { useItemHasBeenVisible } from "../../../core/utils/helpers/lazy-load";
+import { getNumberedSeries } from "../../../apps/material/helper";
 
 export interface SearchResultListItemProps {
   item: Work;

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -377,4 +377,19 @@ export const filterLoansNotOverdue = (loans: LoanType[], warning: number) => {
 export const constructModalId = (prefix: string, fragments: string[]) =>
   `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
 
+export const hasNumberInSeries = (series: Work["series"]) => {
+  // Filter out series that don't have a 'numberInSeries' property
+  const seriesWithNumber = series.filter(
+    (serie) => serie.numberInSeries?.number
+  );
+
+  // Sort the series based on their 'numberInSeries' property
+  return seriesWithNumber.sort((a, b) => {
+    if (a?.numberInSeries?.number && b?.numberInSeries?.number) {
+      return Number(a.numberInSeries.number) - Number(b.numberInSeries.number);
+    }
+    return 0;
+  });
+};
+
 export default {};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -377,7 +377,7 @@ export const filterLoansNotOverdue = (loans: LoanType[], warning: number) => {
 export const constructModalId = (prefix: string, fragments: string[]) =>
   `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
 
-export const hasNumberInSeries = (series: Work["series"]) => {
+export const getNumberedSeries = (series: Work["series"]) => {
   // Filter out series that don't have a 'numberInSeries' property
   const seriesWithNumber = series.filter(
     (serie) => serie.numberInSeries?.number

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -377,19 +377,4 @@ export const filterLoansNotOverdue = (loans: LoanType[], warning: number) => {
 export const constructModalId = (prefix: string, fragments: string[]) =>
   `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
 
-export const getNumberedSeries = (series: Work["series"]) => {
-  // Filter out series that don't have a 'numberInSeries' property
-  const seriesWithNumber = series.filter(
-    (serie) => serie.numberInSeries?.number
-  );
-
-  // Sort the series based on their 'numberInSeries' property
-  return seriesWithNumber.sort((a, b) => {
-    if (a?.numberInSeries?.number && b?.numberInSeries?.number) {
-      return Number(a.numberInSeries.number) - Number(b.numberInSeries.number);
-    }
-    return 0;
-  });
-};
-
 export default {};


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-395

#### This pull request adds a new function 'getNumberedSeries'
'getNumberedSeries' takes in an array of objects (series) and returns a sorted version of the array based on the 'numberInSeries' property. It first filters out any objects that do not have a 'numberInSeries' property, and then sorts the remaining objects based on the numerical value of their 'numberInSeries' property.

#### Screenshot of the result
**After**:
![image](https://user-images.githubusercontent.com/49920322/214840121-ff2b8de1-0664-454e-8c75-673a644c9b6f.png)

**Before**:
![image](https://user-images.githubusercontent.com/49920322/214840233-ca694e69-a4b0-4268-bc88-d22a6c6646bc.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.