### PR TITLE
Add Global Escape Key Handler for Closing Modals

### DIFF
--- a/src/core/modal.slice.ts
+++ b/src/core/modal.slice.ts
@@ -7,6 +7,7 @@ interface PayloadProps {
     modalId: ModalId;
   };
 }
+
 interface StateProps {
   modalIds: string[];
 }
@@ -25,6 +26,13 @@ const returnFocusElement = () => {
   }
   return element;
 };
+
+const removeModalIdFromUrl = (modalId: ModalId) => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const newSearchParams = searchParams.get("modal")?.replace(modalId, "");
+  searchParams.set("modal", newSearchParams || "");
+};
+
 const modalSlice = createSlice({
   name: "modal",
   initialState: { modalIds: [] },
@@ -54,16 +62,19 @@ const modalSlice = createSlice({
     },
     closeModal(state: StateProps, action: PayloadProps) {
       state.modalIds.splice(state.modalIds.indexOf(action.payload.modalId), 1);
-      const searchParams = new URLSearchParams(window.location.search);
-      const newSearchParams = searchParams
-        .get("modal")
-        ?.replace(action.payload.modalId, "");
-      searchParams.set("modal", newSearchParams || "");
+      removeModalIdFromUrl(action.payload.modalId);
       returnFocusElement();
+    },
+    closeLastModal(state: StateProps) {
+      const modalId = state.modalIds.pop();
+      if (modalId) {
+        removeModalIdFromUrl(modalId);
+        returnFocusElement();
+      }
     }
   }
 });
 
-export const { openModal, closeModal } = modalSlice.actions;
+export const { openModal, closeModal, closeLastModal } = modalSlice.actions;
 
 export default modalSlice.reducer;

--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -75,6 +75,11 @@ function reset() {
 }
 
 function init() {
+  // We only want to close the single last modal when the user hits escape.
+  // Consequently we only want a single event listener. We cannot guarantee this
+  // on the app (or component) level as a page may contain multiple apps. 
+  // init provides a single entry point for loading all apps and is suitable for our
+  // purpose.
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape") {
       store.dispatch(closeLastModal());

--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -3,8 +3,9 @@ import { render } from "react-dom";
 import { withErrorBoundary } from "react-error-boundary";
 import { setToken } from "./token";
 import Store from "../components/store";
-import { persistor } from "./store";
+import { persistor, store } from "./store";
 import ErrorBoundaryAlert from "../components/error-boundary-alert/ErrorBoundaryAlert";
+import { closeLastModal } from "./modal.slice";
 
 /**
  * We look for containers and corresponding applications.
@@ -74,6 +75,12 @@ function reset() {
 }
 
 function init() {
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      store.dispatch(closeLastModal());
+    }
+  });
+
   const initial = {
     apps: {},
     setToken,

--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -77,7 +77,7 @@ function reset() {
 function init() {
   // We only want to close the single last modal when the user hits escape.
   // Consequently we only want a single event listener. We cannot guarantee this
-  // on the app (or component) level as a page may contain multiple apps. 
+  // on the app (or component) level as a page may contain multiple apps.
   // init provides a single entry point for loading all apps and is suitable for our
   // purpose.
   document.addEventListener("keydown", (e) => {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-453

#### This PR adds a global escape key handler to close modals.
When the user presses the escape key the `closeLastModal` action is dispatched, and it closes the last opened modal.

By implementing this feature, we ensure that the application is more user-friendly, and users can easily close modals without having to use tap key to search for a close button. Furthermore, this addition helps maintain consistency in user interactions across different applications, as the escape key is widely used for closing modals.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

##### This PR will prevent the re-renders
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/388