### PR TITLE
Prevent empty search on 'Enter' press in search input

### DIFF
--- a/src/apps/search-header/search-header.dev.tsx
+++ b/src/apps/search-header/search-header.dev.tsx
@@ -105,6 +105,11 @@ export default {
       name: "Loading",
       defaultValue: "Loading",
       control: { type: "text" }
+    },
+    searchNoValidCharactersErrorText: {
+      name: "Search non-whitespace character error",
+      defaultValue: "Input must contain at least one non-whitespace character.",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof SearchHeaderEntry>;

--- a/src/apps/search-header/search-header.entry.tsx
+++ b/src/apps/search-header/search-header.entry.tsx
@@ -23,6 +23,7 @@ export interface SearchHeaderTextProps {
   autosuggestAnimatedSeriesCategoryText: string;
   inText: string;
   loadingText: string;
+  searchNoValidCharactersErrorText: string;
 }
 
 export interface SearchHeaderEntryProps

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -26,6 +26,9 @@ const SearchBar: React.FC<SearchBarProps> = ({
       </label>
       {/* eslint-disable react/jsx-props-no-spreading */}
       <input
+        required
+        pattern=".*\S+.*"
+        title={t("searchNoValidCharactersErrorText")}
         name="q"
         className="header__menu-search-input text-body-medium-regular"
         data-cy={dataCy}
@@ -41,6 +44,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
       />
       {/* eslint-enable react/jsx-props-no-spreading */}
       <input
+        required
         type="image"
         src={searchIcon}
         alt={t("searchHeaderIconAltText")}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-461

#### Description

This pull request implements a change that prevents users from executing an empty search when pressing the 'Enter' key in the search input field or the search icon is clicked. The update ensures that a search is only triggered when there is a meaningful input value, not just whitespace characters.

#### Screenshot of the result

https://user-images.githubusercontent.com/49920322/234840414-3fb42b6a-e8be-4d26-8793-faa524f477cd.mov

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions