### PR TITLE
Add 'aria-expanded' to `MaterialDetailsList`

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -239,7 +239,11 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         disclosureIconExpandAltText=""
         dataCy="material-details-disclosure"
       >
-        <MaterialDetailsList className="pl-80 pb-48" data={detailsListData} />
+        <MaterialDetailsList
+          id="main-details"
+          className="pl-80 pb-48"
+          data={detailsListData}
+        />
       </Disclosure>
       {hasReview && hasReview.length > 0 && (
         <DisclosureControllable

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -240,7 +240,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         dataCy="material-details-disclosure"
       >
         <MaterialDetailsList
-          id="main-details"
+          id="material-details"
           className="pl-80 pb-48"
           data={detailsListData}
         />

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -240,7 +240,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         dataCy="material-details-disclosure"
       >
         <MaterialDetailsList
-          id="material-details"
+          id={`material-details-${wid}`}
           className="pl-80 pb-48"
           data={detailsListData}
         />

--- a/src/components/description-list/description-list.tsx
+++ b/src/components/description-list/description-list.tsx
@@ -3,14 +3,16 @@ import * as React from "react";
 export interface DescriptionListProps {
   classNames?: string;
   data: { label: string; value: string | React.ReactNode }[];
+  id: string;
 }
 
 const DescriptionList: React.FC<DescriptionListProps> = ({
   data,
-  classNames
+  classNames,
+  id
 }) => {
   return (
-    <dl className={`list-description ${classNames ?? ""}`}>
+    <dl id={id} className={`list-description ${classNames ?? ""}`}>
       {data.map((item) => {
         const { label, value } = item;
         return (

--- a/src/components/material/MaterialDetailsList.tsx
+++ b/src/components/material/MaterialDetailsList.tsx
@@ -11,11 +11,13 @@ export type ListData = {
 export interface MaterialDetailsListProps {
   className?: string;
   data: ListData;
+  id: string;
 }
 
 const MaterialDetailsList: FC<MaterialDetailsListProps> = ({
   data,
-  className
+  className,
+  id
 }) => {
   const listData = data
     .filter((item) => item.value)
@@ -30,7 +32,7 @@ const MaterialDetailsList: FC<MaterialDetailsListProps> = ({
       return { label, value: rowValue };
     });
 
-  return <DescriptionList data={listData} classNames={className} />;
+  return <DescriptionList id={id} data={listData} classNames={className} />;
 };
 
 export default MaterialDetailsList;

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -99,6 +99,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   ];
 
   const accessTypesCodes = manifestation.accessTypes.map((item) => item.code);
+  const detailsId = `material-details-${pid}`;
 
   return (
     <div className="material-manifestation-item">
@@ -135,6 +136,8 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           }}
           role="button"
           tabIndex={0}
+          aria-controls={detailsId}
+          aria-expanded={isOpen}
         >
           <p className="link-tag text-small-caption">
             {t("detailsOfTheMaterialText")}
@@ -142,7 +145,11 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           <img src={ExpandIcon} alt="" />
         </div>
         {isOpen && (
-          <MaterialDetailsList className="mt-24" data={detailsListData} />
+          <MaterialDetailsList
+            id={detailsId}
+            className="mt-24"
+            data={detailsListData}
+          />
         )}
       </div>
       <div className="material-manifestation-item__buttons">


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-426

#### Add 'aria-expanded' to `MaterialDetailsList`
The aria-expanded attribute has been added to the MaterialDetailsList component to improve accessibility for users with disabilities. This attribute indicates the current state of the element, whether it is expanded or collapsed, and provides information to assistive technologies like screen readers.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.