### PR TITLE
fix/pickup-branch-interested-date-feedback

### DIFF
--- a/src/apps/reservation-list/list/reservation-list.tsx
+++ b/src/apps/reservation-list/list/reservation-list.tsx
@@ -296,6 +296,9 @@ const ReservationList: FC<ReservationListProps> = ({ pageSize }) => {
             faust={reservation.faust}
             identifier={reservation.identifier}
             reservation={reservation}
+            modalId={`${reservationDetails}${
+              reservation.faust || reservation.identifier
+            }`}
           />
         </MaterialDetailsModal>
       )}

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -143,6 +143,7 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
             setShowBranchesSelect(false);
             setShowExpirySelect(false);
             queryClient.invalidateQueries(getGetReservationsV2QueryKey());
+            // todo inform the user that the values have been saved.
             close(modalId);
             open(modalId);
           },

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -30,17 +30,21 @@ import { Button } from "../../../../components/Buttons/Button";
 import ListDetailsDropdown, {
   OptionsProps
 } from "../../../../components/list-details-dropdown/list-details-dropdown";
+import { useModalButtonHandler } from "../../../../core/utils/modal";
 
 interface PhysicalListDetailsProps {
   reservation: ReservationType;
   branches: AgencyBranch[];
+  modalId: string;
 }
 
 const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
   reservation,
-  branches
+  branches,
+  modalId
 }) => {
   const t = useText();
+  const { close, open } = useModalButtonHandler();
   const queryClient = useQueryClient();
   const { mutate } = useUpdateReservations();
   const [pickupBranchFetched, setPickupBranchFetched] = useState<string>("");
@@ -139,6 +143,8 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
             setShowBranchesSelect(false);
             setShowExpirySelect(false);
             queryClient.invalidateQueries(getGetReservationsV2QueryKey());
+            close(modalId);
+            open(modalId);
           },
           // todo error handling, missing in figma
           onError: () => {}
@@ -146,12 +152,15 @@ const PhysicalListDetails: FC<PhysicalListDetailsProps & MaterialProps> = ({
       );
     }
   }, [
+    newBranch,
     reservationId,
     expiryDate,
     newExpiryDate,
     mutate,
-    newBranch?.value,
-    queryClient
+    queryClient,
+    close,
+    modalId,
+    open
   ]);
 
   const cancel = useCallback(() => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
@@ -15,12 +15,14 @@ import { useGetBranches } from "../../../../core/utils/branches";
 export interface ReservationDetailsProps {
   reservation: ReservationType;
   openReservationDeleteModal: (deleteId: string) => void;
+  modalId: string;
 }
 
 const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
   reservation,
   material,
-  openReservationDeleteModal
+  openReservationDeleteModal,
+  modalId
 }) => {
   const t = useText();
   const { state, identifier, numberInQueue } = reservation;
@@ -68,6 +70,7 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
               <PhysicalListDetails
                 branches={branches}
                 reservation={reservation}
+                modalId={modalId}
               />
             )}
           </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5646
https://platform.dandigbib.org/issues/5647

#### Description

This PR addresses the two above issues, regarding lack of feedback when the user presses the "save"-button upon changing their preferred pickup-branch and expiry time of interest. By closing and opening the given modal in quick succession, thereby updating the preset values, it is shown more clearly that the values have been updated. 

This can be changed/reduced to closing the given modal, when a global engine for handling user messages has been established.

#### Screenshot of the result

<img width="1419" alt="Screenshot 2023-02-09 at 15 35 05" src="https://user-images.githubusercontent.com/106669866/217842475-2560a24f-7f8f-4c0e-976b-2ef3c2b5cf4a.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
