### PR TITLE
Fix/autosuggest accessibility

### DIFF
--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -25,33 +25,36 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
 }) => {
   const t = useText();
   return (
-    <>
-      {/* eslint-disable react/jsx-props-no-spreading */}
-      {/* The downshift combobox works this way by design (line 43) */}
-      {categoryData.map((item, incorrectIndex) => {
-        // incorrectIndex because in the whole of autosuggest dropdown it is
-        // not the correct index for the item. We first need to add the length of
-        // items from autosuggest string suggestion to it for it to be accurate (=> index)
-        const index = incorrectIndex + textAndMaterialDataLength;
-        return (
-          <li
-            className={`autosuggest__text text-body-medium-regular px-24 ${clsx(
-              {
-                "autosuggest__text--highlight": highlightedIndex === index
-              }
-            )}`}
-            key={item}
-            {...getItemProps({ item, index })}
-            data-cy={dataCy}
-          >
-            {`${item.term} ${t("inText")}`}
-            <div className="boxed-text text-tags noselect ml-8">
-              {autosuggestCategoryList[incorrectIndex].render}
-            </div>
-          </li>
-        );
-      })}
-    </>
+    <li>
+      <ul role="listbox">
+        {/* eslint-disable react/jsx-props-no-spreading */}
+        {/* The downshift combobox works this way by design (line 43) */}
+        {categoryData.map((item, incorrectIndex) => {
+          // incorrectIndex because in the whole of autosuggest dropdown it is
+          // not the correct index for the item. We first need to add the length of
+          // items from autosuggest string suggestion to it for it to be accurate (=> index)
+          const index = incorrectIndex + textAndMaterialDataLength;
+          return (
+            <li
+              className={`autosuggest__text text-body-medium-regular px-24 ${clsx(
+                {
+                  "autosuggest__text--highlight": highlightedIndex === index
+                }
+              )}`}
+              key={item}
+              {...getItemProps({ item, index })}
+              data-cy={dataCy}
+              id={`suggestion-${index + 1}`}
+            >
+              {`${item.term} ${t("inText")}`}
+              <div className="boxed-text text-tags noselect ml-8">
+                {autosuggestCategoryList[incorrectIndex].render}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </li>
   );
 };
 

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -25,35 +25,33 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
 }) => {
   const t = useText();
   return (
-    <li>
-      <ul>
-        {/* eslint-disable react/jsx-props-no-spreading */}
-        {/* The downshift combobox works this way by design (line 43) */}
-        {categoryData.map((item, incorrectIndex) => {
-          // incorrectIndex because in the whole of autosuggest dropdown it is
-          // not the correct index for the item. We first need to add the length of
-          // items from autosuggest string suggestion to it for it to be accurate (=> index)
-          const index = incorrectIndex + textAndMaterialDataLength;
-          return (
-            <li
-              className={`autosuggest__text text-body-medium-regular px-24 ${clsx(
-                {
-                  "autosuggest__text--highlight": highlightedIndex === index
-                }
-              )}`}
-              key={item}
-              {...getItemProps({ item, index })}
-              data-cy={dataCy}
-            >
-              {`${item.term} ${t("inText")}`}
-              <div className="boxed-text text-tags noselect ml-8">
-                {autosuggestCategoryList[incorrectIndex].render}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </li>
+    <>
+      {/* eslint-disable react/jsx-props-no-spreading */}
+      {/* The downshift combobox works this way by design (line 43) */}
+      {categoryData.map((item, incorrectIndex) => {
+        // incorrectIndex because in the whole of autosuggest dropdown it is
+        // not the correct index for the item. We first need to add the length of
+        // items from autosuggest string suggestion to it for it to be accurate (=> index)
+        const index = incorrectIndex + textAndMaterialDataLength;
+        return (
+          <li
+            className={`autosuggest__text text-body-medium-regular px-24 ${clsx(
+              {
+                "autosuggest__text--highlight": highlightedIndex === index
+              }
+            )}`}
+            key={item}
+            {...getItemProps({ item, index })}
+            data-cy={dataCy}
+          >
+            {`${item.term} ${t("inText")}`}
+            <div className="boxed-text text-tags noselect ml-8">
+              {autosuggestCategoryList[incorrectIndex].render}
+            </div>
+          </li>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -44,7 +44,6 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
               key={item}
               {...getItemProps({ item, index })}
               data-cy={dataCy}
-              id={`suggestion-${index + 1}`}
             >
               {`${item.term} ${t("inText")}`}
               <div className="boxed-text text-tags noselect ml-8">

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -26,60 +26,58 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
 }) => {
   const t = useText();
   return (
-    <li>
-      <ul className="autosuggest__materials">
-        {/* eslint-disable react/jsx-props-no-spreading */}
-        {/* The downshift combobox works this way by design (line 54) */}
-        {materialData.map((item, incorrectIndex) => {
-          // incorrectIndex because in the whole of autosuggest dropdown it is
-          // not the correct index for the item. We first need to add the length of
-          // items from autosuggest string suggestion to it for it to be accurate (=> index)
-          const index = incorrectIndex + textDataLength;
-          const { work } = item;
-          if (!work) {
-            return null;
-          }
-          const { creators } = work;
-          const authors = flattenCreators(
-            creators as WorkSmallFragment["creators"]
-          );
+    <ul className="autosuggest__materials" role="listbox">
+      {/* eslint-disable react/jsx-props-no-spreading */}
+      {/* The downshift combobox works this way by design (line 54) */}
+      {materialData.map((item, incorrectIndex) => {
+        // incorrectIndex because in the whole of autosuggest dropdown it is
+        // not the correct index for the item. We first need to add the length of
+        // items from autosuggest string suggestion to it for it to be accurate (=> index)
+        const index = incorrectIndex + textDataLength;
+        const { work } = item;
+        if (!work) {
+          return null;
+        }
+        const { creators } = work;
+        const authors = flattenCreators(
+          creators as WorkSmallFragment["creators"]
+        );
 
-          return (
-            <li
-              className={`autosuggest__material ${
-                highlightedIndex === index
-                  ? "autosuggest__material--highlight"
-                  : ""
-              }`}
-              key={item.work?.workId}
-              {...getItemProps({ item, index })}
-              data-cy={dataCy}
-            >
-              {/* eslint-enable react/jsx-props-no-spreading */}
-              <div className="autosuggest__material__content">
-                {item.work && (
-                  <Cover
-                    animate
-                    size="xsmall"
-                    id={item.work.manifestations.bestRepresentation.pid}
-                    shadow
-                  />
-                )}
+        return (
+          <li
+            className={`autosuggest__material ${
+              highlightedIndex === index
+                ? "autosuggest__material--highlight"
+                : ""
+            }`}
+            key={item.work?.workId}
+            {...getItemProps({ item, index })}
+            data-cy={dataCy}
+          >
+            {/* eslint-enable react/jsx-props-no-spreading */}
+            <div className="autosuggest__material__content">
+              {item.work && (
+                <Cover
+                  animate
+                  size="xsmall"
+                  id={item.work.manifestations.bestRepresentation.pid}
+                  shadow
+                />
+              )}
 
-                <div className="autosuggest__info">
-                  <div className="text-body-medium-medium autosuggest__title">
-                    {item.work?.titles.main[0]}
-                  </div>
-                  <div className="text-body-small-regular autosuggest__author">
-                    {creatorsToString(authors, t)}
-                  </div>
+              <div className="autosuggest__info">
+                <div className="text-body-medium-medium autosuggest__title">
+                  {item.work?.titles.main[0]}
+                </div>
+                <div className="text-body-small-regular autosuggest__author">
+                  {creatorsToString(authors, t)}
                 </div>
               </div>
-            </li>
-          );
-        })}
-      </ul>
-    </li>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
   );
 };
 

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -54,7 +54,6 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
               key={item.work?.workId}
               {...getItemProps({ item, index })}
               data-cy={dataCy}
-              id={`suggestion-${index + 1}`}
             >
               {/* eslint-enable react/jsx-props-no-spreading */}
               <div className="autosuggest__material__content">

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -26,58 +26,61 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
 }) => {
   const t = useText();
   return (
-    <ul className="autosuggest__materials" role="listbox">
-      {/* eslint-disable react/jsx-props-no-spreading */}
-      {/* The downshift combobox works this way by design (line 54) */}
-      {materialData.map((item, incorrectIndex) => {
-        // incorrectIndex because in the whole of autosuggest dropdown it is
-        // not the correct index for the item. We first need to add the length of
-        // items from autosuggest string suggestion to it for it to be accurate (=> index)
-        const index = incorrectIndex + textDataLength;
-        const { work } = item;
-        if (!work) {
-          return null;
-        }
-        const { creators } = work;
-        const authors = flattenCreators(
-          creators as WorkSmallFragment["creators"]
-        );
+    <li>
+      <ul className="autosuggest__materials" role="listbox">
+        {/* eslint-disable react/jsx-props-no-spreading */}
+        {/* The downshift combobox works this way by design (line 54) */}
+        {materialData.map((item, incorrectIndex) => {
+          // incorrectIndex because in the whole of autosuggest dropdown it is
+          // not the correct index for the item. We first need to add the length of
+          // items from autosuggest string suggestion to it for it to be accurate (=> index)
+          const index = incorrectIndex + textDataLength;
+          const { work } = item;
+          if (!work) {
+            return null;
+          }
+          const { creators } = work;
+          const authors = flattenCreators(
+            creators as WorkSmallFragment["creators"]
+          );
 
-        return (
-          <li
-            className={`autosuggest__material ${
-              highlightedIndex === index
-                ? "autosuggest__material--highlight"
-                : ""
-            }`}
-            key={item.work?.workId}
-            {...getItemProps({ item, index })}
-            data-cy={dataCy}
-          >
-            {/* eslint-enable react/jsx-props-no-spreading */}
-            <div className="autosuggest__material__content">
-              {item.work && (
-                <Cover
-                  animate
-                  size="xsmall"
-                  id={item.work.manifestations.bestRepresentation.pid}
-                  shadow
-                />
-              )}
+          return (
+            <li
+              className={`autosuggest__material ${
+                highlightedIndex === index
+                  ? "autosuggest__material--highlight"
+                  : ""
+              }`}
+              key={item.work?.workId}
+              {...getItemProps({ item, index })}
+              data-cy={dataCy}
+              id={`suggestion-${index + 1}`}
+            >
+              {/* eslint-enable react/jsx-props-no-spreading */}
+              <div className="autosuggest__material__content">
+                {item.work && (
+                  <Cover
+                    animate
+                    size="xsmall"
+                    id={item.work.manifestations.bestRepresentation.pid}
+                    shadow
+                  />
+                )}
 
-              <div className="autosuggest__info">
-                <div className="text-body-medium-medium autosuggest__title">
-                  {item.work?.titles.main[0]}
-                </div>
-                <div className="text-body-small-regular autosuggest__author">
-                  {creatorsToString(authors, t)}
+                <div className="autosuggest__info">
+                  <div className="text-body-medium-medium autosuggest__title">
+                    {item.work?.titles.main[0]}
+                  </div>
+                  <div className="text-body-small-regular autosuggest__author">
+                    {creatorsToString(authors, t)}
+                  </div>
                 </div>
               </div>
-            </div>
-          </li>
-        );
-      })}
-    </ul>
+            </li>
+          );
+        })}
+      </ul>
+    </li>
   );
 };
 

--- a/src/components/autosuggest-text/autosuggest-text-item.tsx
+++ b/src/components/autosuggest-text/autosuggest-text-item.tsx
@@ -33,7 +33,6 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
         key={generateItemId(item)}
         {...getItemProps({ item, index })}
         data-cy={dataCy}
-        id={`suggestion-${index + 1}`}
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
         {item.type === SuggestionType.Creator

--- a/src/components/autosuggest-text/autosuggest-text-item.tsx
+++ b/src/components/autosuggest-text/autosuggest-text-item.tsx
@@ -33,6 +33,7 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
         key={generateItemId(item)}
         {...getItemProps({ item, index })}
         data-cy={dataCy}
+        id={`suggestion-${index + 1}`}
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
         {item.type === SuggestionType.Creator

--- a/src/components/autosuggest-text/autosuggest-text.tsx
+++ b/src/components/autosuggest-text/autosuggest-text.tsx
@@ -33,28 +33,26 @@ export const AutosuggestText: React.FC<AutosuggestTextProps> = ({
   getItemProps
 }) => {
   return (
-    <li>
-      <ul>
-        {textData.map((item: Suggestion, index: number) => {
-          const classes = {
-            textSuggestion: `autosuggest__text text-body-medium-regular px-24 ${clsx(
-              {
-                "autosuggest__text--highlight": highlightedIndex === index
-              }
-            )}`
-          };
-          return (
-            <AutosuggestTextItem
-              classes={classes}
-              item={item}
-              index={index}
-              generateItemId={generateItemId}
-              getItemProps={getItemProps}
-            />
-          );
-        })}
-      </ul>
-    </li>
+    <>
+      {textData.map((item: Suggestion, index: number) => {
+        const classes = {
+          textSuggestion: `autosuggest__text text-body-medium-regular px-24 ${clsx(
+            {
+              "autosuggest__text--highlight": highlightedIndex === index
+            }
+          )}`
+        };
+        return (
+          <AutosuggestTextItem
+            classes={classes}
+            item={item}
+            index={index}
+            generateItemId={generateItemId}
+            getItemProps={getItemProps}
+          />
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/autosuggest-text/autosuggest-text.tsx
+++ b/src/components/autosuggest-text/autosuggest-text.tsx
@@ -33,26 +33,28 @@ export const AutosuggestText: React.FC<AutosuggestTextProps> = ({
   getItemProps
 }) => {
   return (
-    <>
-      {textData.map((item: Suggestion, index: number) => {
-        const classes = {
-          textSuggestion: `autosuggest__text text-body-medium-regular px-24 ${clsx(
-            {
-              "autosuggest__text--highlight": highlightedIndex === index
-            }
-          )}`
-        };
-        return (
-          <AutosuggestTextItem
-            classes={classes}
-            item={item}
-            index={index}
-            generateItemId={generateItemId}
-            getItemProps={getItemProps}
-          />
-        );
-      })}
-    </>
+    <li>
+      <ul role="listbox">
+        {textData.map((item: Suggestion, index: number) => {
+          const classes = {
+            textSuggestion: `autosuggest__text text-body-medium-regular px-24 ${clsx(
+              {
+                "autosuggest__text--highlight": highlightedIndex === index
+              }
+            )}`
+          };
+          return (
+            <AutosuggestTextItem
+              classes={classes}
+              item={item}
+              index={index}
+              generateItemId={generateItemId}
+              getItemProps={getItemProps}
+            />
+          );
+        })}
+      </ul>
+    </li>
   );
 };
 

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -52,6 +52,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
         {...getMenuProps()}
         style={!isOpen ? { display: "none" } : {}}
         data-cy={dataCy}
+        aria-busy="true"
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
 

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -52,9 +52,9 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
       <ul
         className="autosuggest pb-16"
         id="autosuggest"
-        aria-owns="suggestion-1 suggestion-2 suggestion-3 suggestion-4 suggestion-5 suggestion-6
-        suggestion-7 suggestion-8 suggestion-9 suggestion-10 suggestion-11 suggestion-12 suggestion-13
-        suggestion-14 suggestion-15 suggestion-16 suggestion-17"
+        aria-owns="downshift-0-item-0 downshift-0-item-1 downshift-0-item-2 downshift-0-item-3 downshift-0-item-4 downshift-0-item-5
+        downshift-0-item-6 downshift-0-item-7 downshift-0-item-8 downshift-0-item-9 downshift-0-item-10 downshift-0-item-11
+        downshift-0-item-12 downshift-0-item-13 downshift-0-item-14 downshift-0-item-15 downshift-0-item-16"
         {...getMenuProps()}
         style={!isOpen ? { display: "none" } : {}}
         data-cy={dataCy}

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -45,45 +45,56 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
 
   return (
     <>
+      {/* The downshift combobox works by prop-spreading by design */}
       {/* eslint-disable react/jsx-props-no-spreading */}
-      {/* The downshift combobox works this way by design */}
+      {/* Unless specifically stated, downshift would overwrite ul's list role */}
+      {/* eslint-disable jsx-a11y/no-redundant-roles */}
       <ul
         className="autosuggest pb-16"
+        id="autosuggest"
+        aria-owns="suggestion-1 suggestion-2 suggestion-3 suggestion-4 suggestion-5 suggestion-6
+        suggestion-7 suggestion-8 suggestion-9 suggestion-10 suggestion-11 suggestion-12 suggestion-13
+        suggestion-14 suggestion-15 suggestion-16 suggestion-17"
         {...getMenuProps()}
         style={!isOpen ? { display: "none" } : {}}
         data-cy={dataCy}
         aria-busy="true"
+        role="listbox"
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
-
-        <AutosuggestText
-          textData={textData}
-          highlightedIndex={highlightedIndex}
-          getItemProps={getItemProps}
-        />
-        {textData.length > 0 && materialData.length > 0 && (
-          <span className="autosuggest__divider" />
-        )}
-        {materialData.length > 0 && (
-          <AutosuggestMaterial
-            materialData={materialData}
-            getItemProps={getItemProps}
+        {/* eslint-enable jsx-a11y/no-redundant-roles */}
+        <ul>
+          <AutosuggestText
+            textData={textData}
             highlightedIndex={highlightedIndex}
-            textDataLength={textData.length}
+            getItemProps={getItemProps}
           />
-        )}
-        {categoryData && categoryData.length > 0 && (
-          <>
-            <span className="autosuggest__divider" />
-            <AutosuggestCategory
-              categoryData={categoryData}
+          {textData.length > 0 && materialData.length > 0 && (
+            <li className="autosuggest__divider" />
+          )}
+          {materialData.length > 0 && (
+            <AutosuggestMaterial
+              materialData={materialData}
               getItemProps={getItemProps}
               highlightedIndex={highlightedIndex}
-              textAndMaterialDataLength={textData.length + materialData.length}
-              autosuggestCategoryList={autosuggestCategoryList}
+              textDataLength={textData.length}
             />
-          </>
-        )}
+          )}
+          {categoryData && categoryData.length > 0 && (
+            <>
+              <li className="autosuggest__divider" />
+              <AutosuggestCategory
+                categoryData={categoryData}
+                getItemProps={getItemProps}
+                highlightedIndex={highlightedIndex}
+                textAndMaterialDataLength={
+                  textData.length + materialData.length
+                }
+                autosuggestCategoryList={autosuggestCategoryList}
+              />
+            </>
+          )}
+        </ul>
       </ul>
     </>
   );

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -62,7 +62,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
           getItemProps={getItemProps}
         />
         {textData.length > 0 && materialData.length > 0 && (
-          <li className="autosuggest__divider" />
+          <span className="autosuggest__divider" />
         )}
         {materialData.length > 0 && (
           <AutosuggestMaterial
@@ -74,7 +74,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
         )}
         {categoryData && categoryData.length > 0 && (
           <>
-            <li className="autosuggest__divider" />
+            <span className="autosuggest__divider" />
             <AutosuggestCategory
               categoryData={categoryData}
               getItemProps={getItemProps}

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -17,7 +17,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   const t = useText();
   return (
     <>
-      {/* The downshift combobox uses prop spreading by design & associated control is desctructured too */}
+      {/* The downshift combobox uses prop spreading by design & associated control is destructured too */}
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control, react/jsx-props-no-spreading */}
       <label className="hide-visually" {...getLabelProps()}>
         {t("searchHeaderInputLabel")}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-433
https://reload.atlassian.net/browse/DDFSOEG-432
https://reload.atlassian.net/browse/DDFSOEG-431

#### Description
According to https://www.w3.org/TR/wai-aria-1.1/#option & https://www.w3.org/TR/wai-aria-1.1/#listbox our autosuggest wasn't living up to accessibility criteria, where unordered lists of role "listbox" needs to have direct list items that are of role "option" OR own them. Plus an unordered list without a role needs to be a parent to list items.
This PR fixes these problems.

#### Screenshot of the result
n/a

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a