### PR TITLE
Fix/release date

### DIFF
--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -16,7 +16,7 @@ export const allFacetFields = [
   FacetField.ChildrenOrAdults,
   FacetField.Creators,
   FacetField.FictionNonfiction,
-  FacetField.FictionalCharacter,
+  FacetField.FictionalCharacters,
   FacetField.GenreAndForm,
   FacetField.MaterialTypes,
   FacetField.Subjects,

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -143,7 +143,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
           <Link href={materialFullUrl}>{fullTitle}</Link>
         </h2>
 
-        {author && (
+        {author && item && (
           <p className="text-small-caption" data-cy="search-result-item-author">
             {`${t("byAuthorText")} ${author}`}
             {getReleaseYear(item) ? ` (${getReleaseYear(item)})` : ""}

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -13,7 +13,8 @@ import {
   creatorsToString,
   filterCreators,
   flattenCreators,
-  getManifestationPid
+  getManifestationPid,
+  getReleaseYear
 } from "../../../core/utils/helpers/general";
 import SearchResultListItemCover from "./search-result-list-item-cover";
 import HorizontalTermLine from "../../horizontal-term-line/HorizontalTermLine";
@@ -37,13 +38,13 @@ export interface SearchResultListItemProps {
 }
 
 const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
+  item,
   item: {
     titles: { full: fullTitle },
     series,
     creators,
     manifestations: { all: manifestations },
-    workId,
-    workYear
+    workId
   },
   coverTint,
   resultNumber
@@ -145,7 +146,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         {author && (
           <p className="text-small-caption" data-cy="search-result-item-author">
             {`${t("byAuthorText")} ${author}`}
-            {workYear && ` (${workYear.year})`}
+            {getReleaseYear(item) ? ` (${getReleaseYear(item)})` : ""}
           </p>
         )}
       </div>

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -14,7 +14,7 @@ import {
   filterCreators,
   flattenCreators,
   getManifestationPid,
-  getReleaseYear
+  getReleaseYearSearchResult
 } from "../../../core/utils/helpers/general";
 import SearchResultListItemCover from "./search-result-list-item-cover";
 import HorizontalTermLine from "../../horizontal-term-line/HorizontalTermLine";
@@ -146,7 +146,9 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         {author && item && (
           <p className="text-small-caption" data-cy="search-result-item-author">
             {`${t("byAuthorText")} ${author}`}
-            {getReleaseYear(item) ? ` (${getReleaseYear(item)})` : ""}
+            {getReleaseYearSearchResult(item)
+              ? ` (${getReleaseYearSearchResult(item)})`
+              : ""}
           </p>
         )}
       </div>

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -47,6 +47,10 @@ fragment ManifestationsSimpleFields on Manifestation {
       display
     }
   }
+  dateFirstEdition {
+    display
+    year
+  }
   audience {
     generalAudience
   }

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -1917,7 +1917,7 @@
             "deprecationReason": null
           },
           {
-            "name": "fictionalCharacter",
+            "name": "fictionalCharacters",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -7165,6 +7165,18 @@
             "deprecationReason": null
           },
           {
+            "name": "contentSubstitute",
+            "description": "This is a paragraph containing markup where links to manifestations\ncan be inserted. For instance '\"Axel Steens nye job minder om [870970-basis:20307021] fra ...'.\nRelevant manifestations are located in the manifestations field. ",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "heading",
             "description": null,
             "args": [],
@@ -7178,7 +7190,7 @@
           },
           {
             "name": "manifestations",
-            "description": null,
+            "description": "Manifestations that can be used to generate and insert links into 'contentSubsitute'.",
             "args": [],
             "type": {
               "kind": "LIST",
@@ -7519,7 +7531,7 @@
             "deprecationReason": null
           },
           {
-            "name": "fictionalCharacter",
+            "name": "fictionalCharacters",
             "description": null,
             "type": {
               "kind": "LIST",

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -303,7 +303,7 @@ export enum FacetField {
   ChildrenOrAdults = "childrenOrAdults",
   Creators = "creators",
   FictionNonfiction = "fictionNonfiction",
-  FictionalCharacter = "fictionalCharacter",
+  FictionalCharacters = "fictionalCharacters",
   GenreAndForm = "genreAndForm",
   MainLanguages = "mainLanguages",
   MaterialTypes = "materialTypes",
@@ -1014,7 +1014,14 @@ export type Review = {
 export type ReviewElement = {
   __typename?: "ReviewElement";
   content?: Maybe<Scalars["String"]>;
+  /**
+   * This is a paragraph containing markup where links to manifestations
+   * can be inserted. For instance '"Axel Steens nye job minder om [870970-basis:20307021] fra ...'.
+   * Relevant manifestations are located in the manifestations field.
+   */
+  contentSubstitute?: Maybe<Scalars["String"]>;
   heading?: Maybe<Scalars["String"]>;
+  /** Manifestations that can be used to generate and insert links into 'contentSubsitute'. */
   manifestations?: Maybe<Array<Maybe<Manifestation>>>;
   type?: Maybe<ReviewElementType>;
 };
@@ -1057,7 +1064,7 @@ export type SearchFilters = {
   creators?: InputMaybe<Array<Scalars["String"]>>;
   department?: InputMaybe<Array<Scalars["String"]>>;
   fictionNonfiction?: InputMaybe<Array<Scalars["String"]>>;
-  fictionalCharacter?: InputMaybe<Array<Scalars["String"]>>;
+  fictionalCharacters?: InputMaybe<Array<Scalars["String"]>>;
   genreAndForm?: InputMaybe<Array<Scalars["String"]>>;
   location?: InputMaybe<Array<Scalars["String"]>>;
   mainLanguages?: InputMaybe<Array<Scalars["String"]>>;
@@ -1481,6 +1488,11 @@ export type GetMaterialQuery = {
             display: string;
           } | null;
         } | null;
+        dateFirstEdition?: {
+          __typename?: "PublicationYear";
+          display: string;
+          year?: number | null;
+        } | null;
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
@@ -1556,6 +1568,11 @@ export type GetMaterialQuery = {
             display: string;
           } | null;
         } | null;
+        dateFirstEdition?: {
+          __typename?: "PublicationYear";
+          display: string;
+          year?: number | null;
+        } | null;
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
@@ -1630,6 +1647,11 @@ export type GetMaterialQuery = {
             __typename?: "PublicationYear";
             display: string;
           } | null;
+        } | null;
+        dateFirstEdition?: {
+          __typename?: "PublicationYear";
+          display: string;
+          year?: number | null;
         } | null;
         audience?: {
           __typename?: "Audience";
@@ -1784,6 +1806,11 @@ export type SearchWithPaginationQuery = {
               display: string;
             } | null;
           } | null;
+          dateFirstEdition?: {
+            __typename?: "PublicationYear";
+            display: string;
+            year?: number | null;
+          } | null;
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
@@ -1865,6 +1892,11 @@ export type SearchWithPaginationQuery = {
               display: string;
             } | null;
           } | null;
+          dateFirstEdition?: {
+            __typename?: "PublicationYear";
+            display: string;
+            year?: number | null;
+          } | null;
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
@@ -1945,6 +1977,11 @@ export type SearchWithPaginationQuery = {
               __typename?: "PublicationYear";
               display: string;
             } | null;
+          } | null;
+          dateFirstEdition?: {
+            __typename?: "PublicationYear";
+            display: string;
+            year?: number | null;
           } | null;
           audience?: {
             __typename?: "Audience";
@@ -2108,6 +2145,11 @@ export type ManifestationsSimpleFragment = {
         display: string;
       } | null;
     } | null;
+    dateFirstEdition?: {
+      __typename?: "PublicationYear";
+      display: string;
+      year?: number | null;
+    } | null;
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
@@ -2180,6 +2222,11 @@ export type ManifestationsSimpleFragment = {
         display: string;
       } | null;
     } | null;
+    dateFirstEdition?: {
+      __typename?: "PublicationYear";
+      display: string;
+      year?: number | null;
+    } | null;
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
@@ -2251,6 +2298,11 @@ export type ManifestationsSimpleFragment = {
         __typename?: "PublicationYear";
         display: string;
       } | null;
+    } | null;
+    dateFirstEdition?: {
+      __typename?: "PublicationYear";
+      display: string;
+      year?: number | null;
     } | null;
     audience?: {
       __typename?: "Audience";
@@ -2325,6 +2377,11 @@ export type ManifestationsSimpleFieldsFragment = {
       __typename?: "PublicationYear";
       display: string;
     } | null;
+  } | null;
+  dateFirstEdition?: {
+    __typename?: "PublicationYear";
+    display: string;
+    year?: number | null;
   } | null;
   audience?: { __typename?: "Audience"; generalAudience: Array<string> } | null;
   physicalDescriptions: Array<{
@@ -2448,6 +2505,11 @@ export type WorkSmallFragment = {
           display: string;
         } | null;
       } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2523,6 +2585,11 @@ export type WorkSmallFragment = {
           display: string;
         } | null;
       } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2597,6 +2664,11 @@ export type WorkSmallFragment = {
           __typename?: "PublicationYear";
           display: string;
         } | null;
+      } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
       } | null;
       audience?: {
         __typename?: "Audience";
@@ -2764,6 +2836,11 @@ export type WorkMediumFragment = {
           display: string;
         } | null;
       } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2839,6 +2916,11 @@ export type WorkMediumFragment = {
           display: string;
         } | null;
       } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
