### PR TITLE
Add handleFictionOrNonFictionReservation + Refactor materialIsFiction

### DIFF
--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -3,8 +3,12 @@
     "work": {
       "workId": "work-of:870970-basis:52557240",
       "titles": {
-        "full": ["De syv søstre : Maias historie"],
-        "original": ["The seven sisters"]
+        "full": [
+          "De syv søstre : Maias historie"
+        ],
+        "original": [
+          "The seven sisters"
+        ]
       },
       "abstract": [
         "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav"
@@ -25,12 +29,14 @@
         },
         {
           "title": "De syv søstre-serien",
-          "isPopular": null,
+          "isPopular": true,
           "numberInSeries": {
             "display": "1",
-            "number": [1]
+            "number": [
+              1
+            ]
           },
-          "readThisFirst": null,
+          "readThisFirst": true,
           "readThisWhenever": null
         }
       ],
@@ -38,71 +44,127 @@
         {
           "workId": "work-of:870970-basis:52557240",
           "titles": {
-            "main": ["De syv søstre"],
-            "full": ["De syv søstre : Maias historie"],
-            "original": ["The seven sisters"]
+            "main": [
+              "De syv søstre"
+            ],
+            "full": [
+              "De syv søstre : Maias historie"
+            ],
+            "original": [
+              "The seven sisters"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:52970628",
           "titles": {
-            "main": ["Stormsøsteren"],
-            "full": ["Stormsøsteren : Allys historie"],
-            "original": ["The storm sister"]
+            "main": [
+              "Stormsøsteren"
+            ],
+            "full": [
+              "Stormsøsteren : Allys historie"
+            ],
+            "original": [
+              "The storm sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:53280749",
           "titles": {
-            "main": ["Skyggesøsteren"],
-            "full": ["Skyggesøsteren : Stars historie"],
-            "original": ["The shadow sister"]
+            "main": [
+              "Skyggesøsteren"
+            ],
+            "full": [
+              "Skyggesøsteren : Stars historie"
+            ],
+            "original": [
+              "The shadow sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:53802001",
           "titles": {
-            "main": ["Perlesøsteren"],
-            "full": ["Perlesøsteren : CeCes historie"],
-            "original": ["The pearl sister"]
+            "main": [
+              "Perlesøsteren"
+            ],
+            "full": [
+              "Perlesøsteren : CeCes historie"
+            ],
+            "original": [
+              "The pearl sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:54189141",
           "titles": {
-            "main": ["Månesøsteren"],
-            "full": ["Månesøsteren : Tiggys historie"],
-            "original": ["The moon sister"]
+            "main": [
+              "Månesøsteren"
+            ],
+            "full": [
+              "Månesøsteren : Tiggys historie"
+            ],
+            "original": [
+              "The moon sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:46656172",
           "titles": {
-            "main": ["Solsøsteren"],
-            "full": ["Solsøsteren : Electras historie"],
-            "original": ["The sun sister"]
+            "main": [
+              "Solsøsteren"
+            ],
+            "full": [
+              "Solsøsteren : Electras historie"
+            ],
+            "original": [
+              "The sun sister"
+            ]
           }
         },
         {
           "workId": "work-of:870970-basis:38500775",
           "titles": {
-            "main": ["Den forsvundne søster"],
-            "full": ["Den forsvundne søster"],
-            "original": ["The missing sister"]
+            "main": [
+              "Den forsvundne søster"
+            ],
+            "full": [
+              "Den forsvundne søster"
+            ],
+            "original": [
+              "The missing sister"
+            ]
           }
         }
       ],
       "workYear": null,
-      "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+      "genreAndForm": [
+        "roman",
+        "slægtsromaner",
+        "romaner"
+      ],
       "manifestations": {
         "all": [
           {
             "pid": "870970-basis:46615743",
-            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-            "source": ["Bibliotekskatalog"],
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner",
+              "romaner"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -168,15 +230,25 @@
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"
-            }
+            },
+            "workYear": null
           },
           {
-            "pid": "870970-basis:53292968",
-            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-            "source": ["Bibliotekskatalog"],
+            "pid": "870970-basis:52557240",
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -185,156 +257,6 @@
             "materialTypes": [
               {
                 "specific": "bog"
-              }
-            ],
-            "creators": [
-              {
-                "display": "Lucinda Riley",
-                "__typename": "Person"
-              }
-            ],
-            "publisher": [
-              "Cicero"
-            ],
-            "languages": {
-              "main": [
-                {
-                  "display": "dansk"
-                }
-              ]
-            },
-            "identifiers": [
-              {
-                "value": "9788763849630"
-              }
-            ],
-            "contributors": [
-              {
-                "display": "Ulla Lauridsen"
-              }
-            ],
-            "edition": {
-              "summary": "2. udgave, 2017",
-              "publicationYear": {
-                "display": "2017"
-              }
-            },
-            "audience": {
-              "generalAudience": []
-            },
-            "physicalDescriptions": [
-              {
-                "numberOfPages": 523,
-                "playingTime": null
-              }
-            ],
-            "accessTypes": [
-              {
-                "code": "PHYSICAL"
-              }
-            ],
-            "access": [
-              {
-                "__typename": "InterLibraryLoan",
-                "loanIsPossible": true
-              }
-            ],
-            "shelfmark": {
-              "postfix": "Riley",
-              "shelfmark": "83"
-            }
-          },
-          {
-            "pid": "870970-basis:53200346",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              {
-                "specific": "musik (net)"
-              }
-            ],
-            "creators": [
-              {
-                "display": "Lucinda Riley",
-                "__typename": "Person"
-              }
-            ],
-            "publisher": [
-              "Gyldendals Bogklubber"
-            ],
-            "languages": {
-              "main": [
-                {
-                  "display": "dansk"
-                }
-              ]
-            },
-            "identifiers": [
-              {
-                "value": "9788703079875"
-              }
-            ],
-            "contributors": [
-              {
-                "display": "Ulla Lauridsen"
-              }
-            ],
-            "edition": {
-              "summary": "1. bogklubudgave, 2017",
-              "publicationYear": {
-                "display": "2017"
-              }
-            },
-            "audience": {
-              "generalAudience": []
-            },
-            "physicalDescriptions": [
-              {
-                "numberOfPages": 523,
-                "playingTime": null
-              }
-            ],
-            "accessTypes": [
-              {
-                "code": "ONLINE"
-              }
-            ],
-            "access": [
-              {
-                "__typename": "AccessUrl",
-                "origin": "musik",
-                "url": "https://musik.dk/ting/object/870970-basis:52590302",
-                "canAlwaysBeLoaned": false
-              }
-            ],
-            "shelfmark": {
-              "postfix": "Riley",
-              "shelfmark": "83"
-            }
-          },
-          {
-            "pid": "870970-basis:52557240",
-            "genreAndForm": ["roman", "slægtsromaner"],
-            "source": ["Bibliotekskatalog"],
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              {
-                "specific": "film (net)"
               }
             ],
             "creators": [
@@ -380,29 +302,37 @@
             ],
             "accessTypes": [
               {
-                "code": "ONLINE"
+                "code": "PHYSICAL"
               }
             ],
             "access": [
               {
-                "__typename": "AccessUrl",
-                "origin": "Filmstriben",
-                "url": "https://filmstriben.dk/ting/object/870970-basis:52590302",
-                "canAlwaysBeLoaned": false
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
               }
             ],
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"
-            }
+            },
+            "workYear": null
           },
           {
-            "pid": "870970-basis:52643503",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
+            "pid": "870970-basis:52590302",
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner"
+            ],
+            "source": [
+              "eReolen"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -410,7 +340,7 @@
             },
             "materialTypes": [
               {
-                "specific": "lydbog (net)"
+                "specific": "ebog"
               }
             ],
             "creators": [
@@ -420,7 +350,7 @@
               }
             ],
             "publisher": [
-              "Rosinante"
+              "Cicero"
             ],
             "languages": {
               "main": [
@@ -431,19 +361,19 @@
             },
             "identifiers": [
               {
-                "value": "9788763847995"
+                "value": "9788763844123"
+              },
+              {
+                "value": "9788763844123"
               }
             ],
             "contributors": [
-              {
-                "display": "Maria Stokholm"
-              },
               {
                 "display": "Ulla Lauridsen"
               }
             ],
             "edition": {
-              "summary": "2016",
+              "summary": "1. eBogsudgave, 2016",
               "publicationYear": {
                 "display": "2016"
               }
@@ -451,12 +381,7 @@
             "audience": {
               "generalAudience": []
             },
-            "physicalDescriptions": [
-              {
-                "numberOfPages": null,
-                "playingTime": "16 t., 30 min."
-              }
-            ],
+            "physicalDescriptions": [],
             "accessTypes": [
               {
                 "code": "ONLINE"
@@ -464,24 +389,33 @@
             ],
             "access": [
               {
-                "__typename": "AccessUrl",
-                "origin": "website",
-                "url": "https://website.dk/ting/object/870970-basis:52590302",
+                "__typename": "Ereol",
+                "origin": "eReolen",
+                "url": "https://ereolen.dk/ting/object/870970-basis:52590302",
                 "canAlwaysBeLoaned": false
               }
             ],
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"
-            }
+            },
+            "workYear": null
           },
           {
             "pid": "870970-basis:52643414",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
+            "genreAndForm": [
+              "roman"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre (mp3)"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre (mp3)"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -550,15 +484,24 @@
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"
-            }
+            },
+            "workYear": null
           },
           {
-            "pid": "870970-basis:52590302",
-            "genreAndForm": ["roman", "slægtsromaner"],
-            "source": ["eReolen"],
+            "pid": "870970-basis:52643503",
+            "genreAndForm": [
+              "roman"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
             "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
             },
             "fictionNonfiction": {
               "display": "skønlitteratur",
@@ -566,7 +509,173 @@
             },
             "materialTypes": [
               {
-                "specific": "ebog"
+                "specific": "lydbog (net)"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Rosinante"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788763847995"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Maria Stokholm"
+              },
+              {
+                "display": "Ulla Lauridsen"
+              }
+            ],
+            "edition": {
+              "summary": "2016",
+              "publicationYear": {
+                "display": "2016"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": null,
+                "playingTime": "16 t., 30 min."
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:53200346",
+            "genreAndForm": [
+              "roman"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
+            },
+            "fictionNonfiction": {
+              "display": "skønlitteratur",
+              "code": "FICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Gyldendals Bogklubber"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788703079875"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen"
+              }
+            ],
+            "edition": {
+              "summary": "1. bogklubudgave, 2017",
+              "publicationYear": {
+                "display": "2017"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 523,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Riley",
+              "shelfmark": "83"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:53292968",
+            "genreAndForm": [
+              "roman",
+              "slægtsromaner",
+              "romaner"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "De syv søstre"
+              ],
+              "original": [
+                "The seven sisters"
+              ]
+            },
+            "fictionNonfiction": {
+              "display": "skønlitteratur",
+              "code": "FICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
               }
             ],
             "creators": [
@@ -587,10 +696,7 @@
             },
             "identifiers": [
               {
-                "value": "9788763844123"
-              },
-              {
-                "value": "9788763844123"
+                "value": "9788763849630"
               }
             ],
             "contributors": [
@@ -599,41 +705,55 @@
               }
             ],
             "edition": {
-              "summary": "1. eBogsudgave, 2016",
+              "summary": "2. udgave, 2017",
               "publicationYear": {
-                "display": "2016"
+                "display": "2017"
               }
             },
             "audience": {
               "generalAudience": []
             },
-            "physicalDescriptions": [],
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 523,
+                "playingTime": null
+              }
+            ],
             "accessTypes": [
               {
-                "code": "ONLINE"
+                "code": "PHYSICAL"
               }
             ],
             "access": [
               {
-                "__typename": "Ereol",
-                "origin": "eReolen",
-                "url": "https://ereolen.dk/ting/object/870970-basis:52590302",
-                "canAlwaysBeLoaned": false
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
               }
             ],
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"
-            }
+            },
+            "workYear": null
           }
         ],
         "latest": {
           "pid": "870970-basis:46615743",
-          "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-          "source": ["Bibliotekskatalog"],
+          "genreAndForm": [
+            "roman",
+            "slægtsromaner",
+            "romaner"
+          ],
+          "source": [
+            "Bibliotekskatalog"
+          ],
           "titles": {
-            "main": ["De syv søstre"],
-            "original": ["The seven sisters"]
+            "main": [
+              "De syv søstre"
+            ],
+            "original": [
+              "The seven sisters"
+            ]
           },
           "fictionNonfiction": {
             "display": "skønlitteratur",
@@ -699,7 +819,93 @@
           "shelfmark": {
             "postfix": "Riley",
             "shelfmark": "83"
-          }
+          },
+          "workYear": null
+        },
+        "bestRepresentation": {
+          "pid": "870970-basis:46615743",
+          "genreAndForm": [
+            "roman",
+            "slægtsromaner",
+            "romaner"
+          ],
+          "source": [
+            "Bibliotekskatalog"
+          ],
+          "titles": {
+            "main": [
+              "De syv søstre"
+            ],
+            "original": [
+              "The seven sisters"
+            ]
+          },
+          "fictionNonfiction": {
+            "display": "skønlitteratur",
+            "code": "FICTION"
+          },
+          "materialTypes": [
+            {
+              "specific": "bog"
+            }
+          ],
+          "creators": [
+            {
+              "display": "Lucinda Riley",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": [
+            "Cicero"
+          ],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk"
+              }
+            ]
+          },
+          "identifiers": [
+            {
+              "value": "9788763863285"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Ulla Lauridsen"
+            }
+          ],
+          "edition": {
+            "summary": "3. udgave, 2019",
+            "publicationYear": {
+              "display": "2019"
+            }
+          },
+          "audience": {
+            "generalAudience": []
+          },
+          "physicalDescriptions": [
+            {
+              "numberOfPages": 523,
+              "playingTime": null
+            }
+          ],
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Riley",
+            "shelfmark": "83"
+          },
+          "workYear": null
         }
       },
       "materialTypes": [
@@ -707,10 +913,10 @@
           "specific": "bog"
         },
         {
-          "specific": "lydbog (net)"
+          "specific": "ebog"
         },
         {
-          "specific": "ebog"
+          "specific": "lydbog (net)"
         },
         {
           "specific": "lydbog (cd-mp3)"

--- a/cypress/fixtures/material/nonfiction-availability.json
+++ b/cypress/fixtures/material/nonfiction-availability.json
@@ -1,0 +1,74 @@
+[
+  {
+    "recordId": "20636866",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "21417890",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "22223623",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "23445158",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "24922197",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "26019109",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "27173640",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "28477074",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "29798079",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "51634764",
+    "reservable": false,
+    "available": false,
+    "reservations": 0
+  },
+  {
+    "recordId": "53976018",
+    "reservable": true,
+    "available": true,
+    "reservations": 3
+  },
+  {
+    "recordId": "61991484",
+    "reservable": true,
+    "available": false,
+    "reservations": 1
+  }
+]

--- a/cypress/fixtures/material/nonfiction-fbi-api.json
+++ b/cypress/fixtures/material/nonfiction-fbi-api.json
@@ -1,0 +1,1747 @@
+{
+  "data": {
+    "work": {
+      "workId": "work-of:870970-basis:20636866",
+      "titles": {
+        "full": [
+          "Turen går til Rom"
+        ],
+        "original": []
+      },
+      "abstract": [],
+      "creators": [
+        {
+          "display": "Alfredo Tesio",
+          "__typename": "Person"
+        }
+      ],
+      "series": [
+        {
+          "title": "Politikens rejsebøger",
+          "isPopular": null,
+          "numberInSeries": null,
+          "readThisFirst": null,
+          "readThisWhenever": null
+        },
+        {
+          "title": "Turen går til",
+          "isPopular": null,
+          "numberInSeries": null,
+          "readThisFirst": null,
+          "readThisWhenever": null
+        }
+      ],
+      "seriesMembers": [],
+      "workYear": null,
+      "genreAndForm": [
+        "rejseførere"
+      ],
+      "manifestations": {
+        "all": [
+          {
+            "pid": "870970-basis:20636866",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1995",
+              "publicationYear": {
+                "display": "1995"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:21417890",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:22223623",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "87-567-5973-8"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1999",
+              "publicationYear": {
+                "display": "1999"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:23445158",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "87-567-6313-1"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2002",
+              "publicationYear": {
+                "display": "2002"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:24922197",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:26019109",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788756773126"
+              },
+              {
+                "value": "87-567-7312-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "23. udgave / af Alfredo Tesio ; redaktør: Karen Lise Søndergaard og Inge-Lise Paulsen ; kort: Ulla Britze, 2007",
+              "publicationYear": {
+                "display": "2007"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:27173640",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788756781107"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "24. udgave / af Alfredo Tesio ; redaktør: Inge-Lise Paulsen ; kort: Britze, 2008",
+              "publicationYear": {
+                "display": "2008"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:28477074",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788756795036"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marita Hoydal"
+              },
+              {
+                "display": "Pipaluk Balslev Fabricius"
+              },
+              {
+                "display": "Ulla Britze"
+              },
+              {
+                "display": "Søren Lauridsen"
+              }
+            ],
+            "edition": {
+              "summary": "25. udgave, 2010",
+              "publicationYear": {
+                "display": "2010"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:29798079",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740003437"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              },
+              {
+                "display": "Birgitta Lund"
+              },
+              {
+                "display": "Kasper Monty"
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:47077435",
+            "genreAndForm": [],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "lydbog (net)"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740059311"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Karen Abrahamsen"
+              }
+            ],
+            "edition": {
+              "summary": "2019",
+              "publicationYear": {
+                "display": "2019"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": null,
+                "playingTime": "80 min."
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:50690601",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "ebog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740010671"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              },
+              {
+                "display": "Birgitta Lund"
+              },
+              {
+                "display": "Kasper Monty"
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:51634764",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740013115"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              }
+            ],
+            "edition": {
+              "summary": "27. udgave, 2015",
+              "publicationYear": {
+                "display": "2015"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:51658256",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "ebog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740018493"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              }
+            ],
+            "edition": {
+              "summary": "1. e-bogsudgave, 2015",
+              "publicationYear": {
+                "display": "2015"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:53787495",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "ebog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740025316"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              },
+              {
+                "display": "Kasper Monty"
+              },
+              {
+                "display": "Birgitta Lund"
+              }
+            ],
+            "edition": {
+              "summary": "Ny e-bogsudgave, 2017",
+              "publicationYear": {
+                "display": "2017"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:53976018",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740025323"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              }
+            ],
+            "edition": {
+              "summary": "28. udgave, 2018",
+              "publicationYear": {
+                "display": "2018"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:61809988",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "ebog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740067156"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze"
+              },
+              {
+                "display": "Susan Bergqvist"
+              },
+              {
+                "display": "Trine Blak Kosteljanetz"
+              },
+              {
+                "display": "Birgitta Lund"
+              }
+            ],
+            "edition": {
+              "summary": "4. e-bogsudgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:61991484",
+            "genreAndForm": [
+              "rejseførere"
+            ],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "bog"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740063585"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marine Gastineau"
+              },
+              {
+                "display": "Martin Thomas"
+              },
+              {
+                "display": "Thomas Linder Thomsen"
+              },
+              {
+                "display": "Ulla Britze"
+              },
+              {
+                "display": "Susan Bergqvist"
+              },
+              {
+                "display": "Trine Blak Kosteljanetz"
+              },
+              {
+                "display": "Birgitta Lund"
+              }
+            ],
+            "edition": {
+              "summary": "29. udgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          },
+          {
+            "pid": "870970-basis:62820586",
+            "genreAndForm": [],
+            "source": [
+              "Bibliotekskatalog"
+            ],
+            "titles": {
+              "main": [
+                "Turen går til Rom"
+              ],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "specific": "lydbog (net)"
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": [
+              "Politiken"
+            ],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk"
+                }
+              ]
+            },
+            "identifiers": [
+              {
+                "value": "9788740067163"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Paul Becker"
+              },
+              {
+                "display": "Trine Blak Kosteljanetz"
+              }
+            ],
+            "edition": {
+              "summary": "2022",
+              "publicationYear": {
+                "display": "2022"
+              }
+            },
+            "audience": {
+              "generalAudience": []
+            },
+            "physicalDescriptions": [
+              {
+                "numberOfPages": null,
+                "playingTime": "80 min."
+              }
+            ],
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null
+          }
+        ],
+        "latest": {
+          "pid": "870970-basis:62820586",
+          "genreAndForm": [],
+          "source": [
+            "Bibliotekskatalog"
+          ],
+          "titles": {
+            "main": [
+              "Turen går til Rom"
+            ],
+            "original": []
+          },
+          "fictionNonfiction": {
+            "display": "faglitteratur",
+            "code": "NONFICTION"
+          },
+          "materialTypes": [
+            {
+              "specific": "lydbog (net)"
+            }
+          ],
+          "creators": [
+            {
+              "display": "Alfredo Tesio",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": [
+            "Politiken"
+          ],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk"
+              }
+            ]
+          },
+          "identifiers": [
+            {
+              "value": "9788740067163"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Paul Becker"
+            },
+            {
+              "display": "Trine Blak Kosteljanetz"
+            }
+          ],
+          "edition": {
+            "summary": "2022",
+            "publicationYear": {
+              "display": "2022"
+            }
+          },
+          "audience": {
+            "generalAudience": []
+          },
+          "physicalDescriptions": [
+            {
+              "numberOfPages": null,
+              "playingTime": "80 min."
+            }
+          ],
+          "accessTypes": [
+            {
+              "code": "ONLINE"
+            }
+          ],
+          "access": [],
+          "shelfmark": {
+            "postfix": "Tesio",
+            "shelfmark": "47.57 Rom"
+          },
+          "workYear": null
+        },
+        "bestRepresentation": {
+          "pid": "870970-basis:61991484",
+          "genreAndForm": [
+            "rejseførere"
+          ],
+          "source": [
+            "Bibliotekskatalog"
+          ],
+          "titles": {
+            "main": [
+              "Turen går til Rom"
+            ],
+            "original": []
+          },
+          "fictionNonfiction": {
+            "display": "faglitteratur",
+            "code": "NONFICTION"
+          },
+          "materialTypes": [
+            {
+              "specific": "bog"
+            }
+          ],
+          "creators": [
+            {
+              "display": "Alfredo Tesio",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": [
+            "Politiken"
+          ],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk"
+              }
+            ]
+          },
+          "identifiers": [
+            {
+              "value": "9788740063585"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Marine Gastineau"
+            },
+            {
+              "display": "Martin Thomas"
+            },
+            {
+              "display": "Thomas Linder Thomsen"
+            },
+            {
+              "display": "Ulla Britze"
+            },
+            {
+              "display": "Susan Bergqvist"
+            },
+            {
+              "display": "Trine Blak Kosteljanetz"
+            },
+            {
+              "display": "Birgitta Lund"
+            }
+          ],
+          "edition": {
+            "summary": "29. udgave, 2021",
+            "publicationYear": {
+              "display": "2021"
+            }
+          },
+          "audience": {
+            "generalAudience": []
+          },
+          "physicalDescriptions": [
+            {
+              "numberOfPages": 168,
+              "playingTime": null
+            }
+          ],
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Tesio",
+            "shelfmark": "47.57 Rom"
+          },
+          "workYear": null
+        }
+      },
+      "materialTypes": [
+        {
+          "specific": "bog"
+        },
+        {
+          "specific": "lydbog (net)"
+        },
+        {
+          "specific": "ebog"
+        }
+      ],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
+      "subjects": {
+        "all": [
+          {
+            "display": "Rom"
+          },
+          {
+            "display": "Italien"
+          },
+          {
+            "display": "Rejsebeskrivelse"
+          },
+          {
+            "display": "Seværdigheder"
+          },
+          {
+            "display": "Turisme"
+          },
+          {
+            "display": "Dansk GYM"
+          },
+          {
+            "display": "rom"
+          },
+          {
+            "display": "rejseførere"
+          },
+          {
+            "display": "Italia"
+          },
+          {
+            "display": "Rejseførere"
+          },
+          {
+            "display": "Lærerbibliotek"
+          },
+          {
+            "display": "Itali"
+          },
+          {
+            "display": "Rejsehåndbøger"
+          },
+          {
+            "display": "Guide"
+          }
+        ]
+      },
+      "reviews": [
+        {
+          "__typename": "InfomediaReview",
+          "author": "Alfredo Tesio",
+          "date": "2021-12-18",
+          "origin": "Politiken",
+          "rating": null,
+          "id": "e89a110e"
+        }
+      ],
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "47.57 Rom"
+      }
+    }
+  }
+}

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -628,6 +628,11 @@ export default {
       name: "Unknown",
       defaultValue: "Unknown",
       control: { type: "text" }
+    },
+    firstAvailableEditionText: {
+      name: "First available edition",
+      defaultValue: "First available edition",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -121,6 +121,7 @@ interface MaterialEntryTextProps {
   threeMonthsText: string;
   tryAginButtonText: string;
   twoMonthsText: string;
+  firstAvailableEditionText: string;
 }
 interface MaterialEntryUrlProps {
   dplCmsBaseUrl: string;

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -6,7 +6,7 @@ import {
   getAllPids,
   getMaterialTypes,
   getManifestationType,
-  materialIsFiction
+  isMaterial
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
@@ -77,6 +77,7 @@ export const ReservationModalBody = ({
   const [selectedInterest, setSelectedInterest] = useState<number | null>(null);
   const allPids = getAllPids(selectedManifestations);
   const faustIds = convertPostIdsToFaustIds(allPids);
+  const materialIsNonFiction = isMaterial("NONFICTION", work);
   const { mutate } = useAddReservationsV2();
   const userResponse = useGetPatronInformationByPatronIdV2();
   const holdingsResponse = useGetHoldingsV3({
@@ -186,12 +187,14 @@ export const ReservationModalBody = ({
                 icon={Various}
                 title={t("editionText")}
                 text={
-                  selectedPeriodical?.displayText ||
-                  manifestation.edition?.summary ||
-                  ""
+                  materialIsNonFiction
+                    ? selectedPeriodical?.displayText ||
+                      reservableManifestations?.[0]?.edition?.summary ||
+                      ""
+                    : t("firstAvailableEditionText")
                 }
               />
-              {!materialIsFiction(work) && otherManifestationPreferred && (
+              {materialIsNonFiction && otherManifestationPreferred && (
                 <PromoBar
                   classNames="px-35"
                   sticky

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -11,7 +11,8 @@ import {
   filterCreators,
   flattenCreators,
   getManifestationPublicationYear,
-  materialIsFiction
+  isMaterial,
+  orderManifestationsByYear
 } from "../../core/utils/helpers/general";
 import { Manifestation } from "../../core/utils/types/entities";
 import { PeriodicalEdition } from "../material/periodical/helper";
@@ -141,12 +142,25 @@ export const getAuthorLine = (
   if (publicationYear) {
     year = publicationYear;
   }
-  if (materialIsFiction(manifestation)) {
+  if (isMaterial("FICTION", manifestation)) {
     year = `(${t("materialHeaderAllEditionsText")})`;
   }
   return !author
     ? null
     : [t("materialHeaderAuthorByText"), author, year].join(" ");
+};
+
+export const handleFictionOrNonFictionReservation = (
+  reservableManifestations: Manifestation[]
+) => {
+  const newestManifestation = orderManifestationsByYear(
+    reservableManifestations
+  )[0];
+
+  // If the material is nonfiction, only reserve the newest manifestation
+  return isMaterial("NONFICTION", newestManifestation)
+    ? [newestManifestation]
+    : reservableManifestations;
 };
 
 export default {};

--- a/src/components/reservation/reservation.test.ts
+++ b/src/components/reservation/reservation.test.ts
@@ -1,0 +1,97 @@
+const coverUrlPattern = /^https:\/\/res\.cloudinary\.com\/.*\.(jpg|jpeg|png)$/;
+
+describe("Reservation", () => {
+  beforeEach(() => {
+    cy.interceptRest({
+      aliasName: "user",
+      url: "**/agencyid/patrons/patronid/v2",
+      fixtureFilePath: "material/user.json"
+    });
+    cy.interceptRest({
+      aliasName: "holdings",
+      url: "**/agencyid/catalog/holdings/**",
+      fixtureFilePath: "material/holdings.json"
+    });
+    cy.interceptRest({
+      aliasName: "branches",
+      url: "**/agencyid/branches",
+      fixtureFilePath: "material/branches.json"
+    });
+    // Intercept covers.
+    cy.intercept(
+      {
+        url: coverUrlPattern
+      },
+      {
+        fixture: "images/cover.jpg"
+      }
+    );
+    cy.interceptRest({
+      aliasName: "Cover",
+      url: "**/api/v2/covers?**",
+      fixtureFilePath: "cover.json"
+    });
+    // Intercept like button
+    cy.intercept("HEAD", "**/list/default/**", {
+      statusCode: 404
+    }).as("Favorite list service");
+    // Intercept url "translation".
+    cy.interceptRest({
+      aliasName: "UrlProxy",
+      url: "**/dpl-url-proxy?url=**",
+      fixtureFilePath: "material/dpl-url-proxy.json"
+    });
+  });
+
+  it("Renders a reservation modal for fiction", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/fbi-api.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/availability.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--default&type=bog");
+
+    cy.getBySel("material-header-buttons-physical")
+      .should("be.visible")
+      .and("contain", "Reserve bog")
+      .click();
+
+    cy.getBySel("reservation-modal-list-item-text").should(
+      "contain",
+      "First available edition"
+    );
+  });
+
+  it("Renders a reservation modal for nonfiction", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/nonfiction-fbi-api.json"
+    });
+
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/nonfiction-availability.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--turen-gar-til-rom&type=bog");
+
+    cy.getBySel("material-header-buttons-physical")
+      .should("be.visible")
+      .and("contain", "Reserve bog")
+      .click();
+
+    cy.getBySel("reservation-modal-list-item-text").should(
+      "contain",
+      "29. udgave, 2021"
+    );
+  });
+});
+
+export default {};

--- a/src/core/utils/UseReservableManifestations.tsx
+++ b/src/core/utils/UseReservableManifestations.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import { filterManifestationsByType } from "../../apps/material/helper";
+import { handleFictionOrNonFictionReservation } from "../../components/reservation/helper";
 import { getAvailabilityV3 } from "../fbs/fbs";
 import { convertPostIdToFaustId, getAllFaustIds } from "./helpers/general";
 import { Manifestation } from "./types/entities";
 
+// TODO: add unit test see example in text.test.tsx
 const UseReservableManifestations = ({
   manifestations,
   type
@@ -31,11 +33,11 @@ const UseReservableManifestations = ({
 
     const fetchAvailability = async (m: Manifestation[]) => {
       // Fetch availability data.
-      const data = await getAvailabilityV3({
+      const availabilityData = await getAvailabilityV3({
         recordid: faustIds
       });
       // If we for some reason do not get any data, we return empty arrays.
-      if (!data) {
+      if (!availabilityData) {
         return { reservable: [], unReservable: [] };
       }
 
@@ -46,7 +48,7 @@ const UseReservableManifestations = ({
         : m;
       // Get manifestations that are reservable.
       const reservable = filterableManifestations.filter((manifestation) =>
-        data.some(
+        availabilityData.some(
           (item) =>
             item.reservable &&
             item.recordId === convertPostIdToFaustId(manifestation.pid)
@@ -54,7 +56,7 @@ const UseReservableManifestations = ({
       );
       // Get manifestations that are unReservable.
       const unReservable = filterableManifestations.filter((manifestation) =>
-        data.some(
+        availabilityData.some(
           (item) =>
             !item.reservable &&
             item.recordId === convertPostIdToFaustId(manifestation.pid)
@@ -64,7 +66,9 @@ const UseReservableManifestations = ({
     };
 
     fetchAvailability(manifestations).then(({ reservable, unReservable }) => {
-      setReservableManifestations(reservable);
+      setReservableManifestations(
+        handleFictionOrNonFictionReservation(reservable)
+      );
       setUnReservableManifestations(unReservable);
     });
   }, [

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -8,7 +8,7 @@ import configuration, {
   getDeviceConf,
   ConfScope
 } from "../../configuration";
-import { Manifestation, Work } from "../types/entities";
+import { FictionNonfictionType, Manifestation, Work } from "../types/entities";
 import { FaustId, Pid } from "../types/ids";
 import { getUrlQueryParam } from "./url";
 import { LoanType } from "../types/loan-type";
@@ -249,9 +249,11 @@ export const getManifestationsPids = (manifestations: Manifestation[]) => {
 };
 export const stringifyValue = (value: string | null | undefined) =>
   value ? String(value) : "";
-export const materialIsFiction = ({
-  fictionNonfiction
-}: Work | Manifestation) => fictionNonfiction?.code === "FICTION";
+
+export const isMaterial = (
+  type: FictionNonfictionType,
+  material: Work | Manifestation
+) => material?.fictionNonfiction?.code === type;
 
 export const getListItems = (list: ListType[], itemsShown: number) => {
   return [...list].splice(0, itemsShown);

--- a/src/core/utils/types/entities.ts
+++ b/src/core/utils/types/entities.ts
@@ -1,4 +1,5 @@
 import {
+  FictionNonfictionCode,
   ManifestationsSimpleFieldsFragment,
   WorkMediumFragment
 } from "../../dbc-gateway/generated/graphql";
@@ -7,6 +8,7 @@ import { Pid, WorkId } from "./ids";
 export type Manifestation = Omit<ManifestationsSimpleFieldsFragment, "pid"> & {
   pid: Pid;
 };
+
 export type Work = Omit<WorkMediumFragment, "workId" | "manifestations"> & {
   workId: WorkId;
   manifestations: {
@@ -16,3 +18,5 @@ export type Work = Omit<WorkMediumFragment, "workId" | "manifestations"> & {
     bestRepresentation: Manifestation;
   };
 };
+
+export type FictionNonfictionType = `${FictionNonfictionCode}`;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-35

#### This PR Add handleFictionOrNonFictionReservation + Refactor materialIsFiction

- adds a new function 'handleFictionOrNonFictionReservation' which handles reserving the newest manifestation for nonfiction materials and all reservable manifestations for fiction materials.

- 'materialIsFiction' was restructured to 'isMaterial' to be more flexible to specify the material type. so 'isMaterial' function can now be used in a wider range of contexts.


#### Screenshot of the result

![image](https://user-images.githubusercontent.com/49920322/219676568-a2fb2c2e-0b42-4733-b0d0-756b240b358a.png)

![image](https://user-images.githubusercontent.com/49920322/219676652-91a4b94b-85fe-4824-960f-3018a55d907b.png)


DEV Screenshot:
![Skærmbillede 2023-02-17 kl  12 35 33](https://user-images.githubusercontent.com/49920322/219676358-efed369d-e328-423b-bce4-5cd613f1d00c.png)
![Skærmbillede 2023-02-17 kl  12 34 42](https://user-images.githubusercontent.com/49920322/219676362-ad3ac69a-7193-42e5-b448-b41780c9b91f.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.