### PR TITLE
Refactor `DisclosureControllable` toggle & key handling

### DIFF
--- a/src/components/Disclosures/DisclosureControllable.tsx
+++ b/src/components/Disclosures/DisclosureControllable.tsx
@@ -23,8 +23,21 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
   const [isOpen, setIsOpen] = useState<boolean>(showContent);
 
   const toggleOpen = useCallback(() => {
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+    setIsOpen((prevIsOpen) => !prevIsOpen);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    toggleOpen();
+  }, [toggleOpen]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        toggleOpen();
+      }
+    },
+    [toggleOpen]
+  );
 
   const disclosureId = `disclosure-${id}`;
 
@@ -32,8 +45,8 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
     <div className={`disclosure text-body-large ${className}`}>
       <div
         data-cy={cyData}
-        onClick={toggleOpen}
-        onKeyDown={toggleOpen}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}
         aria-controls={disclosureId}


### PR DESCRIPTION
#### Link to issue
[DDFSOEG-472](https://reload.atlassian.net/browse/DDFSOEG-472)

#### This PR refactors the `DisclosureControllable` to improve its accessibility by opening when the "Enter" key is pressed `onKeyDown`. 

The changes address focus issues in `DisclosureControllable` and provide a better user experience.

The changes include:

- Separating the `onClick` and `onKeyDown` event handlers into two separate functions, `handleClick` and `handleKeyDown`. This improves readability and maintains the separation of concerns between different types of events.
- Updating the `toggleOpen` useCallback to use a functional state update for `setIsOpen` instead of relying on the `isOpen` value from the closure. This avoids potential issues with stale state values and makes the callback more efficient.


#### Screenshot of the result
https://user-images.githubusercontent.com/49920322/232033931-4956ae6b-5457-462b-a18f-8a8f75d8e78a.mov

https://user-images.githubusercontent.com/49920322/232033780-67b3b44c-a50d-4794-b470-6ab679c2e574.mov


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

**This PR also addresses the tab issue in the facet browser that we have discussed previously.**