+      } | null;
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
@@ -2913,6 +2995,11 @@ export type WorkMediumFragment = {
           __typename?: "PublicationYear";
           display: string;
         } | null;
+      } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
       } | null;
       audience?: {
         __typename?: "Audience";
@@ -3003,6 +3090,10 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
     publicationYear {
       display
     }
+  }
+  dateFirstEdition {
+    display
+    year
   }
   audience {
     generalAudience

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -348,27 +348,24 @@ export const constructModalId = (prefix: string, fragments: string[]) =>
   `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
 
 export const getReleaseYear = (work: Work) => {
-  const existsOnWork = work.fictionNonfiction;
   const { latest, bestRepresentation } = work.manifestations;
-  switch (
-    materialIsFiction(existsOnWork ? work : bestRepresentation || latest)
-  ) {
-    case true:
-      return (
-        work.workYear?.year ||
-        bestRepresentation.dateFirstEdition?.display ||
-        bestRepresentation.dateFirstEdition?.year ||
-        null
-      );
-    case false:
-      return (
-        latest.edition?.publicationYear?.display ||
-        latest.workYear?.year ||
-        null
-      );
-    default:
-      return null;
+  const manifestation = bestRepresentation || latest;
+
+  // If the work tells us that it is fiction.
+  if (materialIsFiction(work)) {
+    return work.workYear?.year;
   }
+  // If the manifestation tells us that it is fiction.
+  if (materialIsFiction(manifestation)) {
+    return (
+      manifestation.dateFirstEdition?.display ||
+      manifestation.dateFirstEdition?.year
+    );
+  }
+  // If it isn't fiction we get release year from latest manifestation.
+  return (
+    latest.edition?.publicationYear?.display || latest.workYear?.year || null
+  );
 };
 
 export default {};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -345,4 +345,26 @@ export const dataIsNotEmpty = (data: unknown[]) => Boolean(data.length);
 export const constructModalId = (prefix: string, fragments: string[]) =>
   `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
 
+export const getReleaseYear = (work: Work) => {
+  const existsOnWork = work.fictionNonfiction;
+  const { latest, bestRepresentation } = work.manifestations;
+  switch (materialIsFiction(existsOnWork ? work : bestRepresentation)) {
+    case true:
+      return (
+        work.workYear?.year ||
+        bestRepresentation.dateFirstEdition?.display ||
+        bestRepresentation.dateFirstEdition?.year ||
+        null
+      );
+    case false:
+      return (
+        latest.edition?.publicationYear?.display ||
+        latest.workYear?.year ||
+        null
+      );
+    default:
+      return null;
+  }
+};
+
 export default {};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -348,7 +348,9 @@ export const constructModalId = (prefix: string, fragments: string[]) =>
 export const getReleaseYear = (work: Work) => {
   const existsOnWork = work.fictionNonfiction;
   const { latest, bestRepresentation } = work.manifestations;
-  switch (materialIsFiction(existsOnWork ? work : bestRepresentation)) {
+  switch (
+    materialIsFiction(existsOnWork ? work : bestRepresentation || latest)
+  ) {
     case true:
       return (
         work.workYear?.year ||

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -347,10 +347,11 @@ export const dataIsNotEmpty = (data: unknown[]) => Boolean(data.length);
 export const constructModalId = (prefix: string, fragments: string[]) =>
   `${prefix ? `${prefix}-` : ""}${fragments.join("-")}`;
 
-export const getReleaseYear = (work: Work) => {
+// The rendered release year for search results is picked based on
+// whether the work is fiction or not.
+export const getReleaseYearSearchResult = (work: Work) => {
   const { latest, bestRepresentation } = work.manifestations;
   const manifestation = bestRepresentation || latest;
-
   // If the work tells us that it is fiction.
   if (materialIsFiction(work)) {
     return work.workYear?.year;
@@ -363,9 +364,7 @@ export const getReleaseYear = (work: Work) => {
     );
   }
   // If it isn't fiction we get release year from latest manifestation.
-  return (
-    latest.edition?.publicationYear?.display || latest.workYear?.year || null
-  );
+  return getManifestationPublicationYear(latest) || latest.workYear?.year;
 };
 
 export default {};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -247,8 +247,10 @@ export const groupObjectArrayByProperty = <
 export const getManifestationsPids = (manifestations: Manifestation[]) => {
   return manifestations.map((manifestation) => manifestation.pid);
 };
+
 export const stringifyValue = (value: string | null | undefined) =>
   value ? String(value) : "";
+
 export const materialIsFiction = ({
   fictionNonfiction
 }: Work | Manifestation) => fictionNonfiction?.code === "FICTION";


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-404

#### Description
This PR corrects the way we determine release year for search result items. Doing that also required updating our "manifestation simple fields" fragment (graphQL).

#### Screenshot of the result
before:
![image](https://user-images.githubusercontent.com/28546954/216301890-f661e773-489e-4b86-876e-24db19b24905.png)

after:
![image](https://user-images.githubusercontent.com/28546954/216301981-ecbb8ecd-b176-456d-ac34-6b00f76d528e.png)

#### Checklist
- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a