### PR TITLE
improve 'blockStatus' check in `MaterialButtonsPhysical`

### DIFF
--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { isEmpty } from "lodash";
 import {
   getAllFaustIds,
   getManifestationType
@@ -40,14 +41,14 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonCantReserve size={size} />;
   }
 
-  if (userData?.patron?.blockStatus) {
+  if (!isEmpty(userData?.patron?.blockStatus)) {
     return <MaterialButtonUserBlocked size={size} dataCy={dataCy} />;
   }
 
   // We show the reservation button if the user isn't logged in or isn't blocked.
   // In the former case there there's no way to see if they're blocked, so we
   // redirect anonymous user to the login page.
-  if (!userData || !userData?.patron?.blockStatus) {
+  if (!userData || isEmpty(userData?.patron?.blockStatus)) {
     return (
       <MaterialButtonReservePhysical
         dataCy={dataCy}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-486

#### This PR improves the 'blockStatus' check for the `MaterialButtonsPhysical` component
by importing and using the `isEmpty` function from lodash. This ensures a more accurate check for the `userData.patron.blockStatus` property.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.