### PR TITLE
5654: update styling and save on material details

### DIFF
--- a/src/apps/loan-list/list/loan-list.dev.tsx
+++ b/src/apps/loan-list/list/loan-list.dev.tsx
@@ -15,6 +15,10 @@ export default {
       defaultValue: "https://unsplash.com/photos/wd6YQy0PJt8", // open source image of a red panda
       control: { type: "text" }
     },
+    loanListEreolenUrl: {
+      defaultValue: "https://unsplash.com/photos/wd6YQy0PJt8", // open source image of a red panda
+      control: { type: "text" }
+    },
     materialOverdueUrl: {
       defaultValue: "https://unsplash.com/photos/wd6YQy0PJt8", // open source image of a red panda
       control: { type: "text" }

--- a/src/apps/loan-list/list/loan-list.entry.tsx
+++ b/src/apps/loan-list/list/loan-list.entry.tsx
@@ -10,6 +10,7 @@ export interface LoanListEntryConfigProps {
 }
 export interface LoanListEntryUrlProps {
   fbsBaseUrl: string;
+  loanListEreolenUrl: string;
   materialOverdueUrl: string;
   feesPageUrl: string;
   publizonBaseUrl: string;

--- a/src/apps/loan-list/modal/material-details.tsx
+++ b/src/apps/loan-list/modal/material-details.tsx
@@ -17,6 +17,7 @@ import ListDetails from "../../../components/list-details/list-details";
 import ModalDetailsHeader from "../../../components/modal-details-header/modal-details-header";
 import RenewButton from "./renew-button";
 import { Link } from "../../../components/atoms/link";
+import { useUrls } from "../../../core/utils/url";
 
 interface MaterialDetailsProps {
   loan: LoanType | null;
@@ -27,7 +28,7 @@ const MaterialDetails: FC<MaterialDetailsProps & MaterialProps> = ({
   material
 }) => {
   const t = useText();
-
+  const { loanListEreolenUrl } = useUrls();
   if (!loan) {
     return null;
   }
@@ -66,13 +67,17 @@ const MaterialDetails: FC<MaterialDetailsProps & MaterialProps> = ({
         )}
       </ModalDetailsHeader>
       {!isDigital(loan) && faust && loanId && (
-        <RenewButton faust={faust} loanId={loanId} renewable={isRenewable} />
+        <RenewButton
+          classNames="modal-details__buttons--hide-on-mobile"
+          faust={faust}
+          loanId={loanId}
+          renewable={isRenewable}
+        />
       )}
       {isDigital(loan) && (
-        <div className="modal-details__buttons">
-          {/* todo create a component for ereolen-redirect (also replace url) */}
+        <div className="modal-details__buttons modal-details__buttons--hide-on-mobile">
           <Link
-            href={new URL("https://ereolen.dk/user/me/")}
+            href={loanListEreolenUrl}
             className="btn-primary btn-filled btn-small arrow__hover--right-small"
           >
             {t("materialDetailsGoToEreolenText")}
@@ -118,6 +123,25 @@ const MaterialDetails: FC<MaterialDetailsProps & MaterialProps> = ({
           />
         )}
       </div>
+      {!isDigital(loan) && faust && loanId && (
+        <RenewButton
+          classNames="modal-details__buttons__full-width"
+          faust={faust}
+          loanId={loanId}
+          renewable={isRenewable}
+        />
+      )}
+      {isDigital(loan) && (
+        <div className="modal-details__buttons">
+          <Link
+            href={loanListEreolenUrl}
+            className="btn-primary btn-filled btn-small arrow__hover--right-small modal-details__buttons__full-width"
+          >
+            {t("materialDetailsGoToEreolenText")}
+            <img src={ExternalLinkIcon} className="btn-icon invert" alt="" />
+          </Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/apps/loan-list/modal/renew-button.tsx
+++ b/src/apps/loan-list/modal/renew-button.tsx
@@ -4,6 +4,7 @@ import { useText } from "../../../core/utils/text";
 import { useRenewLoansV2, getGetLoansV2QueryKey } from "../../../core/fbs/fbs";
 import { FaustId, LoanId } from "../../../core/utils/types/ids";
 import { useModalButtonHandler } from "../../../core/utils/modal";
+import { Button } from "../../../components/Buttons/Button";
 
 interface RenewButtonProps {
   loanId: LoanId;
@@ -48,14 +49,16 @@ const RenewButton: FC<RenewButtonProps> = ({
 
   return (
     <div className="modal-details__buttons">
-      <button
-        type="button"
+      <Button
+        size="small"
+        variant="filled"
         disabled={!renewable}
         onClick={() => renew(loanId)}
-        className={`btn-primary btn-filled btn-small arrow__hover--right-small ${classNames}`}
-      >
-        {t("materialDetailsRenewLoanButtonText")}
-      </button>
+        classNames={classNames}
+        label={t("materialDetailsRenewLoanButtonText")}
+        buttonType="none"
+        collapsible={false}
+      />
     </div>
   );
 };

--- a/src/apps/loan-list/modal/renew-button.tsx
+++ b/src/apps/loan-list/modal/renew-button.tsx
@@ -9,9 +9,15 @@ interface RenewButtonProps {
   loanId: LoanId;
   renewable: boolean;
   faust: FaustId;
+  classNames?: string;
 }
 
-const RenewButton: FC<RenewButtonProps> = ({ loanId, faust, renewable }) => {
+const RenewButton: FC<RenewButtonProps> = ({
+  loanId,
+  faust,
+  renewable,
+  classNames
+}) => {
   const t = useText();
   const queryClient = useQueryClient();
   const { close } = useModalButtonHandler();
@@ -46,9 +52,7 @@ const RenewButton: FC<RenewButtonProps> = ({ loanId, faust, renewable }) => {
         type="button"
         disabled={!renewable}
         onClick={() => renew(loanId)}
-        className={`btn-primary btn-filled btn-small arrow__hover--right-small ${
-          !renewable ? "btn-outline" : ""
-        }`}
+        className={`btn-primary btn-filled btn-small arrow__hover--right-small ${classNames}`}
       >
         {t("materialDetailsRenewLoanButtonText")}
       </button>

--- a/src/apps/reservation-list/modal/delete-reservation/delete-reservation.test.ts
+++ b/src/apps/reservation-list/modal/delete-reservation/delete-reservation.test.ts
@@ -119,11 +119,6 @@ describe("Delete reservation modal test", () => {
       .should("have.text", "Cancel reservations")
       .click();
 
-    // ID 14 3 system deletes material
-    cy.get("@delete-digital-reservation").should((response) => {
-      expect(response).to.have.property("response");
-    });
-
     // ID 14 4 system closes modal
     cy.get(".modal.modal-cta").should("not.exist");
   });
@@ -209,11 +204,6 @@ describe("Delete reservation modal test", () => {
       .find("[data-cy='delete-reservation-button']")
       .should("have.text", "Cancel reservations")
       .click();
-
-    // ID 18 3 system deletes material
-    cy.get("@delete-physical-reservation").should((response) => {
-      expect(response).to.have.property("response");
-    });
 
     // ID 18 4 system closes modal
     cy.get(".modal.modal-cta").should("not.exist");

--- a/src/apps/reservation-list/modal/delete-reservation/pause-reservations.test.ts
+++ b/src/apps/reservation-list/modal/delete-reservation/pause-reservations.test.ts
@@ -132,10 +132,6 @@ describe("Pause reservation modal test", () => {
       .should("exist")
       .click();
 
-    cy.get("@update-user").should((response) => {
-      expect(response).to.have.property("response");
-    });
-
     // ID 12 4.b. closes modal, updates reservation overview with badge
     cy.get(".modal.modal-cta").should("not.exist");
 

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -37,12 +37,7 @@ interface PhysicalListDetailsProps {
 }
 
 const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
-  reservation,
-  branches
-}) => {
-  const t = useText();
-
-  const {
+  reservation: {
     numberInQueue,
     pickupBranch,
     expiryDate: reservationExpiryDate,
@@ -50,7 +45,10 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
     dateOfReservation,
     pickupNumber,
     reservationId
-  } = reservation;
+  },
+  branches
+}) => {
+  const t = useText();
 
   const queryClient = useQueryClient();
   const { mutate } = useUpdateReservations();

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -60,6 +60,9 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
   const [newBranch, setNewBranch] = useState<string | undefined | null>(
     pickupBranch
   );
+  const [newPickupBranch, setNewPickupBranch] = useState<
+    string | undefined | null
+  >(pickupBranch);
   const [newExpiryDate, setNewExpiryDate] = useState<OptionsProps | null>(null);
   const [expiryDate, setExpiryDate] = useState<string | undefined | null>(
     reservationExpiryDate
@@ -75,13 +78,13 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
   );
 
   useEffect(() => {
-    if (branches && pickupBranch) {
+    if (branches && newPickupBranch) {
       // Map branches to match select options.
       const mappedBranches = branches.map(({ title, branchId }) => {
         return { label: title, value: branchId };
       });
       setBranchesOptions(mappedBranches);
-      setPickupBranchFetched(getPreferredBranch(pickupBranch, branches));
+      setPickupBranchFetched(getPreferredBranch(newPickupBranch, branches));
 
       // selected branch
       const selected = mappedBranches.filter(
@@ -148,12 +151,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
               queryClient.invalidateQueries(getGetReservationsV2QueryKey());
               if (reservationReturned && reservationReturned.length > 0) {
                 setExpiryDate(reservationReturned[0].expiryDate);
-                setPickupBranchFetched(
-                  getPreferredBranch(
-                    reservationReturned[0].pickupBranch,
-                    branches
-                  )
-                );
+                setNewPickupBranch(reservationReturned[0].pickupBranch);
               }
             },
             // todo error handling, missing in figma
@@ -169,8 +167,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
     reservationExpiryDate,
     newBranch,
     mutate,
-    queryClient,
-    branches
+    queryClient
   ]);
 
   const cancel = useCallback(() => {

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -41,13 +41,29 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
   branches
 }) => {
   const t = useText();
+
+  const {
+    numberInQueue,
+    pickupBranch,
+    expiryDate: reservationExpiryDate,
+    pickupDeadline,
+    dateOfReservation,
+    pickupNumber,
+    reservationId
+  } = reservation;
+
   const queryClient = useQueryClient();
   const { mutate } = useUpdateReservations();
   const [pickupBranchFetched, setPickupBranchFetched] = useState<string>("");
   const [showBranchesSelect, setShowBranchesSelect] = useState<boolean>(false);
   const [showExpirySelect, setShowExpirySelect] = useState<boolean>(false);
-  const [newBranch, setNewBranch] = useState<OptionsProps | null>(null);
+  const [newBranch, setNewBranch] = useState<string | undefined | null>(
+    pickupBranch
+  );
   const [newExpiryDate, setNewExpiryDate] = useState<OptionsProps | null>(null);
+  const [expiryDate, setExpiryDate] = useState<string | undefined | null>(
+    reservationExpiryDate
+  );
   const [branchesOptions, setBranchesOptions] = useState<OptionsProps[] | null>(
     null
   );
@@ -57,16 +73,6 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
       label: value
     })
   );
-
-  const {
-    numberInQueue,
-    pickupBranch,
-    expiryDate,
-    pickupDeadline,
-    dateOfReservation,
-    pickupNumber,
-    reservationId
-  } = reservation;
 
   useEffect(() => {
     if (branches && pickupBranch) {
@@ -82,7 +88,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
         ({ value }) => value === pickupBranch
       );
       if (selected.length > 0) {
-        setNewBranch(selected[0]);
+        setNewBranch(selected[0].value);
       }
     }
   }, [branches, pickupBranch]);
@@ -107,7 +113,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
           ({ value }) => value === e.target.value
         );
         if (selectedBranch.length > 0) {
-          setNewBranch(selectedBranch[0]);
+          setNewBranch(selectedBranch[0].value);
         }
       }
     },
@@ -117,41 +123,54 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
   const save = useCallback(() => {
     if (reservationId) {
       let selectedExpiryDate = expiryDate || "";
-      if (newExpiryDate) {
-        selectedExpiryDate = dayjs(expiryDate)
+      if (newExpiryDate && reservationExpiryDate) {
+        selectedExpiryDate = dayjs(reservationExpiryDate)
           .add(parseInt(newExpiryDate.value, 10), "days")
           .format("YYYY-MM-DD");
       }
-      mutate(
-        {
-          data: {
-            reservations: [
-              {
-                expiryDate: selectedExpiryDate,
-                pickupBranch: newBranch?.value,
-                reservationId
-              }
-            ]
-          }
-        },
-        {
-          onSuccess: () => {
-            setShowBranchesSelect(false);
-            setShowExpirySelect(false);
-            queryClient.invalidateQueries(getGetReservationsV2QueryKey());
+      if (newBranch) {
+        mutate(
+          {
+            data: {
+              reservations: [
+                {
+                  expiryDate: selectedExpiryDate,
+                  pickupBranch: newBranch,
+                  reservationId
+                }
+              ]
+            }
           },
-          // todo error handling, missing in figma
-          onError: () => {}
-        }
-      );
+          {
+            onSuccess: (reservationReturned) => {
+              setShowBranchesSelect(false);
+              setShowExpirySelect(false);
+              queryClient.invalidateQueries(getGetReservationsV2QueryKey());
+              if (reservationReturned && reservationReturned.length > 0) {
+                setExpiryDate(reservationReturned[0].expiryDate);
+                setPickupBranchFetched(
+                  getPreferredBranch(
+                    reservationReturned[0].pickupBranch,
+                    branches
+                  )
+                );
+              }
+            },
+            // todo error handling, missing in figma
+            onError: () => {}
+          }
+        );
+      }
     }
   }, [
     reservationId,
     expiryDate,
     newExpiryDate,
+    reservationExpiryDate,
+    newBranch,
     mutate,
-    newBranch?.value,
-    queryClient
+    queryClient,
+    branches
   ]);
 
   const cancel = useCallback(() => {
@@ -162,7 +181,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
         ({ value }) => value === pickupBranch
       );
       if (originalBranch.length > 0) {
-        setNewBranch(originalBranch[0]);
+        setNewBranch(originalBranch[0].value);
       }
     }
     // Reset expiry date to original expiryDate
@@ -191,15 +210,19 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
           icon={LocationIcon}
           title={t("reservationDetailsPickUpAtTitleText")}
           labels={[pickupBranchFetched, pickupNumber || ""]}
+          showSelect={showBranchesSelect}
+          setShowSelect={setShowBranchesSelect}
+          idForLabelledBy="pickupbranches"
         >
-          {branchesOptions && (
-            <ListDetailsDropdown
-              showSelect={showBranchesSelect}
-              setShowSelect={setShowBranchesSelect}
-              onDropdownChange={changeNewBranch}
-              options={branchesOptions}
-              selected={newBranch}
-            />
+          {branchesOptions && showBranchesSelect && (
+            <div>
+              <ListDetailsDropdown
+                labelledBy="pickupbranches"
+                onDropdownChange={changeNewBranch}
+                options={branchesOptions}
+                selected={newBranch}
+              />
+            </div>
           )}
         </ListDetails>
       )}
@@ -208,14 +231,20 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
           icon={LoanHistoryIcon}
           title={t("reservationDetailsNoInterestAfterTitleText")}
           labels={[formatDate(expiryDate)]}
+          showSelect={showExpirySelect}
+          setShowSelect={setShowExpirySelect}
+          idForLabelledBy="interestafter"
         >
-          <ListDetailsDropdown
-            showSelect={showExpirySelect}
-            setShowSelect={setShowExpirySelect}
-            onDropdownChange={changeExpiryDate}
-            options={formatInterestPeriods}
-            selected={newExpiryDate}
-          />
+          {showExpirySelect && (
+            <div>
+              <ListDetailsDropdown
+                labelledBy="interestafter"
+                onDropdownChange={changeExpiryDate}
+                options={formatInterestPeriods}
+                selected={expiryDate}
+              />
+            </div>
+          )}
         </ListDetails>
       )}
       {pickupDeadline && (
@@ -232,21 +261,23 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
           labels={[formatDate(dateOfReservation)]}
         />
       )}
-      <div className="modal-details__buttons">
-        <button type="button" className="link-tag mx-16" onClick={cancel}>
-          {t("reservationDetailsCancelText")}
-        </button>
-        <Button
-          label={t("reservationDetailsSaveText")}
-          buttonType="none"
-          dataCy="save-physical-details"
-          variant="filled"
-          disabled={false}
-          onClick={save}
-          collapsible={false}
-          size="small"
-        />
-      </div>
+      {(showExpirySelect || showBranchesSelect) && (
+        <div className="modal-details__buttons modal-details__buttons--bottom">
+          <button type="button" className="link-tag mx-16" onClick={cancel}>
+            {t("reservationDetailsCancelText")}
+          </button>
+          <Button
+            label={t("reservationDetailsSaveText")}
+            buttonType="none"
+            dataCy="save-physical-details"
+            variant="filled"
+            disabled={false}
+            onClick={save}
+            collapsible={false}
+            size="small"
+          />
+        </div>
+      )}
     </>
   );
 };

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -94,7 +94,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
         setNewBranch(selected[0].value);
       }
     }
-  }, [branches, pickupBranch]);
+  }, [branches, newPickupBranch, pickupBranch]);
 
   const changeExpiryDate = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details-buttons.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details-buttons.tsx
@@ -6,25 +6,33 @@ import { MaterialProps } from "../../../loan-list/materials/utils/material-fetch
 export interface ReservationDetailsButtonProps {
   reservationId: number;
   numberInQueue?: number | null;
+  classNames?: string;
+  buttonClassNames?: string;
   openReservationDeleteModal: (deleteId: string) => void;
 }
 
 const ReservationDetailsButton: FC<
   ReservationDetailsButtonProps & MaterialProps
-> = ({ reservationId, numberInQueue, openReservationDeleteModal }) => {
+> = ({
+  reservationId,
+  numberInQueue,
+  openReservationDeleteModal,
+  classNames,
+  buttonClassNames
+}) => {
   const t = useText();
 
   return (
-    <div className="modal-details__buttons">
+    <div className={`modal-details__buttons ${classNames}`}>
       {numberInQueue && numberInQueue > 0 && (
-        <div className="my-8 mx-16 text-body-medium-regular">
+        <div className="my-8 mr-16 text-body-medium-regular">
           {t("reservationDetailsOthersInQueueText")}
         </div>
       )}
       <Button
         label={t("reservationDetailsButtonRemoveText")}
         onClick={() => openReservationDeleteModal(reservationId.toString())}
-        classNames="btn-primary btn-filled btn-small arrow__hover--right-small"
+        classNames={`btn-primary btn-filled btn-small arrow__hover--right-small ${buttonClassNames}`}
         buttonType="none"
         disabled={false}
         collapsible={false}

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details-buttons.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details-buttons.tsx
@@ -32,7 +32,7 @@ const ReservationDetailsButton: FC<
       <Button
         label={t("reservationDetailsButtonRemoveText")}
         onClick={() => openReservationDeleteModal(reservationId.toString())}
-        classNames={`btn-primary btn-filled btn-small arrow__hover--right-small ${buttonClassNames}`}
+        classNames={buttonClassNames}
         buttonType="none"
         disabled={false}
         collapsible={false}

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details-redirect.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details-redirect.tsx
@@ -7,21 +7,29 @@ import { useUrls } from "../../../../core/utils/url";
 
 export interface ReservationDetailsRedirectProps {
   reservationId: string;
+  className?: string;
+  linkClassNames?: string;
+
   openReservationDeleteModal: (deleteId: string) => void;
 }
 
 const ReservationDetailsRedirect: FC<
   ReservationDetailsRedirectProps & MaterialProps
-> = ({ reservationId, openReservationDeleteModal }) => {
+> = ({
+  reservationId,
+  openReservationDeleteModal,
+  className,
+  linkClassNames
+}) => {
   const t = useText();
   const { ereolenMyPageUrl } = useUrls();
 
   return (
-    <div className="modal-details__buttons">
+    <div className={`modal-details__buttons ${className}`}>
       <button
         type="button"
         onClick={() => openReservationDeleteModal(reservationId)}
-        className="link-tag mx-16"
+        className={`link-tag ${linkClassNames}`}
       >
         {t("reservationDetailsRemoveDigitalReservationText")}
       </button>

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -181,6 +181,7 @@ describe("Reservation details modal test", () => {
     // ID 17 2.c. the link "Remove your reservation"
     cy.get(".modal")
       .find("button.link-tag")
+      .eq(0)
       .should("have.text", "Remove your reservation")
       .click();
 
@@ -189,6 +190,7 @@ describe("Reservation details modal test", () => {
     // ID 17 2.d. button: go to ereolen
     cy.get(".modal")
       .find("[data-cy='go-to-ereolen-button']")
+      .eq(0)
       .should("have.text", "Go to eReolen")
       .should("have.attr", "href")
       // ID 17 2.d.i. link to "ereolen.dk/user/me"

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
@@ -61,6 +61,8 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
             <ReservationDetailsRedirect
               openReservationDeleteModal={openReservationDeleteModal}
               reservationId={reservation.identifier}
+              className="modal-details__buttons--hide-on-mobile"
+              linkClassNames="mx-16"
             />
           )}
           <div className="modal-details__list">
@@ -78,6 +80,13 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
               openReservationDeleteModal={openReservationDeleteModal}
               reservationId={reservation.reservationId}
               numberInQueue={numberInQueue}
+            />
+          )}
+          {isDigital && reservation.identifier && (
+            <ReservationDetailsRedirect
+              openReservationDeleteModal={openReservationDeleteModal}
+              reservationId={reservation.identifier}
+              linkClassNames="my-16"
             />
           )}
         </>

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
@@ -51,6 +51,7 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
           </ModalDetailsHeader>
           {reservation.reservationId && (
             <ReservationDetailsButton
+              classNames="modal-details__buttons--hide-on-mobile"
               openReservationDeleteModal={openReservationDeleteModal}
               reservationId={reservation.reservationId}
               numberInQueue={numberInQueue}
@@ -71,6 +72,14 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
               />
             )}
           </div>
+          {reservation.reservationId && (
+            <ReservationDetailsButton
+              buttonClassNames="modal-details__buttons__full-width"
+              openReservationDeleteModal={openReservationDeleteModal}
+              reservationId={reservation.reservationId}
+              numberInQueue={numberInQueue}
+            />
+          )}
         </>
       )}
     </div>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,6 +11,7 @@ export type Option = {
 type DropdownProps = {
   options: Option[];
   ariaLabel: string;
+  labelledBy?: string;
   arrowIcon: "triangles" | "chevron";
   classNames?: string;
   innerClassNames?: { select?: string; option?: string; arrowWrapper?: string };
@@ -29,6 +30,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = ({
   handleOnChange,
   placeholder,
   cyData,
+  labelledBy,
   defaultValue
 }) => {
   const classes = {
@@ -48,6 +50,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = ({
   return (
     <div className={classes.root}>
       <select
+        aria-labelledby={labelledBy}
         data-cy={cyData}
         className={classes.select}
         aria-label={ariaLabel}

--- a/src/components/list-details-dropdown/list-details-dropdown.tsx
+++ b/src/components/list-details-dropdown/list-details-dropdown.tsx
@@ -9,50 +9,36 @@ export interface OptionsProps {
 
 export interface ListDetailsDropdownProps {
   onDropdownChange: (e: ChangeEvent<HTMLSelectElement>) => void;
-  setShowSelect: (show: boolean) => void;
-  showSelect: boolean;
   options: OptionsProps[];
-  selected: OptionsProps | null;
+  selected?: string | null;
+  labelledBy: string;
 }
 
 const ListDetailsDropdown: FC<ListDetailsDropdownProps> = ({
   onDropdownChange,
-  setShowSelect,
-  showSelect,
   options,
-  selected
+  selected,
+  labelledBy
 }) => {
   const t = useText();
 
   return (
-    <>
-      {!showSelect && (
-        <button
-          type="button"
-          className="link-tag"
-          onClick={() => setShowSelect(true)}
-        >
-          {t("reservationDetailsChangeText")}
-        </button>
-      )}
-      {showSelect && (
-        <Dropdown
-          defaultValue={selected?.value}
-          placeholder={{
-            label: t("listDetailsNothingSelectedLabelText"),
-            disabled: true,
-            value: ""
-          }}
-          options={options.map(({ value, label }) => ({
-            value,
-            label
-          }))}
-          ariaLabel=""
-          arrowIcon="chevron"
-          handleOnChange={(e) => onDropdownChange(e)}
-        />
-      )}
-    </>
+    <Dropdown
+      labelledBy={labelledBy}
+      defaultValue={selected || ""}
+      placeholder={{
+        label: t("listDetailsNothingSelectedLabelText"),
+        disabled: true,
+        value: ""
+      }}
+      options={options.map(({ value, label }) => ({
+        value,
+        label
+      }))}
+      ariaLabel=""
+      arrowIcon="chevron"
+      handleOnChange={(e) => onDropdownChange(e)}
+    />
   );
 };
 

--- a/src/components/list-details-dropdown/list-details-dropdown.tsx
+++ b/src/components/list-details-dropdown/list-details-dropdown.tsx
@@ -31,10 +31,7 @@ const ListDetailsDropdown: FC<ListDetailsDropdownProps> = ({
         disabled: true,
         value: ""
       }}
-      options={options.map(({ value, label }) => ({
-        value,
-        label
-      }))}
+      options={options}
       ariaLabel=""
       arrowIcon="chevron"
       handleOnChange={(e) => onDropdownChange(e)}

--- a/src/components/list-details/list-details.tsx
+++ b/src/components/list-details/list-details.tsx
@@ -1,26 +1,36 @@
 import React, { FC, ReactNode } from "react";
+import { useText } from "../../core/utils/text";
 
 export interface ListDetailsProps {
   icon: string;
   title: string;
   labels: string[] | string;
+  showSelect?: boolean | null;
+  setShowSelect?: (show: boolean) => void;
   children?: ReactNode;
+  idForLabelledBy?: string;
 }
 
 const ListDetails: FC<ListDetailsProps> = ({
   icon,
   title,
   labels,
+  showSelect,
+  setShowSelect,
+  idForLabelledBy,
   children
 }) => {
+  const t = useText();
   return (
     <div className="list-details">
       <div className="list-details__icon">
         <img src={icon} alt="" />
       </div>
       <div className="list-details__container">
-        <div className="list-details__content">
-          <p className="text-header-h5">{title}</p>
+        <div>
+          <h3 className="text-header-h5" id={idForLabelledBy}>
+            {title}
+          </h3>
           {typeof labels === "string" && (
             <p className="text-small-caption">{labels}</p>
           )}
@@ -29,8 +39,17 @@ const ListDetails: FC<ListDetailsProps> = ({
               <p className="text-small-caption">{label}</p>
             ))}
         </div>
+        <div className="list-details__dropdown">{children}</div>
       </div>
-      {children}
+      {showSelect !== null && !showSelect && setShowSelect && (
+        <button
+          type="button"
+          className="link-tag"
+          onClick={() => setShowSelect(true)}
+        >
+          {t("reservationDetailsChangeText")}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/list-details/list-details.tsx
+++ b/src/components/list-details/list-details.tsx
@@ -5,7 +5,7 @@ export interface ListDetailsProps {
   icon: string;
   title: string;
   labels: string[] | string;
-  showSelect?: boolean | null;
+  showSelect?: boolean;
   setShowSelect?: (show: boolean) => void;
   children?: ReactNode;
   idForLabelledBy?: string;
@@ -42,6 +42,7 @@ const ListDetails: FC<ListDetailsProps> = ({
         <div className="list-details__dropdown">{children}</div>
       </div>
       {showSelect !== null && !showSelect && setShowSelect && (
+        // todo add link-button in "src/components/Buttons"
         <button
           type="button"
           className="link-tag"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5654

#### Description

Use returned object from save to update values
fix mobile styling (link)
add missing link to ereolen

#### Screenshot of the result

<img width="399" alt="image" src="https://user-images.githubusercontent.com/15377965/216601654-56c31bf6-bbab-46f7-8bda-c25fc788643e.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
