### PR TITLE
Extract `ButtonExpand` component + Update "dpl-design-system"

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/button-expand/ButtonExpand.tsx
+++ b/src/components/button-expand/ButtonExpand.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import React, { FC } from "react";
 import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
+import { useText } from "../../core/utils/text";
 
 export type ButtonExpandProps = {
   showMore: boolean;
@@ -8,12 +9,13 @@ export type ButtonExpandProps = {
 };
 
 const ButtonExpand: FC<ButtonExpandProps> = ({ showMore, setShowMore }) => {
+  const t = useText();
   return (
     <button
       className="button-expand"
       type="button"
       onClick={() => setShowMore(!showMore)}
-      aria-label="Expand More"
+      aria-label={t("expandMoreText")}
     >
       <img
         className={clsx("button-expand__image", {

--- a/src/components/button-expand/ButtonExpand.tsx
+++ b/src/components/button-expand/ButtonExpand.tsx
@@ -1,0 +1,29 @@
+import clsx from "clsx";
+import React, { FC } from "react";
+import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
+
+export type ButtonExpandProps = {
+  showMore: boolean;
+  setShowMore: (showMore: boolean) => void;
+};
+
+const ButtonExpand: FC<ButtonExpandProps> = ({ showMore, setShowMore }) => {
+  return (
+    <button
+      className="button-expand"
+      type="button"
+      onClick={() => setShowMore(!showMore)}
+      aria-label="Expand More"
+    >
+      <img
+        className={clsx("button-expand__image", {
+          "button-expand__image--expanded": showMore
+        })}
+        src={ExpandMoreIcon}
+        alt=""
+      />
+    </button>
+  );
+};
+
+export default ButtonExpand;

--- a/src/components/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/components/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import Link from "../atoms/links/Link";
-import { useText } from "../../core/utils/text";
 import ButtonExpand from "../button-expand/ButtonExpand";
 
 export interface HorizontalTermLineProps {
@@ -19,7 +18,6 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
   linkList,
   dataCy = "horizontal-term-line"
 }) => {
-  const t = useText();
   const numberOfItemsToShow = 3;
   const [showMore, setShowMore] = useState(false);
   const itemsToShow = showMore

--- a/src/components/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/components/horizontal-term-line/HorizontalTermLine.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
-import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
-import clsx from "clsx";
 import Link from "../atoms/links/Link";
 import { useText } from "../../core/utils/text";
+import ButtonExpand from "../button-expand/ButtonExpand";
 
 export interface HorizontalTermLineProps {
   title: string;
@@ -53,19 +52,7 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
       })}
 
       {showMoreButton && (
-        <button
-          type="button"
-          onClick={() => setShowMore(!showMore)}
-          aria-label={t("expandMoreText")}
-        >
-          <img
-            className={clsx("horizontal-term-line__expand", {
-              "horizontal-term-line__expand--expanded": showMore
-            })}
-            src={ExpandMoreIcon}
-            alt=""
-          />
-        </button>
+        <ButtonExpand showMore={showMore} setShowMore={setShowMore} />
       )}
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,10 +1749,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3":
-  version "0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3/c60fff08a130ddd84b3b8e6452900890bf83e37d#c60fff08a130ddd84b3b8e6452900890bf83e37d"
-  integrity sha512-HRVsOqnKY35DLl71m6gdd1uOLR+DClaBVZI2opC8tjaIJTiNoDtRHEJfMQF+Pdrv6rJwRKBxfn4/hFAJgl0HsQ==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66":
+  version "0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66/788acaf1ef8e4b74bc2c1ba07209a1bbdd0a4f3f#788acaf1ef8e4b74bc2c1ba07209a1bbdd0a4f3f"
+  integrity sha512-PxLLfTk1LfYdMRYIGmKGWVxA6WjjnbUI4wdcrOq0OVCniioHfwfl0/gUF4q/qUl5ijRjshbT7kR6H1ZZHcFhgg==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-488

**This should reflect the changes in:**
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/213

#### This PR is updating "dpl-design-system" to ensure baseline alignment for `HorizontalTermLine` and extracting the `ButtonExpand`to its own component.

Changes made:
- Extracted ButtonExpand into a separate component for improved reusability and maintenance
- Updated "dpl-design-system" to align with the latest design, ensuring baseline alignment for HorizontalTermLine



#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

## Update the after the PR in "design-system"  are merged.
