### PR TITLE
Fix release year on search result page

### DIFF
--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -75,6 +75,14 @@ describe("Search Result", () => {
     );
   });
 
+  it("Renders the correct release year for fictional works", () => {
+    cy.getBySel("search-result-list-item").eq(1).should("contain", "1997");
+  });
+
+  it("Renders the correct release year for non-fictional works", () => {
+    cy.getBySel("search-result-list-item").first().should("contain", "2018");
+  });
+
   beforeEach(() => {
     // Intercept graphql search query.
     cy.fixture("search-result/fbi-api.json")

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -36,6 +36,7 @@ export interface SearchResultListItemProps {
   item: Work;
   coverTint: CoverProps["tint"];
   resultNumber: number;
+  dataCy?: string;
 }
 
 const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
@@ -48,7 +49,8 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     workId
   },
   coverTint,
-  resultNumber
+  resultNumber,
+  dataCy = "search-result-list-item"
 }) => {
   const t = useText();
   const { materialUrl, searchUrl } = useUrls();
@@ -101,6 +103,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <article
       ref={itemRef}
+      data-cy={dataCy}
       className="search-result-item arrow arrow__hover--right-small"
       onClick={handleClick}
       onKeyUp={(e) => e.key === "Enter" && handleClick}

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -456,7 +456,7 @@ export const getReleaseYearSearchResult = (work: Work) => {
     );
   }
   // If it isn't fiction we get release year from latest manifestation.
-  return getManifestationPublicationYear(latest) || latest.workYear?.year;
+  return getManifestationPublicationYear(latest) || "";
 };
 
 // Creates a "by author, author and author"-string

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -438,15 +438,15 @@ export const getReviewRelease = (
 };
 
 // The rendered release year for search results is picked based on
-// whether the work is fiction or not.
+// whether the work is fiction or not. Non-fictional works contain
+// factual information that can be updated between editions - thus it
+// is important to show the latest edition the library has.
 export const getReleaseYearSearchResult = (work: Work) => {
   const { latest, bestRepresentation } = work.manifestations;
   const manifestation = bestRepresentation || latest;
-  // If the work tells us that it is fiction.
   if (materialIsFiction(work)) {
     return work.workYear?.year;
   }
-  // If the manifestation tells us that it is fiction.
   if (materialIsFiction(manifestation)) {
     return (
       work.workYear?.year ||
@@ -455,7 +455,6 @@ export const getReleaseYearSearchResult = (work: Work) => {
       manifestation.edition?.publicationYear?.display
     );
   }
-  // If it isn't fiction we get release year from latest manifestation.
   return getManifestationPublicationYear(latest) || "";
 };
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -430,6 +430,8 @@ export const getReleaseYearSearchResult = (work: Work) => {
   // If the manifestation tells us that it is fiction.
   if (materialIsFiction(manifestation)) {
     return (
+      work.workYear?.year ||
+      manifestation.workYear?.year ||
       manifestation.dateFirstEdition?.year ||
       manifestation.edition?.publicationYear?.display
     );


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-404

#### Description
This PR fixes an issue with not choosing the correct release year to render on the search result page. 

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a