### PR TITLE
Check if the material has `subjects` before showing "Tags"

### DIFF
--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -87,7 +87,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
                 dataCy="material-description-series-members"
               />
             )}
-            {subjectsList && (
+            {subjectsList.length > 0 && (
               <HorizontalTermLine
                 title={t("identifierText")}
                 linkList={subjectsList}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-509

#### Description - Check if the material has `subjects` before showing "Tags"

We only want to display "Tags" / "Emneord" / "subjectsList" if there are some items in the `subjects` array. 
This is achieved by checking subjectsList.length before rendering the HorizontalTermLine component.

#### Screenshot of the result
<img width="1988" alt="image" src="https://user-images.githubusercontent.com/49920322/232690282-173f0233-1339-455e-9f8a-379a81adb52b.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.