### PR TITLE
Add 'aria-labelledby' to `Link` + Change name 'description' to 'altText'

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-0d863db504e2f1f219dc1da1563096fcf5ce97f4",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/Buttons/LinkButton.tsx
+++ b/src/components/Buttons/LinkButton.tsx
@@ -19,6 +19,7 @@ export interface LinkButtonProps {
   trackClick?: () => Promise<unknown>;
   url: URL;
   variant: ButtonVariant;
+  ariaLabelledBy?: string;
 }
 
 const LinkButton: React.FC<LinkButtonProps> = ({
@@ -31,7 +32,8 @@ const LinkButton: React.FC<LinkButtonProps> = ({
   size = "medium",
   trackClick,
   url,
-  variant = "filled"
+  variant = "filled",
+  ariaLabelledBy
 }) => {
   return (
     <Link
@@ -47,6 +49,7 @@ const LinkButton: React.FC<LinkButtonProps> = ({
       )}
       trackClick={trackClick}
       dataCy={dataCy}
+      ariaLabelledBy={ariaLabelledBy}
     >
       {children}
       <ButtonIcon buttonType={buttonType} iconClassNames={iconClassNames} />

--- a/src/components/atoms/links/Link.tsx
+++ b/src/components/atoms/links/Link.tsx
@@ -9,6 +9,7 @@ export interface LinkProps {
   id?: string;
   trackClick?: () => Promise<unknown>;
   dataCy?: string;
+  ariaLabelledBy?: string;
 }
 
 const Link: React.FC<LinkProps> = ({
@@ -18,7 +19,8 @@ const Link: React.FC<LinkProps> = ({
   className,
   id,
   trackClick,
-  dataCy
+  dataCy,
+  ariaLabelledBy
 }) => {
   const redirect = (redirectToNewTab: boolean) => {
     if (redirectToNewTab) {
@@ -55,6 +57,7 @@ const Link: React.FC<LinkProps> = ({
       className={className}
       onClick={handleClick}
       onKeyUp={handleKeyUp}
+      aria-labelledby={ariaLabelledBy}
     >
       {children}
     </a>

--- a/src/components/atoms/links/LinkNoStyle.tsx
+++ b/src/components/atoms/links/LinkNoStyle.tsx
@@ -8,6 +8,7 @@ export interface LinkNoStyleProps {
   className?: string;
   trackClick?: () => Promise<unknown>;
   dataCy?: string;
+  ariaLabelledBy?: string;
 }
 
 const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
@@ -16,7 +17,8 @@ const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
   isNewTab = false,
   className,
   trackClick,
-  dataCy = "link-no-style"
+  dataCy = "link-no-style",
+  ariaLabelledBy
 }) => {
   return (
     <Link
@@ -25,6 +27,7 @@ const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
       className={`hide-linkstyle ${className || ""}`}
       trackClick={trackClick}
       dataCy={dataCy}
+      ariaLabelledBy={ariaLabelledBy}
     >
       {children}
     </Link>

--- a/src/components/cover/cover-image.tsx
+++ b/src/components/cover/cover-image.tsx
@@ -26,7 +26,7 @@ const CoverImage: FC<CoverImageType> = ({
       { "cover__img--shadow": shadow }
     )}
     src={src}
-    alt={altText}
+    alt={altText || ""}
   />
 );
 

--- a/src/components/cover/cover-image.tsx
+++ b/src/components/cover/cover-image.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 
 type CoverImageType = {
   src: string;
-  description?: string;
+  altText?: string;
   animate: boolean;
   setImageLoaded: () => void;
   shadow?: boolean;
@@ -11,7 +11,7 @@ type CoverImageType = {
 
 const CoverImage: FC<CoverImageType> = ({
   src,
-  description,
+  altText,
   animate,
   setImageLoaded,
   shadow
@@ -26,7 +26,7 @@ const CoverImage: FC<CoverImageType> = ({
       { "cover__img--shadow": shadow }
     )}
     src={src}
-    alt={description || ""}
+    alt={altText}
   />
 );
 

--- a/src/components/cover/cover.tsx
+++ b/src/components/cover/cover.tsx
@@ -15,6 +15,7 @@ export type CoverProps = {
   url?: URL;
   idType?: GetCoverCollectionType;
   shadow?: boolean;
+  linkAriaLabelledBy?: string;
 };
 
 export const Cover = ({
@@ -25,7 +26,8 @@ export const Cover = ({
   tint,
   id,
   idType,
-  shadow
+  shadow,
+  linkAriaLabelledBy
 }: CoverProps) => {
   const [imageLoaded, setImageLoaded] = useState<boolean | null>(null);
   const handleSetImageLoaded = useCallback(() => {
@@ -68,16 +70,18 @@ export const Cover = ({
     )
   };
 
-  if (url && description) {
-    // Images inside links must have an non-empty alt text to meet accessibility requirements.
-    // Only render the cover as a link if we have both an url and a description.
+  if (url) {
     return (
-      <LinkNoStyle className={classes.wrapper} url={url}>
+      <LinkNoStyle
+        className={classes.wrapper}
+        url={url}
+        ariaLabelledBy={linkAriaLabelledBy}
+      >
         {coverSrc && (
           <CoverImage
             setImageLoaded={handleSetImageLoaded}
             src={coverSrc}
-            description={description}
+            altText={description}
             animate={animate}
             shadow={shadow}
           />
@@ -92,7 +96,7 @@ export const Cover = ({
         <CoverImage
           setImageLoaded={handleSetImageLoaded}
           src={coverSrc}
-          description={description}
+          altText={description}
           animate={animate}
           shadow={shadow}
         />

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useId } from "react";
 import { useDispatch } from "react-redux";
 import { useDeepCompareEffect } from "react-use";
 import { guardedRequest } from "../../core/guardedRequests.slice";
@@ -55,6 +55,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   selectPeriodicalHandler,
   children
 }) => {
+  const materialTitleId = useId();
   const { itemRef, hasBeenVisible: showItem } = useItemHasBeenVisible();
   const t = useText();
   const dispatch = useDispatch<TypedDispatch>();
@@ -123,6 +124,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
           title={String(title)}
           author={author}
           languageIsoCode={languageIsoCode}
+          materialTitleId={materialTitleId}
         />
         <div ref={itemRef} className="material-header__availability-label">
           {showItem && (
@@ -152,6 +154,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
                     manifestations={selectedManifestations}
                     workId={wid}
                     dataCy="material-header-buttons"
+                    materialTitleId={materialTitleId}
                   />
                 </div>
                 <MaterialAvailabilityText

--- a/src/components/material/MaterialHeaderText.tsx
+++ b/src/components/material/MaterialHeaderText.tsx
@@ -8,18 +8,24 @@ interface MaterialHeaderTextProps {
   title: string;
   author: string;
   languageIsoCode?: string;
+  materialTitleId?: string;
 }
 
 const MaterialHeaderText: React.FC<MaterialHeaderTextProps> = ({
   title,
   author,
-  languageIsoCode
+  languageIsoCode,
+  materialTitleId
 }) => {
   const t = useText();
   const { searchUrl } = useUrls();
   return (
     <>
-      <h1 lang={languageIsoCode} className="text-header-h1 mb-16">
+      <h1
+        id={materialTitleId}
+        lang={languageIsoCode}
+        className="text-header-h1 mb-16"
+      >
         {title}
       </h1>
       {author && (

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -37,7 +37,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   manifestation,
   workId
 }) => {
-  const materialMainfestationItemTitleId = useId();
+  const mainfestationTitleId = useId();
   const t = useText();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid);
@@ -119,7 +119,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
       <div className="material-manifestation-item__text">
         <h3
           lang={languageIsoCode}
-          id={materialMainfestationItemTitleId}
+          id={mainfestationTitleId}
           className="material-manifestation-item__title text-header-h4"
         >
           {titles?.main[0]}
@@ -163,7 +163,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           manifestations={[manifestation]}
           size="small"
           workId={workId}
-          materialTitleId={materialMainfestationItemTitleId}
+          materialTitleId={mainfestationTitleId}
         />
       </div>
     </div>

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { FC, useState } from "react";
+import React, { useId, FC, useState } from "react";
 import ExpandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
 import { AvailabilityLabel } from "../availability-label/availability-label";
 import { Cover } from "../cover/cover";
@@ -38,6 +37,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   manifestation,
   workId
 }) => {
+  const materialMainfestationItemTitleId = useId();
   const t = useText();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid);
@@ -119,6 +119,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
       <div className="material-manifestation-item__text">
         <h3
           lang={languageIsoCode}
+          id={materialMainfestationItemTitleId}
           className="material-manifestation-item__title text-header-h4"
         >
           {titles?.main[0]}
@@ -162,6 +163,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           manifestations={[manifestation]}
           size="small"
           workId={workId}
+          materialTitleId={materialMainfestationItemTitleId}
         />
       </div>
     </div>

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -15,13 +15,15 @@ export interface MaterialButtonsProps {
   size?: ButtonSize;
   workId: WorkId;
   dataCy?: string;
+  materialTitleId: string;
 }
 
 const MaterialButtons: FC<MaterialButtonsProps> = ({
   manifestations,
   size,
   workId,
-  dataCy = "material-buttons"
+  dataCy = "material-buttons",
+  materialTitleId
 }) => {
   const faustIds = getAllFaustIds(manifestations);
   // We don't want to show physical buttons/find on shelf for articles because
@@ -51,6 +53,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
           size={size}
           workId={workId}
           dataCy={`${dataCy}-online`}
+          ariaLabelledBy={materialTitleId}
         />
       )}
     </>

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -19,6 +19,7 @@ export interface MaterialButtonOnlineExternalProps {
   trackOnlineView: () => Promise<unknown>;
   manifestations: Manifestation[];
   dataCy?: string;
+  ariaLabelledBy: string;
 }
 
 export const getOnlineMaterialType = (
@@ -48,7 +49,8 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   size,
   trackOnlineView,
   manifestations,
-  dataCy = "material-button-online-external"
+  dataCy = "material-button-online-external",
+  ariaLabelledBy
 }) => {
   const [translatedUrl, setTranslatedUrl] = useState<URL>(new URL(externalUrl));
   const [urlWasTranslated, setUrlWasTranslated] = useState<boolean | null>(
@@ -101,6 +103,7 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
       iconClassNames="invert"
       trackClick={trackOnlineView}
       dataCy={dataCy}
+      ariaLabelledBy={ariaLabelledBy}
     >
       {label(origin, getMaterialTypes(manifestations))}
     </LinkButton>

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -18,13 +18,15 @@ export interface MaterialButtonsOnlineProps {
   size?: ButtonSize;
   workId: WorkId;
   dataCy?: string;
+  ariaLabelledBy: string;
 }
 
 const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
   manifestations,
   size,
   workId,
-  dataCy = "material-buttons-online"
+  dataCy = "material-buttons-online",
+  ariaLabelledBy
 }) => {
   const { track } = useStatistics();
   const trackOnlineView = () => {
@@ -64,6 +66,7 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
         trackOnlineView={trackOnlineView}
         manifestations={manifestations}
         dataCy={`${dataCy}-external`}
+        ariaLabelledBy={ariaLabelledBy}
       />
     );
   }

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item-cover.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item-cover.tsx
@@ -4,7 +4,6 @@ import { Cover, CoverProps } from "../../cover/cover";
 type SearchResultListItemCoverProps = Omit<CoverProps, "animate" | "size">;
 const SearchResultListItemCover: React.FC<SearchResultListItemCoverProps> = ({
   id,
-  description,
   url,
   tint,
   linkAriaLabelledBy
@@ -14,7 +13,6 @@ const SearchResultListItemCover: React.FC<SearchResultListItemCoverProps> = ({
       animate
       id={id}
       size="small"
-      description={description}
       url={url}
       tint={tint}
       linkAriaLabelledBy={linkAriaLabelledBy}

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item-cover.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item-cover.tsx
@@ -6,16 +6,18 @@ const SearchResultListItemCover: React.FC<SearchResultListItemCoverProps> = ({
   id,
   description,
   url,
-  tint
+  tint,
+  linkAriaLabelledBy
 }) => {
   return (
     <Cover
       animate
       id={id}
       size="small"
-      description={String(description)}
+      description={description}
       url={url}
       tint={tint}
+      linkAriaLabelledBy={linkAriaLabelledBy}
     />
   );
 };

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useId } from "react";
 import { useDispatch } from "react-redux";
 import { useText } from "../../../core/utils/text";
 import { WorkId } from "../../../core/utils/types/ids";
@@ -57,6 +57,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   resultNumber,
   dataCy = "search-result-list-item"
 }) => {
+  const searchResultListItemTitleId = useId();
   const t = useText();
   const { materialUrl, searchUrl } = useUrls();
   const { filters } = useFilterHandler();
@@ -129,9 +130,9 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         {showItem && (
           <SearchResultListItemCover
             id={manifestationPid}
-            description={String(fullTitle)}
             url={materialFullUrl}
             tint={coverTint}
+            linkAriaLabelledBy={searchResultListItemTitleId}
           />
         )}
       </div>
@@ -160,6 +161,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
           className="search-result-item__title text-header-h4 mb-4"
           data-cy="search-result-item-title"
           lang={languageIsoCode}
+          id={searchResultListItemTitleId}
         >
           <Link href={materialFullUrl}>{fullTitle}</Link>
         </h2>

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -57,7 +57,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   resultNumber,
   dataCy = "search-result-list-item"
 }) => {
-  const searchResultListItemTitleId = useId();
+  const searchTitleId = useId();
   const t = useText();
   const { materialUrl, searchUrl } = useUrls();
   const { filters } = useFilterHandler();
@@ -132,7 +132,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
             id={manifestationPid}
             url={materialFullUrl}
             tint={coverTint}
-            linkAriaLabelledBy={searchResultListItemTitleId}
+            linkAriaLabelledBy={searchTitleId}
           />
         )}
       </div>
@@ -161,7 +161,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
           className="search-result-item__title text-header-h4 mb-4"
           data-cy="search-result-item-title"
           lang={languageIsoCode}
-          id={searchResultListItemTitleId}
+          id={searchTitleId}
         >
           <Link href={materialFullUrl}>{fullTitle}</Link>
         </h2>

--- a/src/core/mount.js
+++ b/src/core/mount.js
@@ -23,6 +23,9 @@ function mount(context) {
     // Ensure that the application exists.
     const isValidMount = app;
     if (isValidMount) {
+      // Todo: This should be updated because render() is deprecated.
+      // After the update, ensure that prefixes (identifierPrefix) are specified for all apps.
+      // This will guarantee unique IDs everywhere useID() is utilized.
       render(
         createElement(
           Store,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,10 +1749,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-0d863db504e2f1f219dc1da1563096fcf5ce97f4":
-  version "0.0.0-0d863db504e2f1f219dc1da1563096fcf5ce97f4"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-0d863db504e2f1f219dc1da1563096fcf5ce97f4/a458c5c99b538ef6c4e0204dcbb7ce2480965792#a458c5c99b538ef6c4e0204dcbb7ce2480965792"
-  integrity sha512-6hxxp1WV41x/+ufm93ihnJGgmMr5gHxGkeB0NFpXdSXn35ZK+a3SlUftnyrPpD0aPSxD2Dhm72TlVv0gfYVsvw==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd":
+  version "0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd/e783ff7e1af15a96a23a5556302ea15c7500ccde#e783ff7e1af15a96a23a5556302ea15c7500ccde"
+  integrity sha512-FsQefHXQ6g4xr4RfnfNNQoXOTWkC8BgryrJsmw7+g3Mq17m1s1FYU8fzpDqTrDRpKBz/eZuzA619EfLXFT1AOQ==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-421
https://reload.atlassian.net/browse/DDFSOEG-427

#### This pull request add 'aria-labelledby' to `Link` + Change name 'description' to 'altText'

When the 'coverSrc' property in the `Cover` component is invalid, the image won't be displayed, leading to an empty link. To address this, we use the 'aria-labelledby' attribute to associate the empty link with the title of the search result item. 

We generate a unique identifier for the title using the useId() hook, which is assigned to the id attribute of the title and used as the aria-labelledby value for the Link

Additionally, the description prop in the Cover component is renamed to altText.

This improves the overall experience for users who rely on screen readers.

#### Screenshot of the result
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/49920322/228231052-911857fd-b6f5-4b05-9c04-3a1e5824454a.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
