### PR TITLE
Refactor `constructMaterialUrl` to use 'new URL' object

### DIFF
--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -82,7 +82,7 @@ export const constructMaterialUrl = (
   workId: WorkId,
   type?: string
 ) => {
-  const materialUrl = new URL(url.href);
+  const materialUrl = new URL(url);
 
   // Replace placeholders with values.
   materialUrl.pathname = processUrlPlaceholders(materialUrl.pathname, [

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -82,9 +82,10 @@ export const constructMaterialUrl = (
   workId: WorkId,
   type?: string
 ) => {
-  const materialUrl = url;
+  const materialUrl = new URL(url.href);
+
   // Replace placeholders with values.
-  materialUrl.pathname = processUrlPlaceholders(url.pathname, [
+  materialUrl.pathname = processUrlPlaceholders(materialUrl.pathname, [
     [":workid", workId]
   ]);
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-474

####  This PR fixes an issue with the `constructMaterialUrl` function that modifies the original URL object instead of creating a new one, potentially causing bugs in other parts of the code.

The code changes include:
- Creating a new URL object materialUrl using the original URL object.

These changes ensure that the constructMaterialUrl function behaves as intended and avoids unintended side effects.

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.