### PR TITLE
Add `HorizontalTermLine` for `dk5MainEntry` ("emnetal") to nonFiction Works

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -104,6 +104,11 @@ export default {
       defaultValue: "Nr.",
       control: { type: "text" }
     },
+    subjectNumberText: {
+      name: "Subject number (Emnetal)",
+      defaultValue: "Emnetal",
+      control: { type: "text" }
+    },
     inSeriesText: {
       name: "In series",
       defaultValue: "in series",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -46,7 +46,6 @@ interface MaterialEntryTextProps {
   findOnBookshelfText: string;
   findOnShelfExpandButtonExplanationText: string;
   findOnShelfModalCloseModalAriaLabelText: string;
-  findOnShelfTableDescriptionText: string;
   findOnShelfModalListFindOnShelfText: string;
   findOnShelfModalListItemCountText: string;
   findOnShelfModalListMaterialText: string;
@@ -54,6 +53,7 @@ interface MaterialEntryTextProps {
   findOnShelfModalPeriodicalEditionDropdownText: string;
   findOnShelfModalPeriodicalYearDropdownText: string;
   findOnShelfModalScreenReaderModalDescriptionText: string;
+  findOnShelfTableDescriptionText: string;
   firstAvailableEditionText: string;
   getOnlineText: string;
   goToText: string;
@@ -135,6 +135,7 @@ interface MaterialEntryTextProps {
   seeOnlineText: string;
   shiftText: string;
   sixMonthsText: string;
+  subjectNumberText: string;
   threeMonthsText: string;
   tryAginButtonText: string;
   twoMonthsText: string;

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -14,6 +14,7 @@ import { Work } from "../../core/utils/types/entities";
 import { Pid, WorkId } from "../../core/utils/types/ids";
 import { useUrls } from "../../core/utils/url";
 import HorizontalTermLine from "../horizontal-term-line/HorizontalTermLine";
+import { materialIsFiction } from "../../core/utils/helpers/general";
 
 export interface MaterialDescriptionProps {
   pid: Pid;
@@ -24,9 +25,16 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
   const { itemRef, hasBeenVisible: showItem } = useItemHasBeenVisible();
   const t = useText();
   const { searchUrl, materialUrl } = useUrls();
-  const { fictionNonfiction, series, subjects, seriesMembers, relations } =
-    work;
+  const {
+    fictionNonfiction,
+    series,
+    subjects,
+    seriesMembers,
+    relations,
+    dk5MainEntry
+  } = work;
 
+  const isFiction = materialIsFiction(work);
   const seriesList = getNumberedSeries(series);
 
   const seriesMembersList = seriesMembers.map((item) => {
@@ -65,6 +73,17 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
             </p>
           )}
           <div className="material-description__links mt-32">
+            {!isFiction && dk5MainEntry && (
+              <HorizontalTermLine
+                title="Emnetal"
+                linkList={[
+                  {
+                    url: constructSearchUrl(searchUrl, dk5MainEntry.display),
+                    term: dk5MainEntry.display
+                  }
+                ]}
+              />
+            )}
             {seriesList.map((item, i) => (
               <HorizontalTermLine
                 title={`${t("numberDescriptionText")} ${

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -75,7 +75,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
           <div className="material-description__links mt-32">
             {!isFiction && dk5MainEntry && (
               <HorizontalTermLine
-                title="Emnetal"
+                title={t("subjectNumberText")}
                 linkList={[
                   {
                     url: constructSearchUrl(searchUrl, dk5MainEntry.display),


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-485

#### Description

This PR introduces the `HorizontalTermLine` component for `dk5MainEntry` ("emnetal")  specifically for nonFiction Works

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/49920322/232801092-4e4c682a-551c-4e5f-ab9e-8d6bf79bfee6.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions