### PR TITLE
Remove unnecessary use of `filterCreators`

### DIFF
--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -10,7 +10,6 @@ import {
   constructModalId,
   convertPostIdToFaustId,
   creatorsToString,
-  filterCreators,
   flattenCreators,
   getAllFaustIds,
   getManifestationsPids
@@ -59,10 +58,7 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
     recordid: faustIdArray,
     ...(blacklistBranches ? { exclude: blacklistBranches } : {})
   });
-  const author = creatorsToString(
-    flattenCreators(filterCreators(authors, ["Person"])),
-    t
-  );
+  const author = creatorsToString(flattenCreators(authors), t);
   const title = workTitles.join(", ");
   // If this modal is for all manifestations per material type, use all manifestations'
   // faust ids to create the modal id.

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -6,7 +6,6 @@ import { TypedDispatch } from "../../core/store";
 import {
   convertPostIdToFaustId,
   creatorsToString,
-  filterCreators,
   flattenCreators,
   getMaterialTypes,
   getManifestationPid
@@ -68,10 +67,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
       })
     );
   };
-  const author = creatorsToString(
-    flattenCreators(filterCreators(creators, ["Person"])),
-    t
-  );
+  const author = creatorsToString(flattenCreators(creators), t);
   const isPeriodical = hasCorrectMaterialType(
     MaterialType.magazine,
     selectedManifestations

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -5,7 +5,6 @@ import { Cover } from "../cover/cover";
 import {
   convertPostIdToFaustId,
   creatorsToString,
-  filterCreators,
   flattenCreators
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
@@ -41,10 +40,8 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   const t = useText();
   const [isOpen, setIsOpen] = useState(false);
   const faustId = convertPostIdToFaustId(pid);
-  const creatorsText = creatorsToString(
-    flattenCreators(filterCreators(creators, ["Person"])),
-    t
-  );
+  const author = creatorsToString(flattenCreators(creators), t);
+
   const languageIsoCode = getManifestationLanguageIsoCode([manifestation]);
 
   const detailsListData: ListData = [
@@ -125,7 +122,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           {titles?.main[0]}
         </h3>
         <p className="text-small-caption">
-          {t("materialHeaderAuthorByText")} {creatorsText}
+          {t("materialHeaderAuthorByText")} {author}
           {edition?.publicationYear?.display &&
             ` (${edition.publicationYear.display})`}
         </p>

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -9,7 +9,6 @@ import {
 import {
   convertPostIdToFaustId,
   creatorsToString,
-  filterCreators,
   flattenCreators,
   getLatestManifestation,
   getManifestationPublicationYear,
@@ -140,11 +139,7 @@ export const getAuthorLine = (
 ) => {
   const { creators } = manifestation;
   const publicationYear = getManifestationPublicationYear(manifestation);
-  const author =
-    creatorsToString(
-      flattenCreators(filterCreators(creators, ["Person"])),
-      t
-    ) || null;
+  const author = creatorsToString(flattenCreators(creators), t) || null;
 
   let year = "";
   if (publicationYear) {

--- a/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
+++ b/src/components/search-result-list/search-result-list-item/search-result-list-item.tsx
@@ -11,7 +11,6 @@ import { CoverProps } from "../../cover/cover";
 import Link from "../../atoms/links/Link";
 import {
   creatorsToString,
-  filterCreators,
   flattenCreators,
   getManifestationPid,
   getReleaseYearSearchResult
@@ -67,10 +66,7 @@ const SearchResultListItem: React.FC<SearchResultListItemProps> = ({
   );
 
   const dispatch = useDispatch<TypedDispatch>();
-  const author = creatorsToString(
-    flattenCreators(filterCreators(creators, ["Person"])),
-    t
-  );
+  const author = creatorsToString(flattenCreators(creators), t);
   const manifestationPid = getManifestationPid(manifestations);
   const firstItemInSeries = getNumberedSeries(series).shift();
   const materialFullUrl = constructMaterialUrl(

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -42,14 +42,6 @@ export const orderManifestationsByYear = (
   });
 };
 
-export const filterCreators = (
-  creators: Work["creators"],
-  filterBy: ["Person" | "Corporation"]
-) =>
-  creators.filter((creator: Work["creators"][0]) => {
-    return creator.__typename && filterBy.includes(creator.__typename);
-  });
-
 export const flattenCreators = (creators: Work["creators"]) =>
   creators.map((creator: Work["creators"][0]) => {
     return creator.display;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-503

#### Description

This Pull Request refactors the way we retrieve authors/creators from works and manifestations.

Previously, we looked at whether the type of Creators was a `person` or `Corporation`, but we also want to display the author if the material is, for example, a CD, such as `work-of:870970-basis:23157381`.

Therefore, I have removed the usage of filterCreators and deleted the function.


#### Screenshot of the result
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/49920322/232537470-49e207a1-dc0e-45ba-8fe7-907148d355a5.png">
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/49920322/232537666-911a8ca2-bef5-436d-a067-b286c861c2e5.png">
<img width="1530" alt="image" src="https://user-images.githubusercontent.com/49920322/232537837-7cd9de82-e586-454d-872b-01bf189d99b1.png">
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/49920322/232538105-908ea1e5-4495-4fdc-a485-f7096b86ed1f.png">



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.