### PR TITLE
Test/material buttons

### DIFF
--- a/cypress/fixtures/material/availability.json
+++ b/cypress/fixtures/material/availability.json
@@ -1,6 +1,6 @@
 [
   {
-    "available": false,
+    "available": true,
     "recordId": "52557240",
     "reservable": true,
     "reservations": 2

--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -252,7 +252,7 @@
             },
             "materialTypes": [
               {
-                "specific": "bog"
+                "specific": "musik (net)"
               }
             ],
             "creators": [
@@ -295,13 +295,15 @@
             ],
             "accessTypes": [
               {
-                "code": "PHYSICAL"
+                "code": "ONLINE"
               }
             ],
             "access": [
               {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": true
+                "__typename": "AccessUrl",
+                "origin": "musik",
+                "url": "https://musik.dk/ting/object/870970-basis:52590302",
+                "canAlwaysBeLoaned": false
               }
             ],
             "shelfmark": {
@@ -323,7 +325,7 @@
             },
             "materialTypes": [
               {
-                "specific": "bog"
+                "specific": "film (net)"
               }
             ],
             "creators": [
@@ -366,13 +368,15 @@
             ],
             "accessTypes": [
               {
-                "code": "PHYSICAL"
+                "code": "ONLINE"
               }
             ],
             "access": [
               {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": true
+                "__typename": "AccessUrl",
+                "origin": "Filmstriben",
+                "url": "https://filmstriben.dk/ting/object/870970-basis:52590302",
+                "canAlwaysBeLoaned": false
               }
             ],
             "shelfmark": {
@@ -443,7 +447,14 @@
                 "code": "ONLINE"
               }
             ],
-            "access": [],
+            "access": [
+              {
+                "__typename": "AccessUrl",
+                "origin": "website",
+                "url": "https://website.dk/ting/object/870970-basis:52590302",
+                "canAlwaysBeLoaned": false
+              }
+            ],
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"

