### PR TITLE
  Don't open ReservationModal modal if the user is blocked.

### DIFF
--- a/cypress/fixtures/material/user.json
+++ b/cypress/fixtures/material/user.json
@@ -10,7 +10,7 @@
     },
     "allowBookings": false,
     "birthday": "1991-02-23",
-    "blockStatus": null,
+    "blockStatus": [],
     "defaultInterestPeriod": 180,
     "emailAddress": "test@test.com",
     "name": "test user name",

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -38,7 +38,7 @@ import MaterialSkeleton from "../../components/material/MaterialSkeleton";
 import DisclosureSummary from "../../components/Disclosures/DisclosureSummary";
 import MaterialDisclosure from "./MaterialDisclosure";
 import { useGetPatronInformationByPatronIdV2 } from "../../core/fbs/fbs";
-import { userIsAllowed } from "../../core/utils/helpers/user";
+import { canReserve } from "../../core/utils/helpers/user";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -56,7 +56,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   });
 
   const { data: userData } = useGetPatronInformationByPatronIdV2();
-  const isUserAllowed = userIsAllowed(userData);
+  const isUserAllowed = canReserve(userData);
 
   const { track } = useStatistics();
   useDeepCompareEffect(() => {

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -56,7 +56,8 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   });
 
   const { data: userData } = useGetPatronInformationByPatronIdV2();
