### PR TITLE
Add all authors in `MaterialManifestationItem` details

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -3,7 +3,8 @@ import {
   constructModalId,
   getMaterialTypes,
   getManifestationType,
-  orderManifestationsByYear
+  orderManifestationsByYear,
+  flattenCreators
 } from "../../core/utils/helpers/general";
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
@@ -153,6 +154,10 @@ export const getManifestationContributors = (manifestation: Manifestation) => {
       .map((contributor) => contributor.display)
       .join(" / ") ?? ""
   );
+};
+
+export const getManifestationAuthors = (manifestation: Manifestation) => {
+  return flattenCreators(manifestation.creators).join(", ") ?? "";
 };
 
 export const getDetailsListData = ({

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -216,6 +216,11 @@ export default {
       defaultValue: "Edition",
       control: { type: "text" }
     },
+    detailsListAuthorsText: {
+      name: "Authors",
+      defaultValue: "Authors",
+      control: { type: "text" }
+    },
     editionText: {
       name: "Edition",
       defaultValue: "Edition",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -27,6 +27,7 @@ interface MaterialEntryTextProps {
   daysText: string;
   descriptionHeadlineText: string;
   detailsListAudienceText: string;
+  detailsListAuthorsText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;
   detailsListFirstEditionYearText: string;

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -15,6 +15,7 @@ import { Manifestation } from "../../core/utils/types/entities";
 import { WorkId } from "../../core/utils/types/ids";
 import {
   getManifestationAudience,
+  getManifestationAuthors,
   getManifestationContributors,
   getManifestationEdition,
   getManifestationGenreAndForm,
@@ -96,6 +97,11 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     {
       label: t("detailsListAudienceText"),
       value: getManifestationAudience(manifestation),
+      type: "standard"
+    },
+    {
+      label: t("detailsListAuthorsText"),
+      value: getManifestationAuthors(manifestation),
       type: "standard"
     }
   ];


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-515

#### Description

This pull request adds the ability to display all authors in the `MaterialManifestationItem` details by introducing the `getManifestationAuthors` function. This improvement addresses the limitation of the `creatorsToString` function, which only displays the first two authors in the sub-headline.

#### Screenshot of the result
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/49920322/234246150-f20436c1-9fc4-48d1-afe1-4bb1a921c238.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions