### PR TITLE
Improve keyboard navigation in `SearchResultList`

### DIFF
--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -172,7 +172,11 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
       {campaignData && campaignData.data && (
         <Campaign campaignData={campaignData.data} />
       )}
-      <SearchResultList resultItems={resultItems} />
+      <SearchResultList
+        resultItems={resultItems}
+        page={page}
+        pageSize={pageSize}
+      />
       <PagerComponent isLoading={isLoading} />
       {dataIsNotEmpty(resultItems) && <FacetBrowserModal q={q} />}
     </div>

--- a/src/components/search-result-list/SearchResultList.tsx
+++ b/src/components/search-result-list/SearchResultList.tsx
@@ -43,8 +43,9 @@ const SearchResultList: React.FC<SearchResultListProps> = ({
             <li
               key={item.workId}
               ref={isFirstNewItem ? lastItemRef : null}
-              // Because we're using a ref to focus the first item in the new page when pagination occurs.
-              // we need to remove focus ( set tabIndex -1), so that it can be set programmatically.
+              // We use a ref to focus the first item in the new page programmatically when pagination occurs.
+              // Set tabIndex -1 to support this without allowing keyboard focus. We have just as appropriate
+              // elements within the item suitable for keyboard focus.
               tabIndex={-1}
             >
               <SearchResultListItem

--- a/src/components/search-result-list/SearchResultList.tsx
+++ b/src/components/search-result-list/SearchResultList.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useEffect } from "react";
 import { dataIsNotEmpty, getCoverTint } from "../../core/utils/helpers/general";
 import { Work } from "../../core/utils/types/entities";
 import SearchResultListItem from "./search-result-list-item/search-result-list-item";
@@ -6,10 +6,23 @@ import SearchResultListItemSkeleton from "./search-result-list-item/search-resul
 
 export interface SearchResultListProps {
   resultItems: Work[];
+  page: number;
+  pageSize: number;
 }
 
-const SearchResultList: React.FC<SearchResultListProps> = ({ resultItems }) => {
+const SearchResultList: React.FC<SearchResultListProps> = ({
+  resultItems,
+  page,
+  pageSize
+}) => {
   const worksAreLoaded = dataIsNotEmpty(resultItems);
+  const lastItemRef = React.useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    if (page > 0 && lastItemRef.current) {
+      lastItemRef.current.focus();
+    }
+  }, [page, resultItems]);
 
   return (
     <ul className="search-result-page__list my-32" data-cy="search-result-list">
@@ -24,15 +37,24 @@ const SearchResultList: React.FC<SearchResultListProps> = ({ resultItems }) => {
           </li>
         ))}
       {worksAreLoaded &&
-        resultItems.map((item, i) => (
-          <li key={item.workId}>
-            <SearchResultListItem
-              item={item}
-              coverTint={getCoverTint(i)}
-              resultNumber={i + 1}
-            />
-          </li>
-        ))}
+        resultItems.map((item, i) => {
+          const isFirstNewItem = i === page * pageSize;
+          return (
+            <li
+              key={item.workId}
+              ref={isFirstNewItem ? lastItemRef : null}
+              // Because we're using a ref to focus the first item in the new page when pagination occurs.
+              // we need to remove focus ( set tabIndex -1), so that it can be set programmatically.
+              tabIndex={-1}
+            >
+              <SearchResultListItem
+                item={item}
+                coverTint={getCoverTint(i)}
+                resultNumber={i + 1}
+              />
+            </li>
+          );
+        })}
     </ul>
   );
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-420

#### This pull request improves keyboard navigation in the `SearchResultList`. 

These changes ensure that the focus moves as expected when navigating through the list using the keyboard to move to the next pages.

The following changes have been made:

- Add 'page' and 'pageSize' props to the `SearchResultListProps` interface.
- Add a useEffect hook to focus on the first item of the new page when the page number changes.
- add a ref attribute to the first li element in the SearchResultList component.

#### Screenshot of the result
https://user-images.githubusercontent.com/49920322/231752771-0cf16655-666a-460a-a45d-8535d91fd2d1.mov

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.