### PR TITLE
Use 'workYear' from 'work' instead of manifestation in `MaterialDetailsList`

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -135,12 +135,8 @@ export const getManifestationLanguageIsoCode = (
   return undefined;
 };
 
-export const getManifestationFirstEditionYear = (
-  manifestation: Manifestation
-) => {
-  return manifestation.workYear?.year
-    ? String(manifestation.workYear.year)
-    : "";
+export const getWorkFirstEditionYear = (work: Work) => {
+  return work.workYear?.year ? String(work.workYear.year) : "";
 };
 
 export const getManifestationOriginalTitle = (manifestation: Manifestation) => {
@@ -164,6 +160,7 @@ export const getDetailsListData = ({
   work: Work;
   t: UseTextFunction;
 }): ListData => {
+  const workFirstEditionYear = getWorkFirstEditionYear(work);
   const fallBackManifestation = getWorkManifestation(
     work,
     "bestRepresentation"
@@ -209,10 +206,7 @@ export const getDetailsListData = ({
     },
     {
       label: t("detailsListFirstEditionYearText"),
-      value:
-        getManifestationFirstEditionYear(
-          manifestation ?? fallBackManifestation
-        ) ?? t("detailsListFirstEditionYearUnknownText"),
+      value: workFirstEditionYear,
       type: "standard"
     },
     {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-496

#### Description
This PR fixes the issue of missing the first edition year, which was caused by using 'workYear' on the selected / 'bestRepresentation' manifestation level where it was only provided on some of the manifestations. 

The following changes have been made to address this issue:

- Refactor `getManifestationFirstEditionYear` to `getWorkFirstEditionYear` as we should now use 'workYear' on the work level, rather than the manifestation level.
- Update the details list to display the first edition year using `getWorkFirstEditionYear` 

#### Screenshot of the result
![Skærmbillede 2023-04-21 kl  15 14 11 (3)](https://user-images.githubusercontent.com/49920322/233645062-289ffc7d-06a5-46f7-ae1c-8c07e566b76e.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions