### PR TITLE
Add aria-hidden attribute to autosuggest dividers

### DIFF
--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -61,7 +61,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
           getItemProps={getItemProps}
         />
         {textData.length > 0 && materialData.length > 0 && (
-          <li className="autosuggest__divider" />
+          <li className="autosuggest__divider" aria-hidden />
         )}
         {materialData.length > 0 && (
           <AutosuggestMaterial
@@ -73,7 +73,7 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
         )}
         {categoryData && categoryData.length > 0 && (
           <>
-            <li className="autosuggest__divider" />
+            <li className="autosuggest__divider" aria-hidden />
             <AutosuggestCategory
               categoryData={categoryData}
               getItemProps={getItemProps}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-434

#### This PR addresses the accessibility issue with the autosuggest
by adding the `aria-hidden` attribute to the dividers. This ensures that the dividers are not read by screen readers, providing a better user experience for those using assistive technology.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.