### PR TITLE
Fix/autosuggest structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/apps/search-header/search-header.test.ts
+++ b/src/apps/search-header/search-header.test.ts
@@ -30,49 +30,51 @@ describe("Search header app", () => {
   });
 
   it("Allows user to write into the search field", () => {
-    cy.get(".header__menu-search-input")
-      .should("be.visible")
-      .focus()
-      .type("ad");
+    cy.getBySel("search-header-input").should("be.visible").focus().type("ad");
   });
 
   it("Doesn't show suggestions before 3 characters are typed", () => {
-    cy.get(".header__menu-search-input").focus().type("ha");
-    cy.get(".autosuggest").should("not.be.visible");
-    cy.get(".header__menu-search-input").focus().type("r");
-    cy.get(".autosuggest").should("be.visible");
+    cy.getBySel("search-header-input").focus().type("ha");
+    cy.getBySel("autosuggest").should("not.be.visible");
+    cy.getBySel("search-header-input").focus().type("r");
+    cy.getBySel("autosuggest").should("be.visible");
   });
 
   it("Allows use of arrow keys to navigate autosuggest", () => {
-    cy.get(".header__menu-search-input").focus().type("harry");
-    cy.get(".autosuggest").should("contain.text", "Harry");
-    cy.get(".header__menu-search-input").focus().type("{downArrow}");
-    cy.get("#downshift-0-item-0").should("have.attr", "aria-selected", "true");
+    cy.getBySel("search-header-input").focus().type("harry");
+    cy.getBySel("autosuggest").should("contain.text", "Harry");
+    cy.getBySel("search-header-input").focus().type("{downArrow}");
+    cy.getBySel("autosuggest-text-item")
+      .first()
+      .should("have.attr", "aria-selected", "true");
   });
 
   it("Matches text in the search field with highlighted item", () => {
-    cy.get(".header__menu-search-input").focus().type("har");
-    cy.get(".autosuggest").should("contain.text", "Harry");
-    cy.get(".header__menu-search-input")
+    cy.getBySel("search-header-input").focus().type("har");
+    cy.getBySel("autosuggest").should("contain.text", "Harry");
+    cy.getBySel("search-header-input")
       .focus()
       .type("{downArrow}")
       .should("have.attr", "value", "Harry Potter");
   });
 
   it("Shows both parts of the autosuggest", () => {
-    cy.get(".header__menu-search-input").focus().type("har");
-    cy.get(".autosuggest").should("contain.text", "Harry");
+    cy.getBySel("search-header-input").focus().type("har");
+    cy.getBySel("autosuggest").should("contain.text", "Harry");
     cy.contains("Harry Potter (topic)");
     cy.contains("Harry Potter og de vises sten");
   });
 
   it("Shows cover pictures for the material suggestions", () => {
-    cy.get(".header__menu-search-input").focus().type("har");
-    cy.get(".autosuggest__material__content > .cover > .cover__img").should(
-      "have.attr",
-      "src",
-      "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_small/v1543886150/bogportalen.dk/9788702029444.jpg"
-    );
+    cy.getBySel("search-header-input").focus().type("har");
+    cy.getBySel("autosuggest-material-item")
+      .first()
+      .find("img")
+      .should(
+        "have.attr",
+        "src",
+        "https://res.cloudinary.com/dandigbib/image/upload/t_ddb_cover_small/v1543886150/bogportalen.dk/9788702029444.jpg"
+      );
   });
 });
 

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -25,35 +25,35 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
 }) => {
   const t = useText();
   return (
-    <li>
-      <ul>
-        {/* eslint-disable react/jsx-props-no-spreading */}
-        {/* The downshift combobox works this way by design (line 43) */}
-        {categoryData.map((item, incorrectIndex) => {
-          // incorrectIndex because in the whole of autosuggest dropdown it is
-          // not the correct index for the item. We first need to add the length of
-          // items from autosuggest string suggestion to it for it to be accurate (=> index)
-          const index = incorrectIndex + textAndMaterialDataLength;
-          return (
-            <li
-              className={`autosuggest__text text-body-medium-regular px-24 ${clsx(
-                {
-                  "autosuggest__text--highlight": highlightedIndex === index
-                }
-              )}`}
-              key={item}
-              {...getItemProps({ item, index })}
-              data-cy={dataCy}
-            >
+    <>
+      {/* eslint-disable react/jsx-props-no-spreading */}
+      {/* The downshift combobox works this way by design (line 43) */}
+      {categoryData.map((item, incorrectIndex) => {
+        // incorrectIndex because in the whole of autosuggest dropdown it is
+        // not the correct index for the item. We first need to add the length of
+        // items from autosuggest string suggestion to it for it to be accurate (=> index)
+        const index = incorrectIndex + textAndMaterialDataLength;
+        return (
+          <li
+            className={`autosuggest__text-item text-body-medium-regular px-24 ${clsx(
+              {
+                "autosuggest__text-item--highlight": highlightedIndex === index
+              }
+            )}`}
+            key={item}
+            {...getItemProps({ item, index })}
+            data-cy={dataCy}
+          >
+            <p className="autosuggest__text text-body-medium-regular">
               {`${item.term} ${t("inText")}`}
-              <div className="boxed-text text-tags noselect ml-8">
-                {autosuggestCategoryList[incorrectIndex].render}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </li>
+            </p>
+            <div className="boxed-text text-tags noselect ml-8">
+              {autosuggestCategoryList[incorrectIndex].render}
+            </div>
+          </li>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -35,11 +35,12 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
         const index = incorrectIndex + textAndMaterialDataLength;
         return (
           <li
-            className={`autosuggest__text-item text-body-medium-regular px-24 ${clsx(
+            className={clsx(
+              "autosuggest__text-item text-body-medium-regular px-24",
               {
                 "autosuggest__text-item--highlight": highlightedIndex === index
               }
-            )}`}
+            )}
             key={item}
             {...getItemProps({ item, index })}
             data-cy={dataCy}

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -27,69 +27,67 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
 }) => {
   const t = useText();
   return (
-    <li>
-      <ul className="autosuggest__materials">
-        {/* eslint-disable react/jsx-props-no-spreading */}
-        {/* The downshift combobox works this way by design (line 54) */}
-        {materialData.map((item, incorrectIndex) => {
-          // incorrectIndex because in the whole of autosuggest dropdown it is
-          // not the correct index for the item. We first need to add the length of
-          // items from autosuggest string suggestion to it for it to be accurate (=> index)
-          const index = incorrectIndex + textDataLength;
-          const { work } = item;
-          if (!work) {
-            return null;
-          }
-          const { creators } = work;
-          const authors = flattenCreators(
-            creators as WorkSmallFragment["creators"]
-          );
+    <>
+      {/* eslint-disable react/jsx-props-no-spreading */}
+      {/* The downshift combobox works this way by design (line 54) */}
+      {materialData.map((item, incorrectIndex) => {
+        // incorrectIndex because in the whole of autosuggest dropdown it is
+        // not the correct index for the item. We first need to add the length of
+        // items from autosuggest string suggestion to it for it to be accurate (=> index)
+        const index = incorrectIndex + textDataLength;
+        const { work } = item;
+        if (!work) {
+          return null;
+        }
+        const { creators } = work;
+        const authors = flattenCreators(
+          creators as WorkSmallFragment["creators"]
+        );
 
-          const manifestationLanguageIsoCode =
-            item.work?.manifestations.bestRepresentation &&
-            getManifestationLanguageIsoCode([
-              item.work.manifestations.bestRepresentation
-            ]);
+        const manifestationLanguageIsoCode =
+          item.work?.manifestations.bestRepresentation &&
+          getManifestationLanguageIsoCode([
+            item.work.manifestations.bestRepresentation
+          ]);
 
-          return (
-            <li
-              className={`autosuggest__material ${
+        return (
+          <li
+            className={`autosuggest__material-item
+              ${
                 highlightedIndex === index
-                  ? "autosuggest__material--highlight"
+                  ? "autosuggest__material-item--highlight"
                   : ""
               }`}
-              key={item.work?.workId}
-              {...getItemProps({ item, index })}
-              data-cy={dataCy}
-            >
-              {/* eslint-enable react/jsx-props-no-spreading */}
-              <div className="autosuggest__material__content">
-                {item.work && (
-                  <Cover
-                    animate
-                    size="xsmall"
-                    id={item.work.manifestations.bestRepresentation.pid}
-                    shadow
-                  />
-                )}
-
-                <div className="autosuggest__info">
-                  <div
-                    lang={manifestationLanguageIsoCode}
-                    className="text-body-medium-medium autosuggest__title"
-                  >
-                    {item.work?.titles.main[0]}
-                  </div>
-                  <div className="text-body-small-regular autosuggest__author">
-                    {creatorsToString(authors, t)}
-                  </div>
+            key={item.work?.workId}
+            {...getItemProps({ item, index })}
+            data-cy={dataCy}
+          >
+            {/* eslint-enable react/jsx-props-no-spreading */}
+            <div className="autosuggest__material-card">
+              {item.work && (
+                <Cover
+                  animate
+                  size="xsmall"
+                  id={item.work.manifestations.bestRepresentation.pid}
+                  shadow
+                />
+              )}
+              <div className="autosuggest__info">
+                <div
+                  lang={manifestationLanguageIsoCode}
+                  className="text-body-medium-medium autosuggest__title"
+                >
+                  {item.work?.titles.main[0]}
+                </div>
+                <div className="text-body-small-regular autosuggest__author">
+                  {creatorsToString(authors, t)}
                 </div>
               </div>
-            </li>
-          );
-        })}
-      </ul>
-    </li>
+            </div>
+          </li>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/autosuggest-text/autosuggest-text-item.tsx
+++ b/src/components/autosuggest-text/autosuggest-text-item.tsx
@@ -42,19 +42,21 @@ const AutosuggestTextItem: React.FC<AutosuggestTextItemProps> = ({
         data-cy={dataCy}
         lang={isoLang}
       >
-        {/* eslint-enable react/jsx-props-no-spreading */}
-        {item.type === SuggestionType.Creator
-          ? `${item.term} (${t("stringSuggestionAuthorText")})`
-          : null}
-        {item.type === SuggestionType.Subject
-          ? `${item.term} (${t("stringSuggestionTopicText")})`
-          : null}
-        {item.type === SuggestionType.Composit
-          ? `${item.work?.titles.main} (${t("stringSuggestionWorkText")})`
-          : null}
-        {item.type === SuggestionType.Title
-          ? `${item.term} (${t("stringSuggestionWorkText")})`
-          : null}
+        <p className="autosuggest__text text-body-medium-regular">
+          {/* eslint-enable react/jsx-props-no-spreading */}
+          {item.type === SuggestionType.Creator
+            ? `${item.term} (${t("stringSuggestionAuthorText")})`
+            : null}
+          {item.type === SuggestionType.Subject
+            ? `${item.term} (${t("stringSuggestionTopicText")})`
+            : null}
+          {item.type === SuggestionType.Composit
+            ? `${item.work?.titles.main} (${t("stringSuggestionWorkText")})`
+            : null}
+          {item.type === SuggestionType.Title
+            ? `${item.term} (${t("stringSuggestionWorkText")})`
+            : null}
+        </p>
       </li>
     </>
   );

--- a/src/components/autosuggest-text/autosuggest-text.tsx
+++ b/src/components/autosuggest-text/autosuggest-text.tsx
@@ -36,11 +36,12 @@ export const AutosuggestText: React.FC<AutosuggestTextProps> = ({
     <>
       {textData.map((item: Suggestion, index: number) => {
         const classes = {
-          textSuggestion: `autosuggest__text-item text-body-medium-regular px-24 ${clsx(
+          textSuggestion: clsx(
+            "autosuggest__text-item text-body-medium-regular px-24",
             {
               "autosuggest__text-item--highlight": highlightedIndex === index
             }
-          )}`
+          )
         };
         return (
           <AutosuggestTextItem

--- a/src/components/autosuggest-text/autosuggest-text.tsx
+++ b/src/components/autosuggest-text/autosuggest-text.tsx
@@ -33,28 +33,26 @@ export const AutosuggestText: React.FC<AutosuggestTextProps> = ({
   getItemProps
 }) => {
   return (
-    <li>
-      <ul>
-        {textData.map((item: Suggestion, index: number) => {
-          const classes = {
-            textSuggestion: `autosuggest__text text-body-medium-regular px-24 ${clsx(
-              {
-                "autosuggest__text--highlight": highlightedIndex === index
-              }
-            )}`
-          };
-          return (
-            <AutosuggestTextItem
-              classes={classes}
-              item={item}
-              index={index}
-              generateItemId={generateItemId}
-              getItemProps={getItemProps}
-            />
-          );
-        })}
-      </ul>
-    </li>
+    <>
+      {textData.map((item: Suggestion, index: number) => {
+        const classes = {
+          textSuggestion: `autosuggest__text-item text-body-medium-regular px-24 ${clsx(
+            {
+              "autosuggest__text-item--highlight": highlightedIndex === index
+            }
+          )}`
+        };
+        return (
+          <AutosuggestTextItem
+            classes={classes}
+            item={item}
+            index={index}
+            generateItemId={generateItemId}
+            getItemProps={getItemProps}
+          />
+        );
+      })}
+    </>
   );
 };
 

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -60,9 +60,6 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
           highlightedIndex={highlightedIndex}
           getItemProps={getItemProps}
         />
-        {textData.length > 0 && materialData.length > 0 && (
-          <li className="autosuggest__divider" />
-        )}
         {materialData.length > 0 && (
           <AutosuggestMaterial
             materialData={materialData}
@@ -72,16 +69,13 @@ export const Autosuggest: React.FC<AutosuggestProps> = ({
           />
         )}
         {categoryData && categoryData.length > 0 && (
-          <>
-            <li className="autosuggest__divider" />
-            <AutosuggestCategory
-              categoryData={categoryData}
-              getItemProps={getItemProps}
-              highlightedIndex={highlightedIndex}
-              textAndMaterialDataLength={textData.length + materialData.length}
-              autosuggestCategoryList={autosuggestCategoryList}
-            />
-          </>
+          <AutosuggestCategory
+            categoryData={categoryData}
+            getItemProps={getItemProps}
+            highlightedIndex={highlightedIndex}
+            textAndMaterialDataLength={textData.length + materialData.length}
+            autosuggestCategoryList={autosuggestCategoryList}
+          />
         )}
       </ul>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,10 +1749,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd":
-  version "0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-ceaa97af483049b119af1293ee40b19a45be72fd/e783ff7e1af15a96a23a5556302ea15c7500ccde#e783ff7e1af15a96a23a5556302ea15c7500ccde"
-  integrity sha512-FsQefHXQ6g4xr4RfnfNNQoXOTWkC8BgryrJsmw7+g3Mq17m1s1FYU8fzpDqTrDRpKBz/eZuzA619EfLXFT1AOQ==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3":
+  version "0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-07e84f4f89cf452bdf7dd3b805e4c3e3cf4117b3/c60fff08a130ddd84b3b8e6452900890bf83e37d#c60fff08a130ddd84b3b8e6452900890bf83e37d"
+  integrity sha512-HRVsOqnKY35DLl71m6gdd1uOLR+DClaBVZI2opC8tjaIJTiNoDtRHEJfMQF+Pdrv6rJwRKBxfn4/hFAJgl0HsQ==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-433

#### Description
Our DOM structure wasn't living up to the accessibility criteria set by https://www.w3.org/TR/wai-aria-1.1/#option & https://www.w3.org/TR/wai-aria-1.1/#listbox . Therefore some structural changes were made in [this PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/208/) in the dpl-design-system (one of our packages we use for styling this repository).
This PR adjusts the DOM structure and classes for our React components to that they match dpl-design-system.
+ we use data-cy seelctors for the searhc header test instead of classes, which can change over time.


#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/234270689-aa101606-98db-4950-8ffc-425b12a71f21.png)
![image](https://user-images.githubusercontent.com/28546954/234270715-8ac4867e-3f10-42ac-a3af-1d538f953c53.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
PS: if you want to run this branch locally, you'll need to run `yarn add @reload/dpl-design-system@fix-autosuggest-structure` and then change `import "@danskernesdigitalebibliotek/dpl-design-system/build/css/base.css";`in preview.js file to `import "@reload/dpl-design-system/build/css/base.css";`.