### PR TITLE
Add 'FocusTrap'  in `ReservationSucces`

### DIFF
--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -1,3 +1,4 @@
+import FocusTrap from "focus-trap-react";
 import React from "react";
 import { ReservationResponseV2 } from "../../core/fbs/model";
 import { useText } from "../../core/utils/text";
@@ -39,24 +40,26 @@ const ReservationError: React.FC<ReservationErrorProps> = ({
     handleErrorText[reservationResult] || handleErrorText.default;
 
   return (
-    <section className="reservation-modal reservation-modal--confirm">
-      <h2 className="text-header-h3 pb-48">{reservationErrorInfo.title}</h2>
-      {reservationErrorInfo.description && (
-        <p className="text-body-medium-regular pb-48">
-          {reservationErrorInfo.description}
-        </p>
-      )}
-      <Button
-        classNames="reservation-modal__confirm-button"
-        label={reservationErrorInfo.buttonText}
-        buttonType="none"
-        disabled={false}
-        collapsible={false}
-        size="small"
-        variant="filled"
-        onClick={() => setReservationResponse(null)}
-      />
-    </section>
+    <FocusTrap>
+      <section className="reservation-modal reservation-modal--confirm">
+        <h2 className="text-header-h3 pb-48">{reservationErrorInfo.title}</h2>
+        {reservationErrorInfo.description && (
+          <p className="text-body-medium-regular pb-48">
+            {reservationErrorInfo.description}
+          </p>
+        )}
+        <Button
+          classNames="reservation-modal__confirm-button"
+          label={reservationErrorInfo.buttonText}
+          buttonType="none"
+          disabled={false}
+          collapsible={false}
+          size="small"
+          variant="filled"
+          onClick={() => setReservationResponse(null)}
+        />
+      </section>
+    </FocusTrap>
   );
 };
 

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -1,3 +1,4 @@
+import FocusTrap from "focus-trap-react";
 import React from "react";
 import { useDispatch } from "react-redux";
 import { closeModal } from "../../core/modal.slice";
@@ -24,53 +25,56 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
 }) => {
   const dispatch = useDispatch();
   const t = useText();
+
   return (
-    <section className="reservation-modal reservation-modal--confirm">
-      <h2
-        data-cy="reservation-success-title-text"
-        className="text-header-h3 pb-48"
-      >
-        {t("reservationSuccesTitleText")}
-      </h2>
-      <p
-        data-cy="reservation-success-is-reserved-for-you-text"
-        className="text-body-medium-regular pb-24"
-      >
-        {title} {t("reservationSuccesIsReservedForYouText")}
-      </p>
-      <p
-        data-cy="number-in-queue-text"
-        className="text-body-medium-regular pb-24"
-      >
-        <StockAndReservationInfo
-          stockCount={holdings}
-          reservationCount={reservationCount}
-          numberInQueue={numberInQueue}
+    <FocusTrap>
+      <section className="reservation-modal reservation-modal--confirm">
+        <h2
+          data-cy="reservation-success-title-text"
+          className="text-header-h3 pb-48"
+        >
+          {t("reservationSuccesTitleText")}
+        </h2>
+        <p
+          data-cy="reservation-success-is-reserved-for-you-text"
+          className="text-body-medium-regular pb-24"
+        >
+          {title} {t("reservationSuccesIsReservedForYouText")}
+        </p>
+        <p
+          data-cy="number-in-queue-text"
+          className="text-body-medium-regular pb-24"
+        >
+          <StockAndReservationInfo
+            stockCount={holdings}
+            reservationCount={reservationCount}
+            numberInQueue={numberInQueue}
+          />
+        </p>
+        <p
+          data-cy="reservation-success-preferred-pickup-branch-text"
+          className="text-body-medium-regular pb-48"
+        >
+          {t("reservationSuccessPreferredPickupBranchText", {
+            placeholders: { "@branch": preferredPickupBranch }
+          })}
+          .
+        </p>
+        <Button
+          dataCy="reservation-success-close-button"
+          classNames="reservation-modal__confirm-button"
+          label={t("okButtonText")}
+          buttonType="none"
+          disabled={false}
+          collapsible={false}
+          size="small"
+          variant="filled"
+          onClick={() => {
+            dispatch(closeModal({ modalId }));
+          }}
         />
-      </p>
-      <p
-        data-cy="reservation-success-preferred-pickup-branch-text"
-        className="text-body-medium-regular pb-48"
-      >
-        {t("reservationSuccessPreferredPickupBranchText", {
-          placeholders: { "@branch": preferredPickupBranch }
-        })}
-        .
-      </p>
-      <Button
-        dataCy="reservation-success-close-button"
-        classNames="reservation-modal__confirm-button"
-        label={t("okButtonText")}
-        buttonType="none"
-        disabled={false}
-        collapsible={false}
-        size="small"
-        variant="filled"
-        onClick={() => {
-          dispatch(closeModal({ modalId }));
-        }}
-      />
-    </section>
+      </section>
+    </FocusTrap>
   );
 };
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-447

#### Add 'FocusTrap' to improve accessibility in `ReservationSucces`

FocusTrap helps to trap the focus within the modal when it is open, preventing users from accidentally interacting with elements outside of the modal.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.