### PR TITLE
Add selected materialType to `constructMaterialUrl`

### DIFF
--- a/src/apps/search-result/helper.ts
+++ b/src/apps/search-result/helper.ts
@@ -1,0 +1,20 @@
+import { head } from "lodash";
+import { FacetField } from "../../core/dbc-gateway/generated/graphql";
+import { Filter } from "../../core/filter.slice";
+import { getMaterialTypes } from "../../core/utils/helpers/general";
+import { Manifestation } from "../../core/utils/types/entities";
+
+export const getFirstMaterialTypeFromFilters = (
+  filters: Filter,
+  manifestations: Manifestation[]
+) => {
+  const materialTypeFilter = head(
+    Object.keys(filters[FacetField.MaterialTypes] || {}).sort()
+  );
+  const allMaterialTypes = getMaterialTypes(manifestations);
+  return materialTypeFilter && allMaterialTypes.includes(materialTypeFilter)
+    ? materialTypeFilter
+    : undefined;
+};
+
+export default {};

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -1,12 +1,10 @@
-import { head, mapValues } from "lodash";
+import { mapValues } from "lodash";
 import {
   FacetField,
   useSearchFacetQuery
 } from "../../core/dbc-gateway/generated/graphql";
 import useGetCleanBranches from "../../core/utils/branches";
 import { Filter, FilterItemTerm } from "../../core/filter.slice";
-import { getMaterialTypes } from "../../core/utils/helpers/general";
-import { Manifestation } from "../../core/utils/types/entities";
 
 export const allFacetFields = [
   FacetField.MainLanguages,
@@ -101,18 +99,5 @@ export function getAllFilterPathsAsString(filterObject: {
   });
   return allFilterPathsAsString;
 }
-
-export const getFirstMaterialTypeFromFilters = (
-  filters: Filter,
-  manifestations: Manifestation[]
-) => {
-  const materialTypeFilter = head(
-    Object.keys(filters[FacetField.MaterialTypes] || {}).sort()
-  );
-  const allMaterialTypes = getMaterialTypes(manifestations);
-  return materialTypeFilter && allMaterialTypes.includes(materialTypeFilter)
-    ? materialTypeFilter
-    : undefined;
-};
 
 export default {};

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -5,6 +5,8 @@ import {
 } from "../../core/dbc-gateway/generated/graphql";
 import useGetCleanBranches from "../../core/utils/branches";
 import { Filter, FilterItemTerm } from "../../core/filter.slice";
+import { getMaterialTypes } from "../../core/utils/helpers/general";
+import { Manifestation } from "../../core/utils/types/entities";
 
 export const allFacetFields = [
   FacetField.MainLanguages,
@@ -99,5 +101,16 @@ export function getAllFilterPathsAsString(filterObject: {
   });
   return allFilterPathsAsString;
 }
+
+export const getFirstMaterialTypeFromFilters = (
+  filters: Filter,
+  manifestations: Manifestation[]
+) => {
+  const materialTypeFilter = Object.keys(filters.materialTypes || {}).sort()[0];
+  const allMaterialTypes = getMaterialTypes(manifestations);
+  return allMaterialTypes.includes(materialTypeFilter)
+    ? materialTypeFilter
+    : undefined;
+};
 
 export default {};

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -1,4 +1,4 @@
-import { mapValues } from "lodash";
+import { head, mapValues } from "lodash";
 import {
   FacetField,
   useSearchFacetQuery
@@ -106,9 +106,11 @@ export const getFirstMaterialTypeFromFilters = (
   filters: Filter,
   manifestations: Manifestation[]
 ) => {
-  const materialTypeFilter = Object.keys(filters.materialTypes || {}).sort()[0];
+  const materialTypeFilter = head(
+    Object.keys(filters[FacetField.MaterialTypes] || {}).sort()
+  );
   const allMaterialTypes = getMaterialTypes(manifestations);
-  return allMaterialTypes.includes(materialTypeFilter)
+  return materialTypeFilter && allMaterialTypes.includes(materialTypeFilter)
     ? materialTypeFilter
     : undefined;
 };

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -32,7 +32,7 @@ import { statistics } from "../../../core/statistics/statistics";
 import { useItemHasBeenVisible } from "../../../core/utils/helpers/lazy-load";
 import { getNumberedSeries } from "../../../apps/material/helper";
 import useFilterHandler from "../../../apps/search-result/useFilterHandler";
-import { getFirstMaterialTypeFromFilters } from "../../facet-browser/helper";
+import { getFirstMaterialTypeFromFilters } from "../../../apps/search-result/helper";
 
 export interface SearchResultListItemProps {
   item: Work;

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -31,6 +31,8 @@ import { useStatistics } from "../../../core/statistics/useStatistics";
 import { statistics } from "../../../core/statistics/statistics";
 import { useItemHasBeenVisible } from "../../../core/utils/helpers/lazy-load";
 import { getNumberedSeries } from "../../../apps/material/helper";
+import useFilterHandler from "../../../apps/search-result/useFilterHandler";
+import { getFirstMaterialTypeFromFilters } from "../../facet-browser/helper";
 
 export interface SearchResultListItemProps {
   item: Work;
@@ -52,6 +54,12 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
 }) => {
   const t = useText();
   const { materialUrl, searchUrl } = useUrls();
+  const { filters } = useFilterHandler();
+  const materialTypeFromFilters = getFirstMaterialTypeFromFilters(
+    filters,
+    manifestations
+  );
+
   const dispatch = useDispatch<TypedDispatch>();
   const author = creatorsToString(
     flattenCreators(filterCreators(creators, ["Person"])),
@@ -59,7 +67,11 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   );
   const manifestationPid = getManifestationPid(manifestations);
   const firstItemInSeries = getNumberedSeries(series).shift();
-  const materialFullUrl = constructMaterialUrl(materialUrl, workId as WorkId);
+  const materialFullUrl = constructMaterialUrl(
+    materialUrl,
+    workId as WorkId,
+    materialTypeFromFilters
+  );
   const { track } = useStatistics();
   // We use hasBeenVisible to determine if the search result
   // is, or has been, visible in the viewport.


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-463

#### This pull request adds a new function called `getFirstMaterialTypeFromFilters` 

its retrieves the first materialType from filters that are included in manifestations. it is then used to construct the materialFullUrl in the `SearchResultListItem`

#### Screenshot of the result

https://user-images.githubusercontent.com/49920322/223070074-346bc298-6bc1-4465-a6f9-53c92eb3aa0f.mov


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.