-  const isUserAllowed = canReserve(userData);
+  const patron = userData?.patron;
+  const userCanReserve = patron && canReserve(patron);
 
   const { track } = useStatistics();
   useDeepCompareEffect(() => {
@@ -158,7 +159,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         selectedPeriodical={selectedPeriodical}
         selectPeriodicalHandler={setSelectedPeriodical}
       >
-        {isUserAllowed &&
+        {userCanReserve &&
           manifestations.map((manifestation) => (
             <>
               <ReservationModal
@@ -188,7 +189,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         )}
         {/* Only create a main version of "reservation" & "find on shelf" modal for physical materials with multiple editions.
         Online materials lead to external links, or to same modals as are created for singular editions. */}
-        {isUserAllowed && isParallelReservation(selectedManifestations) && (
+        {userCanReserve && isParallelReservation(selectedManifestations) && (
           <>
             <ReservationModal
               selectedManifestations={selectedManifestations}

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -37,6 +37,8 @@ import MaterialHeader from "../../components/material/MaterialHeader";
 import MaterialSkeleton from "../../components/material/MaterialSkeleton";
 import DisclosureSummary from "../../components/Disclosures/DisclosureSummary";
 import MaterialDisclosure from "./MaterialDisclosure";
+import { useGetPatronInformationByPatronIdV2 } from "../../core/fbs/fbs";
+import { userIsAllowed } from "../../core/utils/helpers/user";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -52,6 +54,9 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const { data, isLoading } = useGetMaterialQuery({
     wid
   });
+
+  const { data: userData } = useGetPatronInformationByPatronIdV2();
+  const isUserAllowed = userIsAllowed(userData);
 
   const { track } = useStatistics();
   useDeepCompareEffect(() => {
@@ -153,39 +158,37 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         selectedPeriodical={selectedPeriodical}
         selectPeriodicalHandler={setSelectedPeriodical}
       >
-        {manifestations.map((manifestation) => (
-          <>
-            <ReservationModal
-              key={`reservation-modal-${manifestation.pid}`}
-              selectedManifestations={[manifestation]}
-              selectedPeriodical={selectedPeriodical}
-              work={work}
-            />
-            <FindOnShelfModal
-              key={`find-on-shelf-modal-${manifestation.pid}`}
-              manifestations={[manifestation]}
-              workTitles={manifestation.titles.main}
-              authors={manifestation.creators}
-              selectedPeriodical={selectedPeriodical}
-              setSelectedPeriodical={setSelectedPeriodical}
-            />
-          </>
-        ))}
-
+        {isUserAllowed &&
+          manifestations.map((manifestation) => (
+            <>
+              <ReservationModal
+                key={`reservation-modal-${manifestation.pid}`}
+                selectedManifestations={[manifestation]}
+                selectedPeriodical={selectedPeriodical}
+                work={work}
+              />
+              <FindOnShelfModal
+                key={`find-on-shelf-modal-${manifestation.pid}`}
+                manifestations={[manifestation]}
+                workTitles={manifestation.titles.main}
+                authors={manifestation.creators}
+                selectedPeriodical={selectedPeriodical}
+                setSelectedPeriodical={setSelectedPeriodical}
+              />
+            </>
+          ))}
         {infomediaIds.length > 0 && (
           <InfomediaModal
             selectedManifestations={selectedManifestations}
             infoMediaId={infomediaIds[0]}
           />
         )}
-
         {hasCorrectAccess("DigitalArticleService", selectedManifestations) && (
           <DigitalModal pid={selectedManifestations[0].pid} workId={wid} />
         )}
-
         {/* Only create a main version of "reservation" & "find on shelf" modal for physical materials with multiple editions.
         Online materials lead to external links, or to same modals as are created for singular editions. */}
-        {isParallelReservation(selectedManifestations) && (
+        {isUserAllowed && isParallelReservation(selectedManifestations) && (
           <>
             <ReservationModal
               selectedManifestations={selectedManifestations}

--- a/src/apps/menu/menu.tsx
+++ b/src/apps/menu/menu.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
 import profileIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/basic/icon-profile.svg";
 import MenuNotLoggedInContent from "./menu-not-logged-in/menu-not-logged-in";
-import { userIsAnonymous } from "../../core/utils/helpers/user";
+import { isAnonymous } from "../../core/utils/helpers/user";
 import MenuLoggedIn from "./menu-logged-in/menu-logged-in";
 
 const Menu: FC = () => {
@@ -41,10 +41,8 @@ const Menu: FC = () => {
       </button>
       {showMenu && (
         <div className="modal-backdrop">
-          {!userIsAnonymous() && (
-            <MenuLoggedIn closePatronMenu={closePatronMenu} />
-          )}
-          {userIsAnonymous() && (
+          {!isAnonymous() && <MenuLoggedIn closePatronMenu={closePatronMenu} />}
+          {isAnonymous() && (
             <MenuNotLoggedInContent closePatronMenu={closePatronMenu} />
           )}
         </div>

--- a/src/components/guarded-app.tsx
+++ b/src/components/guarded-app.tsx
@@ -12,7 +12,7 @@ import {
   getUrlQueryParam,
   removeQueryParametersFromUrl
 } from "../core/utils/helpers/url";
-import { userIsAnonymous } from "../core/utils/helpers/user";
+import { isAnonymous } from "../core/utils/helpers/user";
 import { GuardedAppId } from "../core/utils/types/ids";
 
 export interface GuardedAppProps {
@@ -27,7 +27,7 @@ const GuardedApp = ({ app, children }: GuardedAppProps) => {
   const { request: persistedRequest } = useSelector(
     (state: RootState) => state.guardedRequests
   );
-  const isApplicationBlocked = persistedRequest && !userIsAnonymous();
+  const isApplicationBlocked = persistedRequest && !isAnonymous();
   const didAuthenticate = getUrlQueryParam(AUTH_PARAM);
 
   // We'll leave this debugging here temporarily also in the testing phase for troubleshooting.

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,11 +1,14 @@
 import React from "react";
-import { isEmpty } from "lodash";
 import {
   getAllFaustIds,
   getManifestationType
 } from "../../../../core/utils/helpers/general";
 import { useGetPatronInformationByPatronIdV2 } from "../../../../core/fbs/fbs";
-import { userIsAnonymous } from "../../../../core/utils/helpers/user";
+import {
+  userIsAllowed,
+  userIsAnonymous,
+  userIsBlocked
+} from "../../../../core/utils/helpers/user";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import UseReservableManifestations from "../../../../core/utils/UseReservableManifestations";
@@ -41,14 +44,14 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonCantReserve size={size} />;
   }
 
-  if (!isEmpty(userData?.patron?.blockStatus)) {
+  if (userIsBlocked(userData)) {
     return <MaterialButtonUserBlocked size={size} dataCy={dataCy} />;
   }
 
   // We show the reservation button if the user isn't logged in or isn't blocked.
   // In the former case there there's no way to see if they're blocked, so we
   // redirect anonymous user to the login page.
-  if (!userData || isEmpty(userData?.patron?.blockStatus)) {
+  if (!userData || userIsAllowed(userData)) {
     return (
       <MaterialButtonReservePhysical
         dataCy={dataCy}

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -7,7 +7,7 @@ import { useGetPatronInformationByPatronIdV2 } from "../../../../core/fbs/fbs";
 import {
   userIsAllowed,
   isAnonymous,
-  userIsBlocked
+  isBlocked
 } from "../../../../core/utils/helpers/user";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
@@ -44,7 +44,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonCantReserve size={size} />;
   }
 
-  if (userIsBlocked(userData)) {
+  if (isBlocked(userData)) {
     return <MaterialButtonUserBlocked size={size} dataCy={dataCy} />;
   }
 

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -5,7 +5,7 @@ import {
 } from "../../../../core/utils/helpers/general";
 import { useGetPatronInformationByPatronIdV2 } from "../../../../core/fbs/fbs";
 import {
-  userIsAllowed,
+  canReserve,
   isAnonymous,
   isBlocked
 } from "../../../../core/utils/helpers/user";
@@ -51,7 +51,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   // We show the reservation button if the user isn't logged in or isn't blocked.
   // In the former case there there's no way to see if they're blocked, so we
   // redirect anonymous user to the login page.
-  if (!userData || userIsAllowed(userData)) {
+  if (!userData || canReserve(userData)) {
     return (
       <MaterialButtonReservePhysical
         dataCy={dataCy}

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -6,7 +6,7 @@ import {
 import { useGetPatronInformationByPatronIdV2 } from "../../../../core/fbs/fbs";
 import {
   userIsAllowed,
-  userIsAnonymous,
+  isAnonymous,
   userIsBlocked
 } from "../../../../core/utils/helpers/user";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -33,7 +33,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     manifestations
   });
   const { data: userData, isLoading } = useGetPatronInformationByPatronIdV2({
-    enabled: !userIsAnonymous()
+    enabled: !isAnonymous()
   });
 
   if (isLoading) {

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -35,6 +35,9 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   const { data: userData, isLoading } = useGetPatronInformationByPatronIdV2({
     enabled: !isAnonymous()
   });
+  const patron = userData?.patron;
+  const userCanReserve = patron && canReserve(patron);
+  const userIsBlocked = patron && isBlocked(patron);
 
   if (isLoading) {
     return <MaterialButtonLoading />;
@@ -44,14 +47,15 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonCantReserve size={size} />;
   }
 
-  if (isBlocked(userData)) {
+  if (userIsBlocked) {
     return <MaterialButtonUserBlocked size={size} dataCy={dataCy} />;
   }
 
   // We show the reservation button if the user isn't logged in or isn't blocked.
   // In the former case there there's no way to see if they're blocked, so we
   // redirect anonymous user to the login page.
-  if (!userData || canReserve(userData)) {
+
+  if (!userData || userCanReserve) {
     return (
       <MaterialButtonReservePhysical
         dataCy={dataCy}

--- a/src/core/guardedRequests.slice.ts
+++ b/src/core/guardedRequests.slice.ts
@@ -14,7 +14,7 @@ import {
   turnUrlStringsIntoObjects
 } from "./utils/helpers/url";
 import { GuardedAppId } from "./utils/types/ids";
-import { userIsAnonymous } from "./utils/helpers/user";
+import { isAnonymous } from "./utils/helpers/user";
 
 export const AUTH_PARAM = "didAuthenticate";
 
@@ -93,7 +93,7 @@ export const guardedRequest = createAsyncThunk(
     }
 
     // User is anonymous and the requests is known.
-    if (userIsAnonymous()) {
+    if (isAnonymous()) {
       // So we'll store the request for later execution.
       dispatch(addRequest(requestItem));
 

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -1,6 +1,23 @@
+import { isEmpty } from "lodash";
+import { AuthenticatedPatronV6 } from "../../fbs/model";
 import { hasToken } from "../../token";
 
 export const userIsAnonymous = () => {
   return !hasToken("user");
 };
+
+export const userIsBlocked = (
+  userData: AuthenticatedPatronV6 | null | undefined
+) => {
+  if (!userData) return false;
+  return !isEmpty(userData.patron?.blockStatus);
+};
+
+export const userIsAllowed = (
+  userData: AuthenticatedPatronV6 | null | undefined
+) => {
+  if (!userData) return false;
+  return isEmpty(userData.patron?.blockStatus);
+};
+
 export default {};

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -1,23 +1,17 @@
 import { isEmpty } from "lodash";
-import { AuthenticatedPatronV6 } from "../../fbs/model";
+import { Patron } from "../types/entities";
 import { hasToken } from "../../token";
 
 export const isAnonymous = () => {
   return !hasToken("user");
 };
 
-export const isBlocked = (
-  userData: AuthenticatedPatronV6 | null | undefined
-) => {
-  if (!userData) return false;
-  return !isEmpty(userData.patron?.blockStatus);
+export const isBlocked = (patron: Patron) => {
+  return !isEmpty(patron.blockStatus);
 };
 
-export const canReserve = (
-  userData: AuthenticatedPatronV6 | null | undefined
-) => {
-  if (!userData) return false;
-  return isEmpty(userData.patron?.blockStatus);
+export const canReserve = (patron: Patron) => {
+  return isEmpty(patron.blockStatus);
 };
 
 export default {};

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -2,7 +2,7 @@ import { isEmpty } from "lodash";
 import { AuthenticatedPatronV6 } from "../../fbs/model";
 import { hasToken } from "../../token";
 
-export const userIsAnonymous = () => {
+export const isAnonymous = () => {
   return !hasToken("user");
 };
 

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -6,7 +6,7 @@ export const isAnonymous = () => {
   return !hasToken("user");
 };
 
-export const userIsBlocked = (
+export const isBlocked = (
   userData: AuthenticatedPatronV6 | null | undefined
 ) => {
   if (!userData) return false;

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -13,7 +13,7 @@ export const isBlocked = (
   return !isEmpty(userData.patron?.blockStatus);
 };
 
-export const userIsAllowed = (
+export const canReserve = (
   userData: AuthenticatedPatronV6 | null | undefined
 ) => {
   if (!userData) return false;

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -4,7 +4,7 @@ import CloseIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icon
 import clsx from "clsx";
 import FocusTrap from "focus-trap-react";
 import { closeModal, openModal } from "../modal.slice";
-import { userIsAnonymous } from "./helpers/user";
+import { isAnonymous } from "./helpers/user";
 import {
   currentLocationWithParametersUrl,
   redirectToLoginAndBack
@@ -147,7 +147,7 @@ export const useModalButtonHandler = () => {
     }: GuardedOpenModalProps) => {
       // Redirect anonymous users to the login platform, including a return link
       // to this page with an open modal.
-      if (userIsAnonymous()) {
+      if (isAnonymous()) {
         const returnUrl = currentLocationWithParametersUrl({
           modal: modalId
         });

--- a/src/core/utils/types/entities.ts
+++ b/src/core/utils/types/entities.ts
@@ -4,6 +4,7 @@ import {
   Relations,
   WorkMediumFragment
 } from "../../dbc-gateway/generated/graphql";
+import { PatronV5 } from "../../fbs/model";
 import { Pid, WorkId } from "./ids";
 
 export type Manifestation = Omit<ManifestationsSimpleFieldsFragment, "pid"> & {
@@ -39,3 +40,5 @@ export type Work = Omit<
     hasAdaptation: Relations["hasAdaptation"];
   };
 };
+
+export type Patron = PatronV5;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-492

#### This pull request addresses the issue of the `ReservationModal` being opened for blocked users. 

Previously, when a user who was not logged in clicked on the Reserve button, they were sent to the login platform and then redirected back to the page with a URL containing `&modal=reservation-modal-********`. This opened the modal, even if the user was blocked.

To resolve this issue, I have implemented the following changes:

- Added a check for `isUserAllowed` before rendering the `ReservationModal` and `FindOnShelfModal`.
- Introduced `userIsBlocked` and `userIsAllowed` variables to improve code readability and maintainability.

These changes ensure that the `ReservationModal` is not opened for blocked users.

#### Screenshot of the result
**Blocked user:**

https://user-images.githubusercontent.com/49920322/233066134-ef5c558a-c76b-4f44-9f86-78c10b6730b6.mov

**user:**

https://user-images.githubusercontent.com/49920322/233066263-f1ee63cf-cb6d-4236-8b13-13814c936cca.mov

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions