### PR TITLE
Editions grouped by type and then by age

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -30,10 +30,12 @@ export const getManifestationsOrderByTypeAndYear = (
 
   const materialsMappedBytype = groupBy(
     orderedByYear,
-    "materialTypes[0].specific"
+    // all manifestations that not have a material type will be grouped under "unknown"
+    (m) => m?.materialTypes[0]?.specific ?? "unknown"
   );
 
   return (
+    // Get the keys for each material type.
     Object.keys(materialsMappedBytype)
       // Sort the material types alphabetically.
       .sort()

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,4 +1,4 @@
-import { compact } from "lodash";
+import { compact, groupBy } from "lodash";
 import {
   constructModalId,
   creatorsToString,
@@ -21,6 +21,28 @@ import MaterialType from "../../core/utils/types/material-type";
 
 export const getLatestWorkManifestation = (work: Work) => {
   return work.manifestations.latest as Manifestation;
+};
+
+export const getManifestationsOrderByTypeAndYear = (
+  manifestations: Manifestation[]
+) => {
+  const orderedByYear = orderManifestationsByYear(manifestations);
+
+  const materialsMappedBytype = groupBy(
+    orderedByYear,
+    "materialTypes[0].specific"
+  );
+
+  return (
+    Object.keys(materialsMappedBytype)
+      // Sort the material types alphabetically.
+      .sort()
+      // Create a new array by iterating over the sorted keys and
+      // combining the materials from each type into a single array.
+      .reduce<Manifestation[]>((acc, key) => {
+        return [...acc, ...materialsMappedBytype[key]];
+      }, [])
+  );
 };
 
 export const filterManifestationsByType = (

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -26,7 +26,8 @@ import {
   getWorkDescriptionListData,
   getInfomediaIds,
   divideManifestationsByMaterialType,
-  getBestMaterialTypeForWork
+  getBestMaterialTypeForWork,
+  getManifestationsOrderByTypeAndYear
 } from "./helper";
 import FindOnShelfModal from "../../components/find-on-shelf/FindOnShelfModal";
 import { Manifestation, Work } from "../../core/utils/types/entities";
@@ -58,6 +59,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const { data, isLoading } = useGetMaterialQuery({
     wid
   });
+
   const { track } = useStatistics();
   useDeepCompareEffect(() => {
     if (data?.work?.genreAndForm) {
@@ -174,19 +176,19 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         disclosureIconExpandAltText=""
         dataCy="material-editions-disclosure"
       >
-        {manifestations
-          .sort((a, b) =>
-            a.materialTypes[0].specific > b.materialTypes[0].specific ? 1 : -1
-          )
-          .map((manifestation: Manifestation) => {
-            return (
-              <MaterialMainfestationItem
-                key={manifestation.pid}
-                manifestation={manifestation}
-                workId={wid}
-              />
-            );
-          })}
+        <>
+          {getManifestationsOrderByTypeAndYear(manifestations).map(
+            (manifestation: Manifestation) => {
+              return (
+                <MaterialMainfestationItem
+                  key={manifestation.pid}
+                  manifestation={manifestation}
+                  workId={wid}
+                />
+              );
+            }
+          )}
+        </>
       </Disclosure>
       <Disclosure
         mainIconPath={Receipt}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-31

#### This pull request adds a new function getManifestationsOrderByTypeAndYear that sorts an array of Manifestation objects by year and material type.

- Added a new function getManifestationsOrderByTypeAndYear that takes an array of Manifestation objects as an argument.
- Used two helper functions, orderManifestationsByYear and groupBy, to sort the array of Manifestation objects.
- Returned a new array with the sorted Manifestation objects.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/49920322/215472049-9a3c40fc-37d1-4d56-9a96-6ba7a81d1504.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
