### PR TITLE
fix/intermediate-list-fixing-duplicate-pay-btn

### DIFF
--- a/src/apps/intermediate-list/stackable-fees/total-payment-pay.tsx
+++ b/src/apps/intermediate-list/stackable-fees/total-payment-pay.tsx
@@ -36,7 +36,8 @@ const TotalPaymentPay: FC<TotalPaymentPayProps> = ({
   const checkboxTermsId = `checkbox_terms__${
     (prePaymentTypeChange && "prepaymentchange") || "postpaymentchange"
   }`;
-
+  const postPaymentChangeNotChecked = !prePaymentTypeChange && !check;
+  const postPaymentChangeChecked = !prePaymentTypeChange && check;
   return (
     <div className="intermediate-list-bottom">
       <div className="intermediate-list-bottom__paymenttypes">
@@ -67,7 +68,7 @@ const TotalPaymentPay: FC<TotalPaymentPayProps> = ({
             </>
           }
         />
-        {!prePaymentTypeChange && !check && (
+        {(postPaymentChangeNotChecked || prePaymentTypeChange) && (
           <button
             type="button"
             className={paymentButtonClass}
@@ -79,7 +80,7 @@ const TotalPaymentPay: FC<TotalPaymentPayProps> = ({
             {t("payText")}
           </button>
         )}
-        {!prePaymentTypeChange && check && (
+        {postPaymentChangeChecked && (
           <button
             type="button"
             className="btn-primary btn-filled btn-small arrow__hover--right-small mt-16"

--- a/src/apps/intermediate-list/stackable-fees/total-payment-pay.tsx
+++ b/src/apps/intermediate-list/stackable-fees/total-payment-pay.tsx
@@ -67,14 +67,18 @@ const TotalPaymentPay: FC<TotalPaymentPayProps> = ({
             </>
           }
         />
-        <button
-          type="button"
-          className={paymentButtonClass}
-          onClick={showPaymentButton ? openIntermediatePaymentModal : undefined}
-          disabled={!showPaymentButton}
-        >
-          {t("payText")}
-        </button>
+        {!prePaymentTypeChange && !check && (
+          <button
+            type="button"
+            className={paymentButtonClass}
+            onClick={
+              showPaymentButton ? openIntermediatePaymentModal : undefined
+            }
+            disabled={!showPaymentButton}
+          >
+            {t("payText")}
+          </button>
+        )}
         {!prePaymentTypeChange && check && (
           <button
             type="button"


### PR DESCRIPTION
#### Link to issue

Bugfix for https://platform.dandigbib.org/issues/5391

#### Description

Modifies the conditional rendering of payment button in the intermediate list, to fix a bug causing the button to be displayed twice under certain circumstances.

#### Screenshot of the result

Before:
<img width="1265" alt="Screenshot 2023-01-30 at 14 36 43" src="https://user-images.githubusercontent.com/106669866/215492328-0764a5f6-f846-4454-8486-10c076f8176d.png">

After:
<img width="1259" alt="Screenshot 2023-01-30 at 14 36 19" src="https://user-images.githubusercontent.com/106669866/215492318-e9945303-7e87-493b-82e0-f42ed3bb1c43.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
