### PR TITLE
Fix/accessibility for selects

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -514,6 +514,11 @@ export default {
         "If you wish to change the pick-up location for your reservation, you can do it here.",
       control: { type: "text" }
     },
+    modalReservationFormPickupLabelText: {
+      name: "Modal reservation form pickup branch input label",
+      defaultValue: "Change pickup location for your reservation.",
+      control: { type: "text" }
+    },
     chooseOneText: {
       name: "Choose one text",
       defaultValue: "Choose one",
@@ -528,6 +533,12 @@ export default {
       name: "Modal reservation form no interest after header description",
       defaultValue:
         "If you wish to change the amount of time after which you're no longer interested in the material, you can do it here.",
+      control: { type: "text" }
+    },
+    modalReservationFormNoInterestAfterLabelText: {
+      name: "Modal reservation form no interest after input label",
+      defaultValue:
+        "Change the amount of time after which you're no longer interested in this material.",
       control: { type: "text" }
     },
     infomediaModalScreenReaderModalDescriptionText: {

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -80,8 +80,10 @@ interface MaterialEntryTextProps {
   modalReservationFormEmailInputFieldLabelText: string;
   modalReservationFormNoInterestAfterHeaderDescriptionText: string;
   modalReservationFormNoInterestAfterHeaderTitleText: string;
+  modalReservationFormNoInterestAfterLabelText: string;
   modalReservationFormPickupHeaderDescriptionText: string;
   modalReservationFormPickupHeaderTitleText: string;
+  modalReservationFormPickupLabelText: string;
   modalReservationFormSmsHeaderDescriptionText: string;
   modalReservationFormSmsHeaderTitleText: string;
   modalReservationFormSmsInputFieldDescriptionText: string;

--- a/src/components/reservation/forms/ModalReservationFormSelect.tsx
+++ b/src/components/reservation/forms/ModalReservationFormSelect.tsx
@@ -14,7 +14,7 @@ export interface ModalReservationFormSelectProps {
   items: { label: string; value: string }[];
   defaultSelectedItem: string;
   selectHandler: (value: string) => void;
-  ariaLabel?: string;
+  ariaLabel: string;
 }
 
 const modalProps = (
@@ -34,7 +34,7 @@ const ModalReservationFormSelect = ({
   items,
   defaultSelectedItem,
   selectHandler,
-  ariaLabel = "modal-reservation-form-select"
+  ariaLabel
 }: ModalReservationFormSelectProps) => {
   const { close } = useModalButtonHandler();
   const t = useText();

--- a/src/components/reservation/forms/ModalReservationFormSelect.tsx
+++ b/src/components/reservation/forms/ModalReservationFormSelect.tsx
@@ -14,6 +14,7 @@ export interface ModalReservationFormSelectProps {
   items: { label: string; value: string }[];
   defaultSelectedItem: string;
   selectHandler: (value: string) => void;
+  ariaLabel?: string;
 }
 
 const modalProps = (
@@ -32,7 +33,8 @@ const ModalReservationFormSelect = ({
   header,
   items,
   defaultSelectedItem,
-  selectHandler
+  selectHandler,
+  ariaLabel = "modal-reservation-form-select"
 }: ModalReservationFormSelectProps) => {
   const { close } = useModalButtonHandler();
   const t = useText();
@@ -67,7 +69,7 @@ const ModalReservationFormSelect = ({
             label,
             value
           }))}
-          ariaLabel=""
+          ariaLabel={ariaLabel}
           arrowIcon="chevron"
           handleOnChange={selectChange}
           defaultValue={selectedItem}

--- a/src/components/reservation/forms/NoInterestAfterModal.tsx
+++ b/src/components/reservation/forms/NoInterestAfterModal.tsx
@@ -33,7 +33,7 @@ const NoInterestAfterModal = ({
       items={formatInterestPeriods}
       defaultSelectedItem={String(selectedInterest)}
       selectHandler={(value: string) => setSelectedInterest(Number(value))}
-      ariaLabel={t("modalReservationFormNoInterestAfterHeaderTitleText")}
+      ariaLabel={t("modalReservationFormNoInterestAfterLabelText")}
     />
   );
 };

--- a/src/components/reservation/forms/NoInterestAfterModal.tsx
+++ b/src/components/reservation/forms/NoInterestAfterModal.tsx
@@ -33,6 +33,7 @@ const NoInterestAfterModal = ({
       items={formatInterestPeriods}
       defaultSelectedItem={String(selectedInterest)}
       selectHandler={(value: string) => setSelectedInterest(Number(value))}
+      ariaLabel={t("modalReservationFormNoInterestAfterHeaderTitleText")}
     />
   );
 };

--- a/src/components/reservation/forms/PickupModal.tsx
+++ b/src/components/reservation/forms/PickupModal.tsx
@@ -31,6 +31,7 @@ const PickupModal = ({
       items={formatBranches}
       defaultSelectedItem={defaultBranch}
       selectHandler={selectBranchHandler}
+      ariaLabel={t("modalReservationFormPickupHeaderTitleText")}
     />
   );
 };

--- a/src/components/reservation/forms/PickupModal.tsx
+++ b/src/components/reservation/forms/PickupModal.tsx
@@ -31,7 +31,7 @@ const PickupModal = ({
       items={formatBranches}
       defaultSelectedItem={defaultBranch}
       selectHandler={selectBranchHandler}
-      ariaLabel={t("modalReservationFormPickupHeaderTitleText")}
+      ariaLabel={t("modalReservationFormPickupLabelText")}
     />
   );
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-424

#### Description
On the material page inside the reservation modal - two sub-modals had <select> elements without any aria-labels, which was not living up to accessibility requirements - https://www.w3.org/Translations/WCAG21-da/#headings-and-labels .
