### PR TITLE
Add 'lang' attribute to titles if they are not Danish

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,4 +1,4 @@
-import { compact, groupBy, uniqBy, uniq } from "lodash";
+import { compact, groupBy, uniqBy, uniq, head } from "lodash";
 import {
   constructModalId,
   getMaterialTypes,
@@ -115,19 +115,23 @@ export const getManifestationLanguages = (manifestation: Manifestation) => {
 };
 
 export const getManifestationLanguageIsoCode = (
-  manifestation: Manifestation[]
+  manifestations: Pick<Manifestation, "languages">[]
 ) => {
-  const uniqueLanguages = uniqBy(
-    manifestation.map((m) => m.languages),
-    "main[0].isoCode"
-  );
-  if (
-    uniqueLanguages.length === 1 &&
-    uniqueLanguages[0]?.main?.[0]?.isoCode &&
-    uniqueLanguages[0].main[0].isoCode !== "dan"
-  ) {
-    return uniqueLanguages[0].main[0].isoCode;
+  const mainLanguages = manifestations
+    .map(({ languages }) => languages)
+    .flatMap((language) => language?.main);
+
+  const uniqueLanguagesWithIsoCode = uniqBy(mainLanguages, "isoCode");
+
+  // We only want to set the lang attribute if there is only one isoCode
+  const uniqIsoCode =
+    uniqueLanguagesWithIsoCode.length === 1 &&
+    head(uniqueLanguagesWithIsoCode)?.isoCode;
+
+  if (uniqIsoCode) {
+    return uniqIsoCode;
   }
+  // if there is no isoCode it return undefined so that the lang attribute is not set
   return undefined;
 };
 

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -114,6 +114,23 @@ export const getManifestationLanguages = (manifestation: Manifestation) => {
   );
 };
 
+export const getManifestationLanguageIsoCode = (
+  manifestation: Manifestation[]
+) => {
+  const uniqueLanguages = uniqBy(
+    manifestation.map((m) => m.languages),
+    "main[0].isoCode"
+  );
+  if (
+    uniqueLanguages.length === 1 &&
+    uniqueLanguages[0]?.main?.[0]?.isoCode &&
+    uniqueLanguages[0].main[0].isoCode !== "dan"
+  ) {
+    return uniqueLanguages[0].main[0].isoCode;
+  }
+  return undefined;
+};
+
 export const getManifestationFirstEditionYear = (
   manifestation: Manifestation
 ) => {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -786,3 +786,8 @@ export const InstantLoan = Template.bind({});
 InstantLoan.args = {
   wid: "work-of:870970-basis:134015012"
 };
+
+export const Dinosaurierfedern = Template.bind({});
+Dinosaurierfedern.args = {
+  wid: "work-of:870970-basis:44805421"
+};

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -8,6 +8,7 @@ import {
   flattenCreators
 } from "../../core/utils/helpers/general";
 import { WorkSmallFragment } from "../../core/dbc-gateway/generated/graphql";
+import { getManifestationLanguageIsoCode } from "../../apps/material/helper";
 
 export interface AutosuggestMaterialProps {
   materialData: Suggestions | [];
@@ -44,6 +45,12 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
             creators as WorkSmallFragment["creators"]
           );
 
+          const manifestationLanguageIsoCode =
+            item.work?.manifestations.bestRepresentation &&
+            getManifestationLanguageIsoCode([
+              item.work.manifestations.bestRepresentation
+            ]);
+
           return (
             <li
               className={`autosuggest__material ${
@@ -67,7 +74,10 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
                 )}
 
                 <div className="autosuggest__info">
-                  <div className="text-body-medium-medium autosuggest__title">
+                  <div
+                    lang={manifestationLanguageIsoCode}
+                    className="text-body-medium-medium autosuggest__title"
+                  >
                     {item.work?.titles.main[0]}
                   </div>
                   <div className="text-body-small-regular autosuggest__author">

--- a/src/components/autosuggest-text/autosuggest-text-item.tsx
+++ b/src/components/autosuggest-text/autosuggest-text-item.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useText } from "../../core/utils/text";
 import { SuggestionType } from "../../core/dbc-gateway/generated/graphql";
 import { Suggestion } from "../../core/utils/types/autosuggest";
+import { getManifestationLanguageIsoCode } from "../../apps/material/helper";
 
 export interface AutosuggestTextItemProps {
   classes: {
@@ -23,6 +24,12 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
   getItemProps,
   dataCy = "autosuggest-text-item"
 }) => {
+  const isoLang =
+    item.work?.manifestations.bestRepresentation &&
+    getManifestationLanguageIsoCode([
+      item.work.manifestations.bestRepresentation
+    ]);
+
   const t = useText();
   return (
     <>
@@ -33,6 +40,7 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
         key={generateItemId(item)}
         {...getItemProps({ item, index })}
         data-cy={dataCy}
+        lang={isoLang}
       >
         {/* eslint-enable react/jsx-props-no-spreading */}
         {item.type === SuggestionType.Creator

--- a/src/components/autosuggest/autosuggest.graphql
+++ b/src/components/autosuggest/autosuggest.graphql
@@ -1,4 +1,3 @@
-
 query suggestionsFromQueryString($q: String!) {
   suggest(q: $q) {
     result {
@@ -15,6 +14,7 @@ query suggestionsFromQueryString($q: String!) {
         manifestations {
           bestRepresentation {
             pid
+            ...WithLanguages
           }
         }
       }

--- a/src/components/find-on-shelf/mocked-data.ts
+++ b/src/components/find-on-shelf/mocked-data.ts
@@ -32,7 +32,8 @@ export const mockedManifestationData: Manifestation[] = [
     languages: {
       main: [
         {
-          display: "dansk"
+          display: "dansk",
+          isoCode: "dan"
         }
       ]
     },
@@ -100,7 +101,8 @@ export const mockedManifestationData: Manifestation[] = [
     languages: {
       main: [
         {
-          display: "dansk"
+          display: "dansk",
+          isoCode: "dan"
         }
       ]
     },
@@ -169,7 +171,8 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
     languages: {
       main: [
         {
-          display: "dansk"
+          display: "dansk",
+          isoCode: "dan"
         }
       ]
     },

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -29,6 +29,7 @@ import { statistics } from "../../core/statistics/statistics";
 import { hasCorrectMaterialType } from "./material-buttons/helper";
 import MaterialType from "../../core/utils/types/material-type";
 import { useItemHasBeenVisible } from "../../core/utils/helpers/lazy-load";
+import { getManifestationLanguageIsoCode } from "../../apps/material/helper";
 
 interface MaterialHeaderProps {
   wid: WorkId;
@@ -86,6 +87,10 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
   // This is used to track whether the user is changing between material types or just clicking the same button over
   const manifestationMaterialTypes = getMaterialTypes(selectedManifestations);
 
+  const languageIsoCode = getManifestationLanguageIsoCode(
+    selectedManifestations
+  );
+
   useDeepCompareEffect(() => {
     track("click", {
       id: statistics.materialType.id,
@@ -114,7 +119,11 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
         className="material-header__content"
       >
         <ButtonFavourite id={wid} addToListRequest={addToListRequest} />
-        <MaterialHeaderText title={String(title)} author={author} />
+        <MaterialHeaderText
+          title={String(title)}
+          author={author}
+          languageIsoCode={languageIsoCode}
+        />
         <div ref={itemRef} className="material-header__availability-label">
           {showItem && (
             <AvailabilityLabels

--- a/src/components/material/MaterialHeaderText.tsx
+++ b/src/components/material/MaterialHeaderText.tsx
@@ -7,17 +7,21 @@ import LinkNoStyle from "../atoms/links/LinkNoStyle";
 interface MaterialHeaderTextProps {
   title: string;
   author: string;
+  languageIsoCode?: string;
 }
 
 const MaterialHeaderText: React.FC<MaterialHeaderTextProps> = ({
   title,
-  author
+  author,
+  languageIsoCode
 }) => {
   const t = useText();
   const { searchUrl } = useUrls();
   return (
     <>
-      <h1 className="text-header-h1 mb-16">{title}</h1>
+      <h1 lang={languageIsoCode} className="text-header-h1 mb-16">
+        {title}
+      </h1>
       {author && (
         <p data-cy="material-header-author-text" className="text-body-large">
           <span>{t("materialHeaderAuthorByText")} </span>

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -20,6 +20,7 @@ import {
   getManifestationEdition,
   getManifestationGenreAndForm,
   getManifestationIsbn,
+  getManifestationLanguageIsoCode,
   getManifestationLanguages,
   getManifestationMaterialTypes,
   getManifestationNumberOfPages,
@@ -44,6 +45,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     flattenCreators(filterCreators(creators, ["Person"])),
     t
   );
+  const languageIsoCode = getManifestationLanguageIsoCode([manifestation]);
 
   const detailsListData: ListData = [
     {
@@ -115,7 +117,10 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
         <Cover id={pid} size="small" animate={false} />
       </div>
       <div className="material-manifestation-item__text">
-        <h3 className="material-manifestation-item__title text-header-h4">
+        <h3
+          lang={languageIsoCode}
+          className="material-manifestation-item__title text-header-h4"
+        >
           {titles?.main[0]}
         </h3>
         <p className="text-small-caption">

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -30,7 +30,10 @@ import { Work } from "../../../core/utils/types/entities";
 import { useStatistics } from "../../../core/statistics/useStatistics";
 import { statistics } from "../../../core/statistics/statistics";
 import { useItemHasBeenVisible } from "../../../core/utils/helpers/lazy-load";
-import { getNumberedSeries } from "../../../apps/material/helper";
+import {
+  getManifestationLanguageIsoCode,
+  getNumberedSeries
+} from "../../../apps/material/helper";
 import useFilterHandler from "../../../apps/search-result/useFilterHandler";
 import { getFirstMaterialTypeFromFilters } from "../../../apps/search-result/helper";
 
@@ -74,6 +77,8 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
     workId as WorkId,
     materialTypeFromFilters
   );
+  const languageIsoCode = getManifestationLanguageIsoCode(manifestations);
+
   const { track } = useStatistics();
   // We use hasBeenVisible to determine if the search result
   // is, or has been, visible in the viewport.
@@ -154,6 +159,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
         <h2
           className="search-result-item__title text-header-h4 mb-4"
           data-cy="search-result-item-title"
+          lang={languageIsoCode}
         >
           <Link href={materialFullUrl}>{fullTitle}</Link>
         </h2>

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -33,6 +33,7 @@ fragment ManifestationsSimpleFields on Manifestation {
   languages {
     main {
       display
+      isoCode
     }
   }
   identifiers {
@@ -108,7 +109,7 @@ fragment ManifestationReviewFields on Manifestation {
     ... on DigitalArticleService {
       issn
     }
-    ...on AccessUrl {
+    ... on AccessUrl {
       url
       origin
     }

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -14,6 +14,7 @@ fragment ManifestationsSimpleFields on Manifestation {
   pid
   genreAndForm
   source
+  ...WithLanguages
   titles {
     main
     original
@@ -30,12 +31,6 @@ fragment ManifestationsSimpleFields on Manifestation {
     __typename
   }
   publisher
-  languages {
-    main {
-      display
-      isoCode
-    }
-  }
   identifiers {
     value
   }
@@ -229,6 +224,19 @@ fragment WorkMedium on Work {
           main
         }
       }
+    }
+  }
+}
+
+# Fragments used to ensure consistency for properties between different queries.
+# Generated types from these fragments should not be used directly but instead
+# inferred by Pick'ing fields from other types.
+
+fragment WithLanguages on Manifestation {
+  languages {
+    main {
+      display
+      isoCode
     }
   }
 }

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -1489,6 +1489,16 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "DateTime",
+        "description": "A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "DidYouMean",
         "description": null,
@@ -3313,6 +3323,164 @@
           },
           {
             "name": "USE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LinkCheckResponse",
+        "description": null,
+        "fields": [
+          {
+            "name": "brokenSince",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastCheckedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "LinkCheckStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LinkCheckService",
+        "description": null,
+        "fields": [
+          {
+            "name": "checks",
+            "description": null,
+            "args": [
+              {
+                "name": "urls",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LinkCheckResponse",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "LinkCheckStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BROKEN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GONE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVALID",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OK",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -5656,6 +5824,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "InfomediaResponse",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "linkCheck",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LinkCheckService",
                 "ofType": null
               }
             },

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -1480,7 +1480,11 @@ export type GetMaterialQuery = {
         >;
         languages?: {
           __typename?: "Languages";
-          main?: Array<{ __typename?: "Language"; display: string }> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
@@ -1560,7 +1564,11 @@ export type GetMaterialQuery = {
         >;
         languages?: {
           __typename?: "Languages";
-          main?: Array<{ __typename?: "Language"; display: string }> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
@@ -1640,7 +1648,11 @@ export type GetMaterialQuery = {
         >;
         languages?: {
           __typename?: "Languages";
-          main?: Array<{ __typename?: "Language"; display: string }> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
@@ -1856,7 +1868,11 @@ export type RecommendFromFaustQuery = {
             >;
             languages?: {
               __typename?: "Languages";
-              main?: Array<{ __typename?: "Language"; display: string }> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
@@ -1942,7 +1958,11 @@ export type RecommendFromFaustQuery = {
             >;
             languages?: {
               __typename?: "Languages";
-              main?: Array<{ __typename?: "Language"; display: string }> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
@@ -2028,7 +2048,11 @@ export type RecommendFromFaustQuery = {
             >;
             languages?: {
               __typename?: "Languages";
-              main?: Array<{ __typename?: "Language"; display: string }> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
@@ -2174,7 +2198,11 @@ export type SearchWithPaginationQuery = {
           >;
           languages?: {
             __typename?: "Languages";
-            main?: Array<{ __typename?: "Language"; display: string }> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
@@ -2260,7 +2288,11 @@ export type SearchWithPaginationQuery = {
           >;
           languages?: {
             __typename?: "Languages";
-            main?: Array<{ __typename?: "Language"; display: string }> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
@@ -2346,7 +2378,11 @@ export type SearchWithPaginationQuery = {
           >;
           languages?: {
             __typename?: "Languages";
-            main?: Array<{ __typename?: "Language"; display: string }> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
@@ -2528,7 +2564,11 @@ export type ManifestationsSimpleFragment = {
     >;
     languages?: {
       __typename?: "Languages";
-      main?: Array<{ __typename?: "Language"; display: string }> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
     } | null;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
@@ -2605,7 +2645,11 @@ export type ManifestationsSimpleFragment = {
     >;
     languages?: {
       __typename?: "Languages";
-      main?: Array<{ __typename?: "Language"; display: string }> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
     } | null;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
@@ -2682,7 +2726,11 @@ export type ManifestationsSimpleFragment = {
     >;
     languages?: {
       __typename?: "Languages";
-      main?: Array<{ __typename?: "Language"; display: string }> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
     } | null;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
@@ -2761,7 +2809,11 @@ export type ManifestationsSimpleFieldsFragment = {
   >;
   languages?: {
     __typename?: "Languages";
-    main?: Array<{ __typename?: "Language"; display: string }> | null;
+    main?: Array<{
+      __typename?: "Language";
+      display: string;
+      isoCode: string;
+    }> | null;
   } | null;
   identifiers: Array<{ __typename?: "Identifier"; value: string }>;
   contributors: Array<
@@ -2937,7 +2989,11 @@ export type WorkSmallFragment = {
       >;
       languages?: {
         __typename?: "Languages";
-        main?: Array<{ __typename?: "Language"; display: string }> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
@@ -3017,7 +3073,11 @@ export type WorkSmallFragment = {
       >;
       languages?: {
         __typename?: "Languages";
-        main?: Array<{ __typename?: "Language"; display: string }> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
@@ -3097,7 +3157,11 @@ export type WorkSmallFragment = {
       >;
       languages?: {
         __typename?: "Languages";
-        main?: Array<{ __typename?: "Language"; display: string }> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
@@ -3259,7 +3323,11 @@ export type WorkMediumFragment = {
       >;
       languages?: {
         __typename?: "Languages";
-        main?: Array<{ __typename?: "Language"; display: string }> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
@@ -3339,7 +3407,11 @@ export type WorkMediumFragment = {
       >;
       languages?: {
         __typename?: "Languages";
-        main?: Array<{ __typename?: "Language"; display: string }> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
@@ -3419,7 +3491,11 @@ export type WorkMediumFragment = {
       >;
       languages?: {
         __typename?: "Languages";
-        main?: Array<{ __typename?: "Language"; display: string }> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
@@ -3571,6 +3647,7 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
   languages {
     main {
       display
+      isoCode
     }
   }
   identifiers {

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -24,6 +24,8 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+  DateTime: unknown;
   /** An integer in the range from 1 to 100 */
   PaginationLimit: unknown;
 };
@@ -537,6 +539,30 @@ export enum LibrariansReviewSectionCode {
   Use = "USE"
 }
 
+export type LinkCheckResponse = {
+  __typename?: "LinkCheckResponse";
+  brokenSince?: Maybe<Scalars["DateTime"]>;
+  lastCheckedAt?: Maybe<Scalars["DateTime"]>;
+  status: LinkCheckStatus;
+  url: Scalars["String"];
+};
+
+export type LinkCheckService = {
+  __typename?: "LinkCheckService";
+  checks: Array<LinkCheckResponse>;
+};
+
+export type LinkCheckServiceChecksArgs = {
+  urls?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+export enum LinkCheckStatus {
+  Broken = "BROKEN",
+  Gone = "GONE",
+  Invalid = "INVALID",
+  Ok = "OK"
+}
+
 export type Manifestation = {
   __typename?: "Manifestation";
   /** Abstract of the entity */
@@ -842,6 +868,7 @@ export type Query = {
   __typename?: "Query";
   complexSearch: ComplexSearchResponse;
   infomedia: InfomediaResponse;
+  linkCheck: LinkCheckService;
   localSuggest: LocalSuggestResponse;
   manifestation?: Maybe<Manifestation>;
   manifestations: Array<Maybe<Manifestation>>;
@@ -1478,14 +1505,6 @@ export type GetMaterialQuery = {
           | { __typename: "Corporation"; display: string }
           | { __typename: "Person"; display: string }
         >;
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
           | { __typename?: "Corporation"; display: string }
@@ -1539,6 +1558,14 @@ export type GetMaterialQuery = {
         workYear?: {
           __typename?: "PublicationYear";
           year?: number | null;
+        } | null;
+        languages?: {
+          __typename?: "Languages";
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
       }>;
       latest: {
@@ -1562,14 +1589,6 @@ export type GetMaterialQuery = {
           | { __typename: "Corporation"; display: string }
           | { __typename: "Person"; display: string }
         >;
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
           | { __typename?: "Corporation"; display: string }
@@ -1623,6 +1642,14 @@ export type GetMaterialQuery = {
         workYear?: {
           __typename?: "PublicationYear";
           year?: number | null;
+        } | null;
+        languages?: {
+          __typename?: "Languages";
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
       };
       bestRepresentation: {
@@ -1646,14 +1673,6 @@ export type GetMaterialQuery = {
           | { __typename: "Corporation"; display: string }
           | { __typename: "Person"; display: string }
         >;
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
           | { __typename?: "Corporation"; display: string }
@@ -1707,6 +1726,14 @@ export type GetMaterialQuery = {
         workYear?: {
           __typename?: "PublicationYear";
           year?: number | null;
+        } | null;
+        languages?: {
+          __typename?: "Languages";
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
       };
     };
@@ -1866,14 +1893,6 @@ export type RecommendFromFaustQuery = {
               | { __typename: "Corporation"; display: string }
               | { __typename: "Person"; display: string }
             >;
-            languages?: {
-              __typename?: "Languages";
-              main?: Array<{
-                __typename?: "Language";
-                display: string;
-                isoCode: string;
-              }> | null;
-            } | null;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
               | { __typename?: "Corporation"; display: string }
@@ -1930,6 +1949,14 @@ export type RecommendFromFaustQuery = {
             workYear?: {
               __typename?: "PublicationYear";
               year?: number | null;
+            } | null;
+            languages?: {
+              __typename?: "Languages";
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
           }>;
           latest: {
@@ -1956,14 +1983,6 @@ export type RecommendFromFaustQuery = {
               | { __typename: "Corporation"; display: string }
               | { __typename: "Person"; display: string }
             >;
-            languages?: {
-              __typename?: "Languages";
-              main?: Array<{
-                __typename?: "Language";
-                display: string;
-                isoCode: string;
-              }> | null;
-            } | null;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
               | { __typename?: "Corporation"; display: string }
@@ -2020,6 +2039,14 @@ export type RecommendFromFaustQuery = {
             workYear?: {
               __typename?: "PublicationYear";
               year?: number | null;
+            } | null;
+            languages?: {
+              __typename?: "Languages";
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
           };
           bestRepresentation: {
@@ -2046,14 +2073,6 @@ export type RecommendFromFaustQuery = {
               | { __typename: "Corporation"; display: string }
               | { __typename: "Person"; display: string }
             >;
-            languages?: {
-              __typename?: "Languages";
-              main?: Array<{
-                __typename?: "Language";
-                display: string;
-                isoCode: string;
-              }> | null;
-            } | null;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
               | { __typename?: "Corporation"; display: string }
@@ -2110,6 +2129,14 @@ export type RecommendFromFaustQuery = {
             workYear?: {
               __typename?: "PublicationYear";
               year?: number | null;
+            } | null;
+            languages?: {
+              __typename?: "Languages";
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
           };
         };
@@ -2196,14 +2223,6 @@ export type SearchWithPaginationQuery = {
             | { __typename: "Corporation"; display: string }
             | { __typename: "Person"; display: string }
           >;
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
             | { __typename?: "Corporation"; display: string }
@@ -2260,6 +2279,14 @@ export type SearchWithPaginationQuery = {
           workYear?: {
             __typename?: "PublicationYear";
             year?: number | null;
+          } | null;
+          languages?: {
+            __typename?: "Languages";
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
         }>;
         latest: {
@@ -2286,14 +2313,6 @@ export type SearchWithPaginationQuery = {
             | { __typename: "Corporation"; display: string }
             | { __typename: "Person"; display: string }
           >;
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
             | { __typename?: "Corporation"; display: string }
@@ -2350,6 +2369,14 @@ export type SearchWithPaginationQuery = {
           workYear?: {
             __typename?: "PublicationYear";
             year?: number | null;
+          } | null;
+          languages?: {
+            __typename?: "Languages";
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
         };
         bestRepresentation: {
@@ -2376,14 +2403,6 @@ export type SearchWithPaginationQuery = {
             | { __typename: "Corporation"; display: string }
             | { __typename: "Person"; display: string }
           >;
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
             | { __typename?: "Corporation"; display: string }
@@ -2440,6 +2459,14 @@ export type SearchWithPaginationQuery = {
           workYear?: {
             __typename?: "PublicationYear";
             year?: number | null;
+          } | null;
+          languages?: {
+            __typename?: "Languages";
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
         };
       };
@@ -2469,7 +2496,18 @@ export type SuggestionsFromQueryStringQuery = {
         >;
         manifestations: {
           __typename?: "Manifestations";
-          bestRepresentation: { __typename?: "Manifestation"; pid: string };
+          bestRepresentation: {
+            __typename?: "Manifestation";
+            pid: string;
+            languages?: {
+              __typename?: "Languages";
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
+            } | null;
+          };
         };
       } | null;
     }>;
@@ -2562,14 +2600,6 @@ export type ManifestationsSimpleFragment = {
       | { __typename: "Corporation"; display: string }
       | { __typename: "Person"; display: string }
     >;
-    languages?: {
-      __typename?: "Languages";
-      main?: Array<{
-        __typename?: "Language";
-        display: string;
-        isoCode: string;
-      }> | null;
-    } | null;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
       | { __typename?: "Corporation"; display: string }
@@ -2621,6 +2651,14 @@ export type ManifestationsSimpleFragment = {
       shelfmark: string;
     } | null;
     workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    languages?: {
+      __typename?: "Languages";
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
+    } | null;
   }>;
   latest: {
     __typename?: "Manifestation";
@@ -2643,14 +2681,6 @@ export type ManifestationsSimpleFragment = {
       | { __typename: "Corporation"; display: string }
       | { __typename: "Person"; display: string }
     >;
-    languages?: {
-      __typename?: "Languages";
-      main?: Array<{
-        __typename?: "Language";
-        display: string;
-        isoCode: string;
-      }> | null;
-    } | null;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
       | { __typename?: "Corporation"; display: string }
@@ -2702,6 +2732,14 @@ export type ManifestationsSimpleFragment = {
       shelfmark: string;
     } | null;
     workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    languages?: {
+      __typename?: "Languages";
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
+    } | null;
   };
   bestRepresentation: {
     __typename?: "Manifestation";
@@ -2724,14 +2762,6 @@ export type ManifestationsSimpleFragment = {
       | { __typename: "Corporation"; display: string }
       | { __typename: "Person"; display: string }
     >;
-    languages?: {
-      __typename?: "Languages";
-      main?: Array<{
-        __typename?: "Language";
-        display: string;
-        isoCode: string;
-      }> | null;
-    } | null;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
       | { __typename?: "Corporation"; display: string }
@@ -2783,6 +2813,14 @@ export type ManifestationsSimpleFragment = {
       shelfmark: string;
     } | null;
     workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    languages?: {
+      __typename?: "Languages";
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
+    } | null;
   };
 };
 
@@ -2807,14 +2845,6 @@ export type ManifestationsSimpleFieldsFragment = {
     | { __typename: "Corporation"; display: string }
     | { __typename: "Person"; display: string }
   >;
-  languages?: {
-    __typename?: "Languages";
-    main?: Array<{
-      __typename?: "Language";
-      display: string;
-      isoCode: string;
-    }> | null;
-  } | null;
   identifiers: Array<{ __typename?: "Identifier"; value: string }>;
   contributors: Array<
     | { __typename?: "Corporation"; display: string }
@@ -2863,6 +2893,14 @@ export type ManifestationsSimpleFieldsFragment = {
     shelfmark: string;
   } | null;
   workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
+  languages?: {
+    __typename?: "Languages";
+    main?: Array<{
+      __typename?: "Language";
+      display: string;
+      isoCode: string;
+    }> | null;
+  } | null;
 };
 
 export type ManifestationReviewFieldsFragment = {
@@ -2987,14 +3025,6 @@ export type WorkSmallFragment = {
         | { __typename: "Corporation"; display: string }
         | { __typename: "Person"; display: string }
       >;
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
         | { __typename?: "Corporation"; display: string }
@@ -3048,6 +3078,14 @@ export type WorkSmallFragment = {
       workYear?: {
         __typename?: "PublicationYear";
         year?: number | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
     }>;
     latest: {
@@ -3071,14 +3109,6 @@ export type WorkSmallFragment = {
         | { __typename: "Corporation"; display: string }
         | { __typename: "Person"; display: string }
       >;
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
         | { __typename?: "Corporation"; display: string }
@@ -3132,6 +3162,14 @@ export type WorkSmallFragment = {
       workYear?: {
         __typename?: "PublicationYear";
         year?: number | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
     };
     bestRepresentation: {
@@ -3155,14 +3193,6 @@ export type WorkSmallFragment = {
         | { __typename: "Corporation"; display: string }
         | { __typename: "Person"; display: string }
       >;
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
         | { __typename?: "Corporation"; display: string }
@@ -3216,6 +3246,14 @@ export type WorkSmallFragment = {
       workYear?: {
         __typename?: "PublicationYear";
         year?: number | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
     };
   };
@@ -3321,14 +3359,6 @@ export type WorkMediumFragment = {
         | { __typename: "Corporation"; display: string }
         | { __typename: "Person"; display: string }
       >;
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
         | { __typename?: "Corporation"; display: string }
@@ -3382,6 +3412,14 @@ export type WorkMediumFragment = {
       workYear?: {
         __typename?: "PublicationYear";
         year?: number | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
     }>;
     latest: {
@@ -3405,14 +3443,6 @@ export type WorkMediumFragment = {
         | { __typename: "Corporation"; display: string }
         | { __typename: "Person"; display: string }
       >;
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
         | { __typename?: "Corporation"; display: string }
@@ -3466,6 +3496,14 @@ export type WorkMediumFragment = {
       workYear?: {
         __typename?: "PublicationYear";
         year?: number | null;
+      } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
     };
     bestRepresentation: {
@@ -3489,14 +3527,6 @@ export type WorkMediumFragment = {
         | { __typename: "Corporation"; display: string }
         | { __typename: "Person"; display: string }
       >;
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
         | { __typename?: "Corporation"; display: string }
@@ -3551,8 +3581,28 @@ export type WorkMediumFragment = {
         __typename?: "PublicationYear";
         year?: number | null;
       } | null;
+      languages?: {
+        __typename?: "Languages";
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
+      } | null;
     };
   };
+};
+
+export type WithLanguagesFragment = {
+  __typename?: "Manifestation";
+  languages?: {
+    __typename?: "Languages";
+    main?: Array<{
+      __typename?: "Language";
+      display: string;
+      isoCode: string;
+    }> | null;
+  } | null;
 };
 
 export const ManifestationReviewFieldsFragmentDoc = `
@@ -3623,11 +3673,22 @@ export const SeriesSimpleFragmentDoc = `
   readThisWhenever
 }
     `;
+export const WithLanguagesFragmentDoc = `
+    fragment WithLanguages on Manifestation {
+  languages {
+    main {
+      display
+      isoCode
+    }
+  }
+}
+    `;
 export const ManifestationsSimpleFieldsFragmentDoc = `
     fragment ManifestationsSimpleFields on Manifestation {
   pid
   genreAndForm
   source
+  ...WithLanguages
   titles {
     main
     original
@@ -3644,12 +3705,6 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
     __typename
   }
   publisher
-  languages {
-    main {
-      display
-      isoCode
-    }
-  }
   identifiers {
     value
   }
@@ -3709,7 +3764,7 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
     year
   }
 }
-    `;
+    ${WithLanguagesFragmentDoc}`;
 export const ManifestationsSimpleFragmentDoc = `
     fragment ManifestationsSimple on Manifestations {
   all {
@@ -3979,13 +4034,14 @@ export const SuggestionsFromQueryStringDocument = `
         manifestations {
           bestRepresentation {
             pid
+            ...WithLanguages
           }
         }
       }
     }
   }
 }
-    `;
+    ${WithLanguagesFragmentDoc}`;
 export const useSuggestionsFromQueryStringQuery = <
   TData = SuggestionsFromQueryStringQuery,
   TError = unknown


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-436

#### This pull request adds new functionality to improve accessibility by assigning the 'lang' attribute to titles
A new function called `getManifestationLanguageIsoCode` has been implemented to accomplish this.

The `getManifestationLanguageIsoCode` function takes an array of LanguagesFragment objects and returns the ISO code of the main language. If multiple unique main languages are present, it defaults to the language defined in the document's HTML tag.

In addition, 'LanguagesFragment' fragments have been added to enhance code generation (Types)

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/49920322/231412810-c9df997a-3fc8-4353-8c89-7bcac9002853.png)

![image](https://user-images.githubusercontent.com/49920322/228797946-5b8fd9be-e684-40e4-93e4-5a9dc25f9f4b.png)

![image](https://user-images.githubusercontent.com/49920322/231414618-94071375-39e5-4ce8-91e7-83554f45ef54.png)



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.