### PR TITLE
Fix text mistakes

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -605,7 +605,7 @@ export default {
     materialIsAvailableInAnotherEditionText: {
       name: "Skip queue material is available in another edition",
       defaultValue:
-        '{"type":"plural","text":["Skip the queue - The material is available in another edition - @title @authorAndYear - reservations: @reservation","Skip the queue - The material is available in another edition - @title @authorAndYear - reservations: @reservations"]}',
+        "Skip the queue - The material is available in another edition - @title @authorAndYear - reservations: @reservations",
       control: { type: "text" }
     }
   }

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -253,7 +253,7 @@ export default {
     materialsInStockInfoText: {
       name: "Materials in stock info text",
       defaultValue:
-        '{"type":"plural","text":["We have 1 copy of the material in stock. ","We have @count copies of the material in stock. "]}',
+        '{"type":"plural","text":["We have 1 copy of the material in stock. ","We have @count copies of the material in stock."]}',
       control: { type: "text" }
     },
     materialReservationInfoText: {
@@ -427,7 +427,7 @@ export default {
     },
     numberInQueueText: {
       name: "Number in queue text",
-      defaultValue: "You are number @number in the queue. ",
+      defaultValue: "You are number @number in the queue.",
       control: { type: "text" }
     },
     alreadyReservedText: {

--- a/src/components/material/StockAndReservationInfo.tsx
+++ b/src/components/material/StockAndReservationInfo.tsx
@@ -31,8 +31,8 @@ const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
 
   return (
     <>
-      {numberInQueueText && numberInQueueText}
-      {materialsInStockInfoText && materialsInStockInfoText}
+      {numberInQueueText && `${numberInQueueText} `}
+      {materialsInStockInfoText && `${materialsInStockInfoText} `}
       {materialReservationInfoText && materialReservationInfoText}
     </>
   );

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -197,7 +197,6 @@ export const ReservationModalBody = ({
                   sticky
                   type="info"
                   text={t("materialIsAvailableInAnotherEditionText", {
-                    count: otherManifestationPreferred.reservations,
                     placeholders: {
                       "@title": otherManifestationPreferred.titles.main[0],
                       "@authorAndYear":


### PR DESCRIPTION
#### Link to issue

#### This pull request contains two changes:

- Removal of an unnecessary plural translation in the PromoBar inside ReservationModalBody.

- Addition of space in the StockAndReservationInfo component. The space has been added to the code instead of being written in the CMS for better maintainability.

#### Screenshot of the result
![Skærmbillede 2023-01-30 kl  13 35 02](https://user-images.githubusercontent.com/49920322/215478745-5d6ba2a4-3efe-45d8-8ce1-74754cbe0d6a.png)
![Skærmbillede 2023-01-30 kl  13 35 16](https://user-images.githubusercontent.com/49920322/215478770-fb2fc6e7-4c30-4db3-8578-786425106795.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.