### PR TITLE
Refactor `usePager` to accept  'isLoading'

### DIFF
--- a/src/apps/loan-list/list/list.tsx
+++ b/src/apps/loan-list/list/list.tsx
@@ -65,7 +65,7 @@ const List: FC<ListProps> = ({
             loans={displayedLoans}
             view={view}
           />
-          {PagerComponent}
+          <PagerComponent />
         </>
       )}
       {loans.length === 0 && <EmptyList emptyListText={emptyListLabel} />}

--- a/src/apps/loan-list/list/list.tsx
+++ b/src/apps/loan-list/list/list.tsx
@@ -38,11 +38,11 @@ const List: FC<ListProps> = ({
     return displayedLoans.length;
   };
 
-  const { itemsShown, PagerComponent } = usePager(
-    loans.length,
+  const { itemsShown, PagerComponent } = usePager({
+    hitcount: loans.length,
     pageSize,
-    view === "list" ? undefined : overrideItemsShown
-  );
+    overrideItemsShown: view === "list" ? undefined : overrideItemsShown
+  });
 
   useEffect(() => {
     if (view === "list") {

--- a/src/apps/loan-list/modal/renew-loans-modal-content.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal-content.tsx
@@ -137,7 +137,7 @@ const RenewLoansModalContent: FC<RenewLoansModalContentProps> = ({
               />
             );
           })}
-          {PagerComponent}
+          <PagerComponent />
         </ul>
         {!isVisible && (
           <div className="modal-loan__buttons modal-loan__buttons--bottom">

--- a/src/apps/loan-list/modal/renew-loans-modal-content.tsx
+++ b/src/apps/loan-list/modal/renew-loans-modal-content.tsx
@@ -32,7 +32,10 @@ const RenewLoansModalContent: FC<RenewLoansModalContentProps> = ({
   const queryClient = useQueryClient();
   const { close } = useModalButtonHandler();
   const renewableMaterials = getAmountOfRenewableLoans(loansModal);
-  const { itemsShown, PagerComponent } = usePager(loansModal.length, pageSize);
+  const { itemsShown, PagerComponent } = usePager({
+    hitcount: loansModal.length,
+    pageSize
+  });
   const intersectionRef = React.useRef(null);
   const { isIntersecting: isVisible } = useIntersection(intersectionRef, {
     threshold: 0

--- a/src/apps/reservation-list/list/list.tsx
+++ b/src/apps/reservation-list/list/list.tsx
@@ -25,10 +25,10 @@ const List: FC<ListProps> = ({
   const [displayedReservations, setDisplayedReservations] = useState<
     ReservationType[]
   >([]);
-  const { itemsShown, PagerComponent } = usePager(
-    reservations.length,
+  const { itemsShown, PagerComponent } = usePager({
+    hitcount: reservations.length,
     pageSize
-  );
+  });
 
   useEffect(() => {
     if (reservations) {

--- a/src/apps/reservation-list/list/list.tsx
+++ b/src/apps/reservation-list/list/list.tsx
@@ -70,7 +70,7 @@ const List: FC<ListProps> = ({
                 />
               ))}
             </ul>
-            {PagerComponent}
+            <PagerComponent />
           </div>
         </>
       ) : (

--- a/src/apps/search-header/search-header.dev.tsx
+++ b/src/apps/search-header/search-header.dev.tsx
@@ -101,7 +101,7 @@ export default {
       defaultValue: "in",
       control: { type: "text" }
     },
-    LoadingText: {
+    loadingText: {
       name: "Loading",
       defaultValue: "Loading",
       control: { type: "text" }

--- a/src/apps/search-result/search-result.dev.tsx
+++ b/src/apps/search-result/search-result.dev.tsx
@@ -192,6 +192,11 @@ export default {
       name: "Alert error message text",
       defaultValue: "An error occurred",
       control: { type: "text" }
+    },
+    loadingText: {
+      name: "Loading",
+      defaultValue: "Loading",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof SearchResultEntry>;

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -7,9 +7,9 @@ import { withUrls } from "../../core/utils/url";
 import SearchResult from "./search-result";
 
 interface SearchResultEntryTextProps {
+  addMoreFiltersText: string;
   alertErrorCloseText: string;
   alertErrorMessageText: string;
-  addMoreFiltersText: string;
   byAuthorText: string;
   clearAllText: string;
   etAlText: string;
@@ -26,6 +26,7 @@ interface SearchResultEntryTextProps {
   facetWorkTypesText: string;
   filterListText: string;
   inSeriesText: string;
+  loadingText: string;
   numberDescriptionText: string;
   resultPagerStatusText: string;
   showingResultsForText: string;

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -39,11 +39,9 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   const [resultItems, setResultItems] = useState<Work[]>([]);
   const [hitcount, setHitCount] = useState<number>(0);
   const [canWeTrackHitcount, setCanWeTrackHitcount] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const { PagerComponent, page } = usePager({
     hitcount,
-    pageSize,
-    isLoading
+    pageSize
   });
   const { mutate } = useCampaignMatchPOST();
   const [campaignData, setCampaignData] = useState<CampaignMatchPOST200 | null>(
@@ -102,7 +100,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { data } = useSearchWithPaginationQuery({
+  const { data, isLoading } = useSearchWithPaginationQuery({
     q: { all: q },
     offset: page * pageSize,
     limit: pageSize,
@@ -110,7 +108,6 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   });
 
   useEffect(() => {
-    setIsLoading(true);
     if (!data) {
       return;
     }
@@ -125,8 +122,6 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
     };
 
     setHitCount(resultCount);
-
-    setIsLoading(false);
 
     // if page has change then append the new result to the existing result
     if (page > 0) {
@@ -181,7 +176,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
         <Campaign campaignData={campaignData.data} />
       )}
       <SearchResultList resultItems={resultItems} />
-      {PagerComponent}
+      <PagerComponent isLoading={isLoading} />
       {dataIsNotEmpty(resultItems) && <FacetBrowserModal q={q} />}
     </div>
   );

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -39,7 +39,12 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   const [resultItems, setResultItems] = useState<Work[]>([]);
   const [hitcount, setHitCount] = useState<number>(0);
   const [canWeTrackHitcount, setCanWeTrackHitcount] = useState<boolean>(false);
-  const { PagerComponent, page } = usePager(hitcount, pageSize);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const { PagerComponent, page } = usePager({
+    hitcount,
+    pageSize,
+    isLoading
+  });
   const { mutate } = useCampaignMatchPOST();
   const [campaignData, setCampaignData] = useState<CampaignMatchPOST200 | null>(
     null
@@ -105,6 +110,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   });
 
   useEffect(() => {
+    setIsLoading(true);
     if (!data) {
       return;
     }
@@ -119,6 +125,8 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
     };
 
     setHitCount(resultCount);
+
+    setIsLoading(false);
 
     // if page has change then append the new result to the existing result
     if (page > 0) {

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -38,7 +38,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
   if (isLoading && !textData) {
     return (
       <ul className="autosuggest pb-16" data-cy={dataCy}>
-        <li className="ml-24">{t("LoadingText")}</li>
+        <li className="ml-24">{t("loadingText")}</li>
       </ul>
     );
   }

--- a/src/components/result-pager/result-pager.tsx
+++ b/src/components/result-pager/result-pager.tsx
@@ -5,11 +5,13 @@ export interface ResultPagerProps {
   setPageHandler: () => void;
   itemsShown: number;
   hitcount: number;
+  isLoading?: boolean;
 }
 function ResultPager({
   setPageHandler,
   itemsShown,
-  hitcount
+  hitcount,
+  isLoading
 }: ResultPagerProps) {
   const t = useText();
   return (
@@ -22,12 +24,15 @@ function ResultPager({
       {/* If all items are not visible yet, we need to show the button. */}
       {itemsShown !== hitcount && (
         <button
+          disabled={isLoading}
           type="button"
           className="btn-primary btn-outline btn-medium arrow__hover--right-small"
           onClick={setPageHandler}
         >
           {/* TODO: Solve casing in CSS */}
-          {t("showMoreText").toUpperCase()}
+          {isLoading
+            ? t("loadingText").toUpperCase()
+            : t("showMoreText").toUpperCase()}
         </button>
       )}
     </div>

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -5,15 +5,13 @@ type PagerProps = {
   hitcount: number;
   pageSize: number;
   overrideItemsShown?: () => number;
+};
+
+type PagerComponentProps = {
   isLoading?: boolean;
 };
 
-const usePager = ({
-  hitcount,
-  pageSize,
-  overrideItemsShown,
-  isLoading
-}: PagerProps) => {
+const usePager = ({ hitcount, pageSize, overrideItemsShown }: PagerProps) => {
   const [itemsShown, setItemsShown] = useState(
     pageSize >= hitcount ? hitcount : pageSize
   );
@@ -34,14 +32,15 @@ const usePager = ({
     setPage(currentPage);
   };
 
-  const PagerComponent = hitcount ? (
-    <ResultPager
-      itemsShown={overrideItemsShown ? overrideItemsShown() : itemsShown}
-      hitcount={hitcount}
-      setPageHandler={pagehandler}
-      isLoading={isLoading}
-    />
-  ) : null;
+  const PagerComponent: React.FC<PagerComponentProps> = ({ isLoading }) =>
+    hitcount ? (
+      <ResultPager
+        itemsShown={overrideItemsShown ? overrideItemsShown() : itemsShown}
+        hitcount={hitcount}
+        setPageHandler={pagehandler}
+        isLoading={isLoading}
+      />
+    ) : null;
 
   return { itemsShown, PagerComponent, page };
 };

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -1,11 +1,19 @@
 import React, { useState, useEffect } from "react";
 import ResultPager from "./result-pager";
 
-const usePager = (
-  hitcount: number,
-  pageSize: number,
-  overrideItemsShown?: () => number
-) => {
+type PagerProps = {
+  hitcount: number;
+  pageSize: number;
+  overrideItemsShown?: () => number;
+  isLoading?: boolean;
+};
+
+const usePager = ({
+  hitcount,
+  pageSize,
+  overrideItemsShown,
+  isLoading
+}: PagerProps) => {
   const [itemsShown, setItemsShown] = useState(
     pageSize >= hitcount ? hitcount : pageSize
   );
@@ -31,6 +39,7 @@ const usePager = (
       itemsShown={overrideItemsShown ? overrideItemsShown() : itemsShown}
       hitcount={hitcount}
       setPageHandler={pagehandler}
+      isLoading={isLoading}
     />
   ) : null;
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-459

#### This PR refactors the `usePager` hook to accept a PagerProps object as an argument, which contains hitcount, pageSize, overrideItemsShown, and the new isLoading properties. 

The isLoading property is used to show a loading indicator while the search results are loading.

**Changes Made:**

- Refactored usePager to accept PagerProps object.
- Added isLoading property in PagerProps.
- Updated search-result, result-pager, and autosuggest components to use the new PagerProps.


#### Screenshot of the result
https://user-images.githubusercontent.com/49920322/223100785-3a3d2e4c-e2e5-45f2-9210-1101f388b454.mov

#### Additional comments or questions
It also updates the search-result, result-pager, and autosuggest components to use the new PagerProps object in usePager.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.