### PR TITLE
Add `aria-label` to `ReservationFormListItem`

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -665,6 +665,26 @@ export default {
       name: "Expand more text",
       defaultValue: "Expand more",
       control: { type: "text" }
+    },
+    changeInterestPeriodText: {
+      name: "Change interest period text",
+      defaultValue: "Change interest period",
+      control: { type: "text" }
+    },
+    changePickupLocationText: {
+      name: "Change pickup location text",
+      defaultValue: "Change pickup location",
+      control: { type: "text" }
+    },
+    changeSmsNumberText: {
+      name: "Change sms number text",
+      defaultValue: "Change sms number",
+      control: { type: "text" }
+    },
+    changeEmailText: {
+      name: "Change email text",
+      defaultValue: "Change email",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -14,6 +14,10 @@ interface MaterialEntryTextProps {
   approveReservationText: string;
   cantReserveText: string;
   cantViewReviewText: string;
+  changeEmailText: string;
+  changeInterestPeriodText: string;
+  changePickupLocationText: string;
+  changeSmsNumberText: string;
   chooseOneText: string;
   closeText: string;
   daysText: string;
@@ -36,6 +40,7 @@ interface MaterialEntryTextProps {
   editionsText: string;
   editionText: string;
   etAlText: string;
+  expandMoreText: string;
   fictionNonfictionText: string;
   filmAdaptationsText: string;
   findOnBookshelfText: string;
@@ -48,6 +53,7 @@ interface MaterialEntryTextProps {
   findOnShelfModalPeriodicalEditionDropdownText: string;
   findOnShelfModalPeriodicalYearDropdownText: string;
   findOnShelfModalScreenReaderModalDescriptionText: string;
+  firstAvailableEditionText: string;
   getOnlineText: string;
   goToText: string;
   haveNoInterestAfterText: string;
@@ -126,8 +132,6 @@ interface MaterialEntryTextProps {
   threeMonthsText: string;
   tryAginButtonText: string;
   twoMonthsText: string;
-  firstAvailableEditionText: string;
-  expandMoreText: string;
 }
 interface MaterialEntryUrlProps {
   dplCmsBaseUrl: string;

--- a/src/components/reservation/ReservationFormListItem.tsx
+++ b/src/components/reservation/ReservationFormListItem.tsx
@@ -6,13 +6,15 @@ interface ReservationFormListItemProps {
   title: string;
   text: string;
   changeHandler?: () => void;
+  buttonAriaLabel?: string;
 }
 
 const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
   icon,
   title,
   text,
-  changeHandler
+  changeHandler,
+  buttonAriaLabel
 }) => {
   const t = useText();
   return (
@@ -32,6 +34,7 @@ const ReservationFormListItem: React.FC<ReservationFormListItemProps> = ({
           onClick={changeHandler}
           type="button"
           className="link-tag text-small-caption cursor-pointer"
+          aria-label={buttonAriaLabel}
         >
           {t("shiftText")}
         </button>

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -80,6 +80,7 @@ const UserListItems: FC<UserListItemsProps> = ({
             title={t("haveNoInterestAfterText")}
             text={interestPeriod}
             changeHandler={openModal("interestPeriod")}
+            buttonAriaLabel={t("changeInterestPeriodText")}
           />
           <NoInterestAfterModal
             selectedInterest={selectedInterest ?? defaultInterestPeriod}
@@ -94,6 +95,7 @@ const UserListItems: FC<UserListItemsProps> = ({
             title={t("pickupLocationText")}
             text={pickupBranch}
             changeHandler={openModal("pickup")}
+            buttonAriaLabel={t("changePickupLocationText")}
           />
           <PickupModal
             branches={whitelistBranches}
@@ -112,6 +114,7 @@ const UserListItems: FC<UserListItemsProps> = ({
               title={t("receiveSmsWhenMaterialReadyText")}
               text={stringifyValue(phoneNumber)}
               changeHandler={openModal("sms")}
+              buttonAriaLabel={t("changeSmsNumberText")}
             />
             <SmsModal patron={patron} />
           </>
@@ -121,6 +124,7 @@ const UserListItems: FC<UserListItemsProps> = ({
           title={t("receiveEmailWhenMaterialReadyText")}
           text={stringifyValue(emailAddress)}
           changeHandler={openModal("email")}
+          buttonAriaLabel={t("changeEmailText")}
         />
         <EmailModal patron={patron} />
       </>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-434

#### This PR is a proposed solution to add an `aria-label` to the `ReservationFormListItem` component. 
As screen readers need to know what the change buttons do in the reservation model, this change will improve accessibility and user experience for those who rely on assistive technologies.

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.