### PR TITLE
Add `allowOutsideClick` to `FocusTrap` in ReservationSucces/ Error modal

### DIFF
--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -40,7 +40,11 @@ const ReservationError: React.FC<ReservationErrorProps> = ({
     handleErrorText[reservationResult] || handleErrorText.default;
 
   return (
-    <FocusTrap>
+    <FocusTrap
+      focusTrapOptions={{
+        allowOutsideClick: true
+      }}
+    >
       <section className="reservation-modal reservation-modal--confirm">
         <h2 className="text-header-h3 pb-48">{reservationErrorInfo.title}</h2>
         {reservationErrorInfo.description && (

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -27,7 +27,11 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   const t = useText();
 
   return (
-    <FocusTrap>
+    <FocusTrap
+      focusTrapOptions={{
+        allowOutsideClick: true
+      }}
+    >
       <section className="reservation-modal reservation-modal--confirm">
         <h2
           data-cy="reservation-success-title-text"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-506

####  This PR fixes the issue of not being able to close the ReservationSuccess or ReservationError modal by pressing the cross/close button.

The default behavior is to not allow clicking outside the `FocusTrap`. However, we still want to be able to close the modal with the mouse, so we set allowOutsideClick to `true`.

#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
