### PR TITLE
Add 'hostPublication' to  `ReviewMetadata` + Refactor `metaDataText`

### DIFF
--- a/src/components/material/ReviewExternal.tsx
+++ b/src/components/material/ReviewExternal.tsx
@@ -4,6 +4,7 @@ import ReviewMetadata from "./ReviewMetadata";
 import ReviewHearts from "./ReviewHearts";
 import {
   getAuthorNames,
+  getPublicationName,
   getReviewRelease
 } from "../../core/utils/helpers/general";
 import { ReviewManifestation } from "../../core/utils/types/entities";
@@ -15,11 +16,20 @@ export interface ReviewExternalProps {
 }
 
 const ReviewExternal: React.FC<ReviewExternalProps> = ({
-  review: { workYear, dateFirstEdition, creators, review, access, edition },
+  review: {
+    workYear,
+    dateFirstEdition,
+    creators,
+    review,
+    access,
+    edition,
+    hostPublication
+  },
   dataCy = "review-external"
 }) => {
   const date = getReviewRelease(dateFirstEdition, workYear, edition);
   const authors = getAuthorNames(creators);
+  const publication = getPublicationName(hostPublication);
   // This value needs to be casted, because TS for some reason doesn't accept that we filter the access
   const accessUrls = access.filter(
     (accessItem) => accessItem.__typename === "AccessUrl"
@@ -27,7 +37,13 @@ const ReviewExternal: React.FC<ReviewExternalProps> = ({
 
   return (
     <li className="review text-small-caption" data-cy={dataCy}>
-      {(authors || date) && <ReviewMetadata author={authors} date={date} />}
+      {(authors || date || publication) && (
+        <ReviewMetadata
+          author={authors}
+          date={date}
+          publication={publication}
+        />
+      )}
       {review?.rating && <ReviewHearts amountOfHearts={review.rating} />}
       {accessUrls &&
         accessUrls.map(({ url, origin }, index) => {

--- a/src/components/material/ReviewInfomedia.tsx
+++ b/src/components/material/ReviewInfomedia.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../core/dbc-gateway/generated/graphql";
 import {
   getAuthorNames,
+  getPublicationName,
   getReviewRelease
 } from "../../core/utils/helpers/general";
 import {
@@ -27,11 +28,20 @@ export interface ReviewInfomediaProps {
 }
 
 const ReviewInfomedia: React.FC<ReviewInfomediaProps> = ({
-  review: { workYear, dateFirstEdition, access, creators, review, edition },
+  review: {
+    workYear,
+    dateFirstEdition,
+    access,
+    creators,
+    review,
+    edition,
+    hostPublication
+  },
   dataCy = "review-infomedia"
 }) => {
   const date = getReviewRelease(dateFirstEdition, workYear, edition);
   const authors = getAuthorNames(creators);
+  const publication = getPublicationName(hostPublication);
   const infomediaAccess = access.filter(
     (accessItem) => accessItem.__typename === "InfomediaService"
   ) as Pick<InfomediaService, "id">[];
@@ -62,7 +72,13 @@ const ReviewInfomedia: React.FC<ReviewInfomediaProps> = ({
   if (infomedia.error) {
     return (
       <li className="review text-small-caption" data-cy={dataCy}>
-        {(authors || date) && <ReviewMetadata author={authors} date={date} />}
+        {(authors || date || publication) && (
+          <ReviewMetadata
+            author={authors}
+            date={date}
+            publication={publication}
+          />
+        )}
         {review?.rating && <ReviewHearts amountOfHearts={review.rating} />}
         <div className="review__headline mb-8">
           {infomedia.error === "BORROWER_NOT_LOGGED_IN" ? (
@@ -91,7 +107,13 @@ const ReviewInfomedia: React.FC<ReviewInfomediaProps> = ({
 
   return (
     <li className="review text-small-caption" id={infomediaId}>
-      {(authors || date) && <ReviewMetadata author={authors} date={date} />}
+      {(authors || date || publication) && (
+        <ReviewMetadata
+          author={authors}
+          date={date}
+          publication={publication}
+        />
+      )}
       {review?.rating && <ReviewHearts amountOfHearts={review.rating} />}
       {infomedia.article?.headLine && (
         <h3 className="review__headline mb-8">{infomedia.article.headLine}</h3>

--- a/src/components/material/ReviewLibrarian.tsx
+++ b/src/components/material/ReviewLibrarian.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   getAuthorNames,
+  getPublicationName,
   getReviewRelease
 } from "../../core/utils/helpers/general";
 import { ReviewManifestation } from "../../core/utils/types/entities";
@@ -12,15 +13,29 @@ export interface ReviewLibrarianProps {
 }
 
 const ReviewLibrarian: React.FC<ReviewLibrarianProps> = ({
-  review: { workYear, dateFirstEdition, creators, review, edition },
+  review: {
+    workYear,
+    dateFirstEdition,
+    creators,
+    review,
+    edition,
+    hostPublication
+  },
   dataCy = "review-librarian"
 }) => {
   const date = getReviewRelease(dateFirstEdition, workYear, edition);
   const authors = getAuthorNames(creators);
+  const publication = getPublicationName(hostPublication);
 
   return (
     <li className="review text-small-caption" data-cy={dataCy}>
-      {(authors || date) && <ReviewMetadata author={authors} date={date} />}
+      {(authors || date || publication) && (
+        <ReviewMetadata
+          author={authors}
+          date={date}
+          publication={publication}
+        />
+      )}
       {review?.reviewByLibrarians &&
         review.reviewByLibrarians.map((librarianReview) => {
           return (

--- a/src/components/material/ReviewMetadata.tsx
+++ b/src/components/material/ReviewMetadata.tsx
@@ -6,6 +6,7 @@ import LinkNoStyle from "../atoms/links/LinkNoStyle";
 export interface ReviewMetadataProps {
   author?: string | null;
   date?: string | null;
+  publication?: string | null;
   url?: URL;
 }
 
@@ -17,26 +18,37 @@ export const usDateStringToDateObj = (date: string): Date => {
 const ReviewMetadata: React.FC<ReviewMetadataProps> = ({
   author,
   date,
+  publication,
   url
 }) => {
   const metaDataText = (
     returnAuthor: string | null | undefined,
+    returnHost: string | null | undefined,
     returnDate: string | null | undefined
   ) => {
-    return `${returnAuthor || ""}${returnAuthor && returnDate ? ", " : ""}${
-      returnDate || ""
-    }`;
+    const authorText = returnAuthor || "";
+    const hostText = returnHost || "";
+    const authorAndHostSeparator = authorText && hostText ? " - " : "";
+    const dateText = returnDate && `, ${returnDate}`;
+
+    return `
+    ${authorText}${authorAndHostSeparator}${hostText}${dateText}
+    `;
   };
 
   if (url) {
     return (
       <LinkNoStyle url={url} className="link-tag text-small-caption mb-8">
-        {metaDataText(author, date)}
+        {metaDataText(author, publication, date)}
       </LinkNoStyle>
     );
   }
 
-  return <div className="review__meta mb-8">{metaDataText(author, date)}</div>;
+  return (
+    <div className="review__meta mb-8">
+      {metaDataText(author, publication, date)}
+    </div>
+  );
 };
 
 export default ReviewMetadata;

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -418,6 +418,9 @@ export const getAuthorNames = (
 ) => {
   const names = creators.map(({ display }) => display);
   let returnContentString = "";
+  if (names.length === 0) {
+    return returnContentString;
+  }
   if (names.length === 1) {
     returnContentString = `${by ? `${by} ` : ""}${names.join(", ")}`;
   } else {
@@ -426,6 +429,14 @@ export const getAuthorNames = (
       .join(", ")} ${and ? `${and} ` : ""}${names.slice(-1)}`;
   }
   return returnContentString;
+};
+export const getPublicationName = (
+  hostPublication: { title: string } | null | undefined
+) => {
+  if (!hostPublication) {
+    return "";
+  }
+  return hostPublication.title;
 };
 
 export const getReviewRelease = (


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-500

#### This pull request resolves the issue of the missing 'hostPublication' in the Reviews author line by introducing the necessary changes.


- Implement a `getPublicationName` function that retrieves the 'hostPublication' and returns the host title.
- Add the 'publication' obtained from `getPublicationName` to `ReviewMetadata`.
- Update the existing `metaDataText` handling logic to include the 'publication', ensuring correct display and formatting of the author line in Reviews.


#### Screenshot of the result
![Skærmbillede 2023-04-20 kl  14 25 07 (3)](https://user-images.githubusercontent.com/49920322/233365186-a4abb395-6eb3-4148-a5a7-c2cc0ce43e0b.png)



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions


