### PR TITLE
Add 'aria-pressed' attribute to `AvailabilityLabel`

### DIFF
--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -225,7 +225,7 @@ describe("Material", () => {
     );
   });
 
-  it("Check if selected availability label have aria-pressed=true", () => {
+  it("Has a selected availability label based on url parameter", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -242,7 +242,7 @@ describe("Material", () => {
       .should("have.attr", "aria-pressed", "true");
   });
 
-  it("Check if unselected availability label have aria-pressed=false", () => {
+  it("Does not have selected availability labels which does not match url parameter", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -225,6 +225,40 @@ describe("Material", () => {
     );
   });
 
+  it("Check if selected availability label have aria-pressed=true", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/fbi-api.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+
+    cy.getBySel("material-description").scrollIntoView();
+
+    cy.getBySel("availability-label")
+      .find('[data-cy="availability-label-type"]')
+      .contains("bog")
+      .parent()
+      .should("have.attr", "aria-pressed", "true");
+  });
+
+  it("Check if unselected availability label have aria-pressed=false", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/fbi-api.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+
+    cy.getBySel("material-description").scrollIntoView();
+
+    cy.getBySel("availability-label")
+      .find('[data-cy="availability-label-type"]')
+      .contains("lydbog")
+      .parent()
+      .should("have.attr", "aria-pressed", "false");
+  });
+
   beforeEach(() => {
     cy.interceptRest({
       httpMethod: "POST",

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -91,6 +91,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
       role="button"
       tabIndex={0}
       data-cy={dataCy}
+      aria-pressed={selected}
     >
       <div className={classes.triangle} />
       <img className={classes.check} src={CheckIcon} alt="check-icon" />

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -94,7 +94,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
       aria-pressed={selected}
     >
       <div className={classes.triangle} />
-      <img className={classes.check} src={CheckIcon} alt="check-icon" />
+      <img className={classes.check} src={CheckIcon} alt="" />
       {manifestText && (
         <>
           <p


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-449

#### Add 'aria-pressed' attribute to AvailabilityLabel

The aria-pressed attribute has been added to the AvailabilityLabel component in the availability-label.tsx file. The selected prop is used to determine the value of the aria-pressed attribute. Additionally, two Cypress tests have been added to ensure that the aria-pressed attribute is correctly set for both selected and unselected availability labels.

Changes Made:
- Added aria-pressed attribute to the AvailabilityLabel component
- Added two Cypress tests to ensure correct behavior of aria-pressed attribute


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.