### PR TITLE
Add expand icon to horizontal term line

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-31504fb5749d518291fd22ee70781c13ee46e2e3",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-75429e0a3ac67c2971d90e81eefa436278ebc47b",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -648,6 +648,11 @@ export default {
       name: "Alert error message text",
       defaultValue: "An error occurred",
       control: { type: "text" }
+    },
+    expandMoreText: {
+      name: "Expand more text",
+      defaultValue: "Expand more",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -125,6 +125,7 @@ interface MaterialEntryTextProps {
   tryAginButtonText: string;
   twoMonthsText: string;
   firstAvailableEditionText: string;
+  expandMoreText: string;
 }
 interface MaterialEntryUrlProps {
   dplCmsBaseUrl: string;

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -48,6 +48,22 @@ describe("Material", () => {
       .and("contain.text", "Nr. 1  in seriesDe syv søstre-serien");
   });
 
+  it("Renders only first 3 horizontal lines items", () => {
+    cy.getBySel("material-description-series-members")
+      .should("be.visible")
+      .find("span")
+      .should("have.length", 3);
+  });
+
+  it("Renders additional horizontal lines items after button click", () => {
+    cy.getBySel("material-description-series-members").find("button").click();
+
+    cy.getBySel("material-description-series-members")
+      .should("be.visible")
+      .find("span")
+      .should("have.length", 7);
+  });
+
   it("Renders authors", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",

--- a/src/components/Disclosures/DisclosureControllable.tsx
+++ b/src/components/Disclosures/DisclosureControllable.tsx
@@ -61,7 +61,9 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
         <span className="disclosure__text">{title}</span>
 
         <img
-          className="disclosure__expand noselect"
+          className={clsx("disclosure__expand noselect", {
+            "disclosure__expand--expanded": isOpen
+          })}
           src={ExpandMoreIcon}
           alt=""
         />

--- a/src/components/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/components/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,5 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
+import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
+import clsx from "clsx";
 import { Link } from "../atoms/link";
+import { useText } from "../../core/utils/text";
 
 export interface HorizontalTermLineProps {
   title: string;
@@ -17,6 +20,14 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   linkList,
   dataCy = "horizontal-term-line"
 }) => {
+  const t = useText();
+  const numberOfItemsToShow = 3;
+  const [showMore, setShowMore] = useState(false);
+  const itemsToShow = showMore
+    ? linkList
+    : linkList.slice(0, numberOfItemsToShow);
+  const showMoreButton = linkList.length > numberOfItemsToShow;
+
   return (
     <div data-cy={dataCy} className="text-small-caption horizontal-term-line">
       <p className="text-label-bold">
@@ -26,7 +37,7 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
         )}
       </p>
 
-      {linkList.map((item) => {
+      {itemsToShow.map((item) => {
         const { term, url } = item;
         return (
           <span key={term}>
@@ -36,6 +47,22 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
           </span>
         );
       })}
+
+      {showMoreButton && (
+        <button
+          type="button"
+          onClick={() => setShowMore(!showMore)}
+          aria-label={t("expandMoreText")}
+        >
+          <img
+            className={clsx("horizontal-term-line__expand", {
+              "horizontal-term-line__expand--expanded": showMore
+            })}
+            src={ExpandMoreIcon}
+            alt=""
+          />
+        </button>
+      )}
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,10 +1749,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-31504fb5749d518291fd22ee70781c13ee46e2e3":
-  version "0.0.0-31504fb5749d518291fd22ee70781c13ee46e2e3"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-31504fb5749d518291fd22ee70781c13ee46e2e3/51de9beba10f4c9c90dfbda23491cd87b4624bed#51de9beba10f4c9c90dfbda23491cd87b4624bed"
-  integrity sha512-tY8iCc9b5bWR2kn9iqE0FfuSCJ89qV5oHQBJpzFyHIpgHQnHEOzpuYjO13JpWc9pFtj9+x4g4cmqkt1DFFXGfg==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-75429e0a3ac67c2971d90e81eefa436278ebc47b":
+  version "0.0.0-75429e0a3ac67c2971d90e81eefa436278ebc47b"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-75429e0a3ac67c2971d90e81eefa436278ebc47b/c9069520ea0fac288f59b61a496386d11dfa80ad#c9069520ea0fac288f59b61a496386d11dfa80ad"
+  integrity sha512-BqxhQlseGf0CTYIifkpXkEmW1eDcTirsSERay5ovysj7AIm3b30FgH1I8wTf28KrwcsnEYuuwnQXmrCqy98rYg==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
## Remember to update design-system after the merge 
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/199

#### Link to issue
https://reload.atlassian.net/browse/DSC-37

#### This pull request enhances the HorizontalTermLine component with the following new features:

- Limits the number of terms displayed to the value set in numberOfItemsToShow, which is set to 2.

- a toggle button has been added, allowing users to switch between displaying only the limited number of terms and all of them. The button features a toggle icon that changes according to the component's state.

**Other Changes**
- Add css modifier in DisclosureControllable to flip arrow icon


#### Screenshot of the result
![image](https://user-images.githubusercontent.com/49920322/217819807-6d4c25af-019f-4af1-8faa-1999771c40f3.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.