--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -3,12 +3,8 @@
     "work": {
       "workId": "work-of:870970-basis:52557240",
       "titles": {
-        "full": [
-          "De syv søstre : Maias historie"
-        ],
-        "original": [
-          "The seven sisters"
-        ]
+        "full": ["De syv søstre : Maias historie"],
+        "original": ["The seven sisters"]
       },
       "abstract": [
         "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav"
@@ -32,9 +28,7 @@
           "isPopular": null,
           "numberInSeries": {
             "display": "1",
-            "number": [
-              1
-            ]
+            "number": [1]
           },
           "readThisFirst": null,
           "readThisWhenever": null
@@ -44,127 +38,71 @@
         {
           "workId": "work-of:870970-basis:52557240",
           "titles": {
-            "main": [
-              "De syv søstre"
-            ],
-            "full": [
-              "De syv søstre : Maias historie"
-            ],
-            "original": [
-              "The seven sisters"
-            ]
+            "main": ["De syv søstre"],
+            "full": ["De syv søstre : Maias historie"],
+            "original": ["The seven sisters"]
           }
         },
         {
           "workId": "work-of:870970-basis:52970628",
           "titles": {
-            "main": [
-              "Stormsøsteren"
-            ],
-            "full": [
-              "Stormsøsteren : Allys historie"
-            ],
-            "original": [
-              "The storm sister"
-            ]
+            "main": ["Stormsøsteren"],
+            "full": ["Stormsøsteren : Allys historie"],
+            "original": ["The storm sister"]
           }
         },
         {
           "workId": "work-of:870970-basis:53280749",
           "titles": {
-            "main": [
-              "Skyggesøsteren"
-            ],
-            "full": [
-              "Skyggesøsteren : Stars historie"
-            ],
-            "original": [
-              "The shadow sister"
-            ]
+            "main": ["Skyggesøsteren"],
+            "full": ["Skyggesøsteren : Stars historie"],
+            "original": ["The shadow sister"]
           }
         },
         {
           "workId": "work-of:870970-basis:53802001",
           "titles": {
-            "main": [
-              "Perlesøsteren"
-            ],
-            "full": [
-              "Perlesøsteren : CeCes historie"
-            ],
-            "original": [
-              "The pearl sister"
-            ]
+            "main": ["Perlesøsteren"],
+            "full": ["Perlesøsteren : CeCes historie"],
+            "original": ["The pearl sister"]
           }
         },
         {
           "workId": "work-of:870970-basis:54189141",
           "titles": {
-            "main": [
-              "Månesøsteren"
-            ],
-            "full": [
-              "Månesøsteren : Tiggys historie"
-            ],
-            "original": [
-              "The moon sister"
-            ]
+            "main": ["Månesøsteren"],
+            "full": ["Månesøsteren : Tiggys historie"],
+            "original": ["The moon sister"]
           }
         },
         {
           "workId": "work-of:870970-basis:46656172",
           "titles": {
-            "main": [
-              "Solsøsteren"
-            ],
-            "full": [
-              "Solsøsteren : Electras historie"
-            ],
-            "original": [
-              "The sun sister"
-            ]
+            "main": ["Solsøsteren"],
+            "full": ["Solsøsteren : Electras historie"],
+            "original": ["The sun sister"]
           }
         },
         {
           "workId": "work-of:870970-basis:38500775",
           "titles": {
-            "main": [
-              "Den forsvundne søster"
-            ],
-            "full": [
-              "Den forsvundne søster"
-            ],
-            "original": [
-              "The missing sister"
-            ]
+            "main": ["Den forsvundne søster"],
+            "full": ["Den forsvundne søster"],
+            "original": ["The missing sister"]
           }
         }
       ],
       "workYear": null,
-      "genreAndForm": [
-        "roman",
-        "slægtsromaner",
-        "romaner"
-      ],
+      "genreAndForm": ["roman", "slægtsromaner", "romaner"],
       "manifestations": {
         "all": [
           {
             "pid": "870970-basis:46615743",
-            "genreAndForm": [
-              "roman",
-              "slægtsromaner",
-              "romaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -231,21 +169,11 @@
           },
           {
             "pid": "870970-basis:53292968",
-            "genreAndForm": [
-              "roman",
-              "slægtsromaner",
-              "romaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -312,19 +240,11 @@
           },
           {
             "pid": "870970-basis:53200346",
-            "genreAndForm": [
-              "roman"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["roman"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -391,20 +311,11 @@
           },
           {
             "pid": "870970-basis:52557240",
-            "genreAndForm": [
-              "roman",
-              "slægtsromaner"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["roman", "slægtsromaner"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -471,19 +382,11 @@
           },
           {
             "pid": "870970-basis:52643503",
-            "genreAndForm": [
-              "roman"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["roman"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -548,19 +451,11 @@
           },
           {
             "pid": "870970-basis:52643414",
-            "genreAndForm": [
-              "roman"
-            ],
-            "source": [
-              "Bibliotekskatalog"
-            ],
+            "genreAndForm": ["roman"],
+            "source": ["Bibliotekskatalog"],
             "titles": {
-              "main": [
-                "De syv søstre (mp3)"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre (mp3)"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -630,20 +525,11 @@
           },
           {
             "pid": "870970-basis:52590302",
-            "genreAndForm": [
-              "roman",
-              "slægtsromaner"
-            ],
-            "source": [
-              "eReolen"
-            ],
+            "genreAndForm": ["roman", "slægtsromaner"],
+            "source": ["eReolen"],
             "titles": {
-              "main": [
-                "De syv søstre"
-              ],
-              "original": [
-                "The seven sisters"
-              ]
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -712,21 +598,11 @@
         ],
         "latest": {
           "pid": "870970-basis:46615743",
-          "genreAndForm": [
-            "roman",
-            "slægtsromaner",
-            "romaner"
-          ],
-          "source": [
-            "Bibliotekskatalog"
-          ],
+          "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+          "source": ["Bibliotekskatalog"],
           "titles": {
-            "main": [
-              "De syv søstre"
-            ],
-            "original": [
-              "The seven sisters"
-            ]
+            "main": ["De syv søstre"],
+            "original": ["The seven sisters"]
           },
           "fictionNonfiction": {
             "display": "skønlitteratur",

--- a/cypress/fixtures/material/unavailability.json
+++ b/cypress/fixtures/material/unavailability.json
@@ -1,0 +1,8 @@
+[
+  {
+    "available": false,
+    "recordId": "52557240",
+    "reservable": false,
+    "reservations": 2
+  }
+]

--- a/src/components/material/material-buttons/generic/MaterialButtonCantReserve.tsx
+++ b/src/components/material/material-buttons/generic/MaterialButtonCantReserve.tsx
@@ -6,10 +6,12 @@ import { Button } from "../../../Buttons/Button";
 
 export interface MaterialButtonCantReserveProps {
   size?: ButtonSize;
+  dataCy?: string;
 }
 
 const MaterialButtonCantReserve: FC<MaterialButtonCantReserveProps> = ({
-  size
+  size,
+  dataCy = "material-header-buttons-cant-reserve"
 }) => {
   const t = useText();
 
@@ -21,6 +23,7 @@ const MaterialButtonCantReserve: FC<MaterialButtonCantReserveProps> = ({
       disabled
       collapsible={false}
       size={size || "large"}
+      dataCy={dataCy}
     />
   );
 };

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -6,12 +6,13 @@ import {
 import { Manifestation } from "../../../core/utils/types/entities";
 
 export const hasCorrectAccess = (
-  desiredAccess: Access["__typename"],
+  desiredAccess: NonNullable<Access["__typename"]>,
   manifestations: Manifestation[]
 ) => {
   return manifestations.some((manifestation) => {
     return manifestation.access.some(
-      ({ __typename }) => __typename === desiredAccess
+      ({ __typename }) =>
+        __typename.toLowerCase() === desiredAccess.toLowerCase()
     );
   });
 };

--- a/src/components/material/material-buttons/material-buttons.test.ts
+++ b/src/components/material/material-buttons/material-buttons.test.ts
@@ -1,0 +1,167 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("Material buttons", () => {
+  it("Renders a clickable find on shelf button even if no materials are available", () => {
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/unavailability.json"
+    });
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("bog").first().click();
+    cy.getBySel("material-header-buttons-find-on-shelf")
+      .should("exist")
+      .and("be.enabled");
+  });
+
+  it("Doesn't render find on shelf button for online materials", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("ebog").first().click();
+    cy.getBySel("material-header-buttons-find-on-shelf").should("not.exist");
+  });
+
+  it("Renders a reservation button for physical materials with material type", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("bog").first().click();
+    cy.getBySel("material-header-buttons-physical")
+      .should("exist")
+      .and("contain", "bog");
+    cy.getBySel("availability-label")
+      .contains("lydbog (cd-mp3)")
+      .first()
+      .click();
+    cy.getBySel("material-header-buttons-physical")
+      .should("exist")
+      .and("contain", "lydbog (cd-mp3)");
+  });
+
+  it("Renders reservation button disabled if a material isn't reservable", () => {
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/unavailability.json"
+    });
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("bog").first().click();
+    cy.getBySel("material-header-buttons-cant-reserve")
+      .should("be.disabled")
+      .and("contain", "Can't be reserved");
+  });
+
+  it("Renders the correct action button for ebooks from ereolen", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("ebog").first().click();
+    cy.getBySel("material-buttons-online-external").contains("Go to ereolen");
+  });
+
+  it("Renders the correct action button for movies from filmstriben", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("film").first().click();
+    cy.getBySel("material-buttons-online-external").contains(
+      "Go to filmstriben"
+    );
+  });
+
+  it("Renders the correct action button for online audio books", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("lydbog (net)").first().click();
+    cy.getBySel("material-buttons-online-external").contains("Listen online");
+  });
+
+  it("Renders the correct action button for other online materials", () => {
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.getBySel("availability-label").contains("musik").first().click();
+    cy.getBySel("material-buttons-online-external").contains("See online");
+  });
+
+  it("Renders the correct action button for online digital articles", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/order-digital-copy/order-digital-fbi-api"
+    });
+    cy.visit(
+      "/iframe.html?id=apps-material--digital&viewMode=story&type=tidsskriftsartikel"
+    );
+    cy.getBySel("material-header-buttons-online-digital-article").contains(
+      "Order digital copy"
+    );
+  });
+
+  it("Renders the correct action button for infomedia articles", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/infomedia-fbi-api.json"
+    });
+    cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story");
+    cy.getBySel("material-header-buttons-online-infomedia-article")
+      .should("exist")
+      .and("contain", "Read article");
+  });
+
+  beforeEach(() => {
+    cy.interceptRest({
+      httpMethod: "POST",
+      aliasName: "reservations",
+      url: "**/patrons/patronid/reservations/**",
+      fixtureFilePath: "material/reservations.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/holdings.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "branches",
+      url: "**/agencyid/branches",
+      fixtureFilePath: "material/branches.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "user",
+      url: "**/agencyid/patrons/patronid/v2",
+      fixtureFilePath: "material/user.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
+
+    // Intercept like button
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+
+    // Intercept covers.
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+    // Intercept url "translation".
+    cy.interceptRest({
+      aliasName: "UrlProxy",
+      url: "**/dpl-url-proxy?url=**",
+      fixtureFilePath: "material/dpl-url-proxy.json"
+    });
+
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/fbi-api.json"
+    });
+  });
+});
+
+export default {};

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
@@ -30,7 +30,7 @@ const MaterialButtonOnlineDigitalArticle: FC<
 
   return (
     <Button
-      label={t("orderDigitalCopy")}
+      label={t("orderDigitalCopyButtonText")}
       buttonType="none"
       variant="filled"
       disabled={false}

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -8,6 +8,7 @@ import { getMaterialTypes } from "../../../../core/utils/helpers/general";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
+import MaterialTypes from "../../../../core/utils/types/material-type";
 import { LinkNoStyle } from "../../../atoms/link-no-style";
 import { Button } from "../../../Buttons/Button";
 
@@ -32,7 +33,9 @@ export const getOnlineMaterialType = (
     return "emovie";
   }
   if (
-    materialTypes.find((element) => element.toLowerCase().includes("lydbog"))
+    materialTypes.find((element) =>
+      element.toLowerCase().includes(MaterialTypes.audioBookGeneric)
+    )
   ) {
     return "audiobook";
   }

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -25,13 +25,15 @@ export const getOnlineMaterialType = (
   sourceName: AccessUrl["origin"],
   materialTypes: MaterialType["specific"][]
 ) => {
-  if (sourceName.includes("ereol")) {
+  if (sourceName.toLowerCase().includes("ereol")) {
     return "ebook";
   }
-  if (sourceName.includes("filmstriben")) {
+  if (sourceName.toLowerCase().includes("filmstriben")) {
     return "emovie";
   }
-  if (materialTypes.find((element) => element.includes("lydbog"))) {
+  if (
+    materialTypes.find((element) => element.toLowerCase().includes("lydbog"))
+  ) {
     return "audiobook";
   }
   return "unknown";

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -49,7 +49,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   size,
   trackOnlineView,
   manifestations,
-  dataCy = "material-buttons-online-external"
+  dataCy = "material-button-online-external"
 }) => {
   const [translatedUrl, setTranslatedUrl] = useState<URL>(new URL(externalUrl));
   const [urlWasTranslated, setUrlWasTranslated] = useState<boolean | null>(

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -44,7 +44,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   size,
   trackOnlineView,
   manifestations,
-  dataCy = "material-button-online-external"
+  dataCy = "material-buttons-online-external"
 }) => {
   const [translatedUrl, setTranslatedUrl] = useState<URL>(new URL(externalUrl));
   const [urlWasTranslated, setUrlWasTranslated] = useState<boolean | null>(
@@ -99,6 +99,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
         size={size || "large"}
         iconClassNames="invert"
         onClick={trackOnlineView}
+        dataCy={dataCy}
       />
     </LinkNoStyle>
   );

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -3,6 +3,7 @@ const enum MaterialType {
   ebook = "e-bog",
   movie = "film",
   audioBook = "lydbog (net)",
+  audioBookGeneric = "lydbog",
   music = "node",
   game = "playstation 5",
   animatedSeries = "tegneserie",


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-375

#### Description
This PR introduces the material-buttons cypress test that checks whether the material page action/reservation buttons and the find on shelf button behave as they should. 
I also adjusted and added some fixtures to e.g. be able to reuse material page fbi-api.json fixture in my test. 

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/214865538-d142fd2d-8be2-49ca-b6fc-856f9e67cd83.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a