### PR TITLE
Fixing parallel reservation issues with blacklisting 

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -9,7 +9,6 @@ import {
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
 import {
-  AvailabilityV3,
   HoldingsForBibliographicalRecordV3,
   HoldingsV3
 } from "../../core/fbs/model";
@@ -26,7 +25,12 @@ import {
   isArticle
 } from "../../components/material/material-buttons/helper";
 import { UseConfigFunction } from "../../core/utils/config";
-import { getAvailabilityV3, useGetAvailabilityV3 } from "../../core/fbs/fbs";
+import {
+  getAvailabilityV3,
+  getHoldingsV3,
+  useGetAvailabilityV3,
+  useGetHoldingsV3
+} from "../../core/fbs/fbs";
 
 export const getWorkManifestation = (
   work: Work,
@@ -460,3 +464,21 @@ export const getAvailability = async ({
       "blacklistedAvailabilityBranchesConfig"
     )
   );
+
+export const useGetHoldings = ({
+  faustIds,
+  config,
+  options
+}: {
+  faustIds: FaustId[];
+  config: UseConfigFunction;
+  options?: {
+    query?: UseQueryOptions<Awaited<ReturnType<typeof getHoldingsV3>>>;
+  };
+}) => {
+  const { data, isLoading, isError } = useGetHoldingsV3(
+    getBlacklistedArgs(faustIds, config, "blacklistedPickupBranchesConfig"),
+    options
+  );
+  return { data, isLoading, isError };
+};

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -28,7 +28,6 @@ import { UseConfigFunction } from "../../core/utils/config";
 import {
   getAvailabilityV3,
   getHoldingsV3,
-  useGetAvailabilityV3,
   useGetHoldingsV3
 } from "../../core/fbs/fbs";
 
@@ -412,14 +411,16 @@ export const isParallelReservation = (manifestations: Manifestation[]) =>
   !isArticle(manifestations);
 
 // Because we  need to exclude the branches that are blacklisted, we need to use a custom hook to prevent duplicate code
-export const getBlacklistedArgs = (
+export const getBlacklistedQueryArgs = (
   faustIds: FaustId[],
   config: UseConfigFunction,
-  blacklist:
-    | "blacklistedAvailabilityBranchesConfig"
-    | "blacklistedPickupBranchesConfig"
+  blacklist: "availability" | "pickup"
 ) => {
-  const blacklistBranches = config(blacklist, {
+  const configKey =
+    blacklist === "availability"
+      ? "blacklistedAvailabilityBranchesConfig"
+      : "blacklistedPickupBranchesConfig";
+  const blacklistBranches = config(configKey, {
     transformer: "stringToArray"
   });
   return {
@@ -435,13 +436,7 @@ export const getAvailability = async ({
   faustIds: FaustId[];
   config: UseConfigFunction;
 }) =>
-  getAvailabilityV3(
-    getBlacklistedArgs(
-      faustIds,
-      config,
-      "blacklistedAvailabilityBranchesConfig"
-    )
-  );
+  getAvailabilityV3(getBlacklistedQueryArgs(faustIds, config, "availability"));
 
 export const useGetHoldings = ({
   faustIds,
@@ -455,7 +450,7 @@ export const useGetHoldings = ({
   };
 }) => {
   const { data, isLoading, isError } = useGetHoldingsV3(
-    getBlacklistedArgs(faustIds, config, "blacklistedPickupBranchesConfig"),
+    getBlacklistedQueryArgs(faustIds, config, "pickup"),
     options
   );
   return { data, isLoading, isError };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -412,7 +412,7 @@ export const isParallelReservation = (manifestations: Manifestation[]) =>
   !isArticle(manifestations);
 
 // Because we  need to exclude the branches that are blacklisted, we need to use a custom hook to prevent duplicate code
-const getBlacklistedArgs = (
+export const getBlacklistedArgs = (
   faustIds: FaustId[],
   config: UseConfigFunction,
   blacklist:
@@ -426,28 +426,6 @@ const getBlacklistedArgs = (
     recordid: faustIds,
     ...(blacklistBranches ? { exclude: blacklistBranches } : {})
   };
-};
-
-export const useGetAvailability = ({
-  faustIds,
-  config,
-  options
-}: {
-  faustIds: FaustId[];
-  config: UseConfigFunction;
-  options?: {
-    query?: UseQueryOptions<Awaited<ReturnType<typeof getAvailabilityV3>>>;
-  };
-}) => {
-  const { data, isLoading, isError } = useGetAvailabilityV3(
-    getBlacklistedArgs(
-      faustIds,
-      config,
-      "blacklistedAvailabilityBranchesConfig"
-    ),
-    options
-  );
-  return { data, isLoading, isError };
 };
 
 export const getAvailability = async ({

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,4 +1,5 @@
 import { compact, groupBy, uniqBy, uniq, head } from "lodash";
+import { UseQueryOptions } from "react-query";
 import {
   constructModalId,
   getMaterialTypes,
@@ -8,6 +9,7 @@ import {
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import { ListData } from "../../components/material/MaterialDetailsList";
 import {
+  AvailabilityV3,
   HoldingsForBibliographicalRecordV3,
   HoldingsV3
 } from "../../core/fbs/model";
@@ -23,6 +25,8 @@ import {
   hasCorrectAccessType,
   isArticle
 } from "../../components/material/material-buttons/helper";
+import { UseConfigFunction } from "../../core/utils/config";
+import { getAvailabilityV3, useGetAvailabilityV3 } from "../../core/fbs/fbs";
 
 export const getWorkManifestation = (
   work: Work,
@@ -402,3 +406,57 @@ export const isParallelReservation = (manifestations: Manifestation[]) =>
   manifestations.length > 1 &&
   hasCorrectAccessType(AccessTypeCode.Physical, manifestations) &&
   !isArticle(manifestations);
+
+// Because we  need to exclude the branches that are blacklisted, we need to use a custom hook to prevent duplicate code
+const getBlacklistedArgs = (
+  faustIds: FaustId[],
+  config: UseConfigFunction,
+  blacklist:
+    | "blacklistedAvailabilityBranchesConfig"
+    | "blacklistedPickupBranchesConfig"
+) => {
+  const blacklistBranches = config(blacklist, {
+    transformer: "stringToArray"
+  });
+  return {
+    recordid: faustIds,
+    ...(blacklistBranches ? { exclude: blacklistBranches } : {})
+  };
+};
+
+export const useGetAvailability = ({
+  faustIds,
+  config,
+  options
+}: {
+  faustIds: FaustId[];
+  config: UseConfigFunction;
+  options?: {
+    query?: UseQueryOptions<Awaited<ReturnType<typeof getAvailabilityV3>>>;
+  };
+}) => {
+  const { data, isLoading, isError } = useGetAvailabilityV3(
+    getBlacklistedArgs(
+      faustIds,
+      config,
+      "blacklistedAvailabilityBranchesConfig"
+    ),
+    options
+  );
+  return { data, isLoading, isError };
+};
+
+export const getAvailability = async ({
+  faustIds,
+  config
+}: {
+  faustIds: FaustId[];
+  config: UseConfigFunction;
+}) =>
+  getAvailabilityV3(
+    getBlacklistedArgs(
+      faustIds,
+      config,
+      "blacklistedAvailabilityBranchesConfig"
+    )
+  );

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -30,17 +30,20 @@ export default {
     },
     blacklistedPickupBranchesConfig: {
       name: "Blacklisted Pickup branches",
-      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      defaultValue:
+        "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024,DK-775164",
       control: { type: "text" }
     },
     blacklistedAvailabilityBranchesConfig: {
       name: "Blacklisted Availability branches",
-      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      defaultValue:
+        "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024,DK-775164",
       control: { type: "text" }
     },
     blacklistedInstantLoanBranchesConfig: {
       name: "Blacklisted Instant Loan branches",
-      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      defaultValue:
+        "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024,DK-775164",
       control: { type: "text" }
     },
     branchesConfig: {

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -7,13 +7,14 @@ import { statistics } from "../../core/statistics/statistics";
 import { getParentAvailabilityLabelClass, useAvailabilityData } from "./helper";
 import { AccessTypeCode } from "../../core/dbc-gateway/generated/graphql";
 import AvailabilityLabelInside from "./availability-label-inside";
+import { FaustId } from "../../core/utils/types/ids";
 
 export interface AvailabilityLabelProps {
   manifestText: string;
   accessTypes: AccessTypeCode[];
   selected?: boolean;
   url?: URL;
-  faustIds: string[];
+  faustIds: FaustId[];
   handleSelectManifestation?: () => void | undefined;
   cursorPointer?: boolean;
   dataCy?: string;

--- a/src/components/availability-label/helper.ts
+++ b/src/components/availability-label/helper.ts
@@ -3,8 +3,8 @@ import clsx from "clsx";
 import { useGetV1ProductsIdentifier } from "../../core/publizon/publizon";
 import { useConfig } from "../../core/utils/config";
 import { AccessTypeCode } from "../../core/dbc-gateway/generated/graphql";
-import { useGetAvailability } from "../../apps/material/helper";
 import { FaustId } from "../../core/utils/types/ids";
+import useGetAvailability from "../../core/utils/useGetAvailability";
 
 export const useAvailabilityData = ({
   accessTypes,

--- a/src/components/availability-label/helper.ts
+++ b/src/components/availability-label/helper.ts
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import clsx from "clsx";
-import { useGetAvailabilityV3 } from "../../core/fbs/fbs";
 import { useGetV1ProductsIdentifier } from "../../core/publizon/publizon";
 import { useConfig } from "../../core/utils/config";
 import { AccessTypeCode } from "../../core/dbc-gateway/generated/graphql";
+import { useGetAvailability } from "../../apps/material/helper";
+import { FaustId } from "../../core/utils/types/ids";
 
 export const useAvailabilityData = ({
   accessTypes,
@@ -11,22 +12,17 @@ export const useAvailabilityData = ({
   isbn
 }: {
   accessTypes: AccessTypeCode[];
-  faustIds: string[] | null;
+  faustIds: FaustId[] | null;
   isbn: string | null;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
   const config = useConfig();
-  const blacklistBranches = config("blacklistedAvailabilityBranchesConfig", {
-    transformer: "stringToArray"
-  });
   const isOnline = accessTypes?.includes(AccessTypeCode.Online) ?? false;
 
-  useGetAvailabilityV3(
-    {
-      recordid: faustIds ?? [],
-      ...(blacklistBranches ? { exclude: blacklistBranches } : {})
-    },
-    {
+  useGetAvailability({
+    faustIds: faustIds ?? [],
+    config,
+    options: {
       query: {
         // FBS / useGetAvailabilityV3 is responsible for handling availability
         // for physical items. This will be the majority of all materials so we
@@ -39,7 +35,7 @@ export const useAvailabilityData = ({
         }
       }
     }
-  );
+  });
 
   useGetV1ProductsIdentifier(isbn ?? "", {
     query: {

--- a/src/components/find-on-shelf/FindOnShelfModal.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModal.tsx
@@ -3,9 +3,9 @@ import { FC } from "react";
 import { partition } from "lodash";
 import {
   isAnyManifestationAvailableOnBranch,
-  totalBranchesHaveMaterial
+  totalBranchesHaveMaterial,
+  useGetHoldings
 } from "../../apps/material/helper";
-import { useGetHoldingsV3 } from "../../core/fbs/fbs";
 import {
   constructModalId,
   convertPostIdToFaustId,
@@ -46,17 +46,14 @@ const FindOnShelfModal: FC<FindOnShelfModalProps> = ({
   setSelectedPeriodical
 }) => {
   const config = useConfig();
-  const blacklistBranches = config("blacklistedPickupBranchesConfig", {
-    transformer: "stringToArray"
-  });
   const t = useText();
   const pidArray = getManifestationsPids(manifestations);
   const faustIdArray = pidArray.map((manifestationPid) =>
     convertPostIdToFaustId(manifestationPid)
   );
-  const { data, isLoading } = useGetHoldingsV3({
-    recordid: faustIdArray,
-    ...(blacklistBranches ? { exclude: blacklistBranches } : {})
+  const { data, isLoading } = useGetHoldings({
+    faustIds: faustIdArray,
+    config
   });
   const author = creatorsToString(flattenCreators(authors), t);
   const title = workTitles.join(", ");

--- a/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
+++ b/src/components/material/MaterialAvailabilityText/physical/MaterialAvailabilityTextPhysical.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import {
   getTotalHoldings,
-  getTotalReservations
+  getTotalReservations,
+  useGetHoldings
 } from "../../../../apps/material/helper";
-import { useGetHoldingsV3 } from "../../../../core/fbs/fbs";
 import { convertPostIdsToFaustIds } from "../../../../core/utils/helpers/general";
 import { Pid } from "../../../../core/utils/types/ids";
 import StockAndReservationInfo from "../../StockAndReservationInfo";
 import MaterialAvailabilityTextParagraph from "../generic/MaterialAvailabilityTextParagraph";
+import { useConfig } from "../../../../core/utils/config";
 
 interface MaterialAvailabilityTextPhysicalProps {
   pids: Pid[];
@@ -16,9 +17,11 @@ interface MaterialAvailabilityTextPhysicalProps {
 const MaterialAvailabilityTextPhysical: React.FC<
   MaterialAvailabilityTextPhysicalProps
 > = ({ pids }) => {
+  const config = useConfig();
   const faustIds = convertPostIdsToFaustIds(pids);
-  const { data, isLoading, isError } = useGetHoldingsV3({
-    recordid: faustIds
+  const { data, isLoading, isError } = useGetHoldings({
+    faustIds,
+    config
   });
 
   if (isLoading || isError || !data) return null;

--- a/src/components/material/periodical/MaterialPeriodical.tsx
+++ b/src/components/material/periodical/MaterialPeriodical.tsx
@@ -1,11 +1,11 @@
 import { isEmpty } from "lodash";
 import React, { FC } from "react";
-import { useGetHoldingsV3 } from "../../../core/fbs/fbs";
 import { useConfig } from "../../../core/utils/config";
 import { groupObjectArrayByProperty } from "../../../core/utils/helpers/general";
 import { FaustId } from "../../../core/utils/types/ids";
 import { GroupList, PeriodicalEdition } from "./helper";
 import MaterialPeriodicalSelect from "./MaterialPeriodicalSelect";
+import { useGetHoldings } from "../../../apps/material/helper";
 
 export interface MaterialPeriodicalProps {
   faustId: FaustId;
@@ -19,12 +19,10 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   selectPeriodicalHandler
 }) => {
   const config = useConfig();
-  const blacklistBranches = config("blacklistedPickupBranchesConfig", {
-    transformer: "stringToArray"
-  });
-  const { data, isLoading, isError } = useGetHoldingsV3({
-    recordid: [String(faustId)],
-    ...(blacklistBranches ? { exclude: blacklistBranches } : {})
+
+  const { data, isLoading, isError } = useGetHoldings({
+    faustIds: [faustId],
+    config
   });
 
   if (isLoading || isError || !data) return null;

--- a/src/components/reservation/ReservationError.tsx
+++ b/src/components/reservation/ReservationError.tsx
@@ -1,43 +1,45 @@
 import FocusTrap from "focus-trap-react";
 import React from "react";
-import { ReservationResponseV2 } from "../../core/fbs/model";
+import {
+  ReservationResponseV2,
+  ReservationResultV2
+} from "../../core/fbs/model";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
 
 type ReservationErrorProps = {
-  reservationResult: string;
+  reservationResults: ReservationResultV2[];
   setReservationResponse: (
     reservationResponse: ReservationResponseV2 | null
   ) => void;
 };
 
 const ReservationError: React.FC<ReservationErrorProps> = ({
-  reservationResult,
+  reservationResults,
   setReservationResponse
 }) => {
   const t = useText();
 
-  const handleErrorText: {
-    [key: string]: {
-      title: string;
-      description: string;
-      buttonText: string;
-    };
-  } = {
-    already_reserved: {
-      title: t("alreadyReservedText"),
-      description: "",
-      buttonText: t("closeText")
-    },
-    default: {
+  const handleErrorText = (reservationResultArray: ReservationResultV2[]) => {
+    const hasAlreadyReserved = reservationResultArray.some(
+      ({ result }) => result === "already_reserved"
+    );
+
+    if (hasAlreadyReserved) {
+      return {
+        title: t("alreadyReservedText"),
+        description: "",
+        buttonText: t("closeText")
+      };
+    }
+    return {
       title: t("reservationErrorsTitleText"),
       description: t("reservationErrorsDescriptionText"),
       buttonText: t("tryAginButtonText")
-    }
-  } as const;
+    };
+  };
 
-  const reservationErrorInfo =
-    handleErrorText[reservationResult] || handleErrorText.default;
+  const reservationErrorInfo = handleErrorText(reservationResults);
 
   return (
     <FocusTrap

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -24,12 +24,12 @@ import ReservationError from "./ReservationError";
 import {
   getTotalHoldings,
   getTotalReservations,
-  reservationModalId
+  reservationModalId,
+  useGetHoldings
 } from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
   useAddReservationsV2,
-  useGetHoldingsV3,
   useGetPatronInformationByPatronIdV2
 } from "../../core/fbs/fbs";
 import { Manifestation, Work } from "../../core/utils/types/entities";
@@ -101,9 +101,7 @@ export const ReservationModalBody = ({
   const faustIds = convertPostIdsToFaustIds(allPids);
   const { mutate } = useAddReservationsV2();
   const userResponse = useGetPatronInformationByPatronIdV2();
-  const holdingsResponse = useGetHoldingsV3({
-    recordid: faustIds
-  });
+  const holdingsResponse = useGetHoldings({ faustIds, config });
   const { track } = useStatistics();
   const { otherManifestationPreferred } = useAlternativeAvailableManifestation(
     work,

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -160,7 +160,7 @@ export const ReservationModalBody = ({
   };
 
   const reservationSuccess = reservationResponse?.success || false;
-  const reservationResult = reservationResponse?.reservationResults[0]?.result;
+  const reservationResults = reservationResponse?.reservationResults;
   const reservationDetails =
     reservationResponse?.reservationResults[0]?.reservationDetails;
   const manifestation =
@@ -184,7 +184,7 @@ export const ReservationModalBody = ({
 
   return (
     <>
-      {!reservationResult && (
+      {!reservationResults && (
         <section className="reservation-modal">
           <header className="reservation-modal-header">
             <Cover id={manifestation.pid} size="medium" animate />
@@ -279,9 +279,9 @@ export const ReservationModalBody = ({
           numberInQueue={reservationDetails.numberInQueue}
         />
       )}
-      {!reservationSuccess && reservationResult && (
+      {!reservationSuccess && reservationResults && (
         <ReservationError
-          reservationResult={reservationResult}
+          reservationResults={reservationResults}
           setReservationResponse={setReservationResponse}
         />
       )}

--- a/src/components/reservation/useAlternativeAvailableManifestation.ts
+++ b/src/components/reservation/useAlternativeAvailableManifestation.ts
@@ -4,10 +4,11 @@ import {
   getAllFaustIds,
   convertPostIdToFaustId
 } from "../../core/utils/helpers/general";
-import { useGetAvailabilityV3 } from "../../core/fbs/fbs";
 import { AvailabilityV3 } from "../../core/fbs/model";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import { Pid } from "../../core/utils/types/ids";
+import { useConfig } from "../../core/utils/config";
+import { useGetAvailability } from "../../apps/material/helper";
 
 type ManifestationWithAvailability = Manifestation & AvailabilityV3;
 
@@ -15,15 +16,16 @@ const useAlternativeAvailableManifestation = (
   work: Work,
   currentManifestationPids: Pid[]
 ) => {
+  const config = useConfig();
   const [isOtherManifestationPreferred, setIsOtherManifestationPreferred] =
     useState(false);
   const [otherManifestationPreferred, setOtherManifestationPreferred] =
     useState<ManifestationWithAvailability | null>(null);
 
   const faustIds = getAllFaustIds(work.manifestations.all);
-
-  const { data: availabilityData } = useGetAvailabilityV3({
-    recordid: faustIds
+  const { data: availabilityData } = useGetAvailability({
+    faustIds,
+    config
   });
 
   useDeepCompareEffect(() => {

--- a/src/components/reservation/useAlternativeAvailableManifestation.ts
+++ b/src/components/reservation/useAlternativeAvailableManifestation.ts
@@ -8,7 +8,7 @@ import { AvailabilityV3 } from "../../core/fbs/model";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import { Pid } from "../../core/utils/types/ids";
 import { useConfig } from "../../core/utils/config";
-import { useGetAvailability } from "../../apps/material/helper";
+import useGetAvailability from "../../core/utils/useGetAvailability";
 
 type ManifestationWithAvailability = Manifestation & AvailabilityV3;
 

--- a/src/core/utils/UseReservableManifestations.tsx
+++ b/src/core/utils/UseReservableManifestations.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
-import { filterManifestationsByType } from "../../apps/material/helper";
-import { getAvailabilityV3 } from "../fbs/fbs";
+import {
+  getAvailability,
+  filterManifestationsByType
+} from "../../apps/material/helper";
 import { convertPostIdToFaustId, getAllFaustIds } from "./helpers/general";
 import { Manifestation } from "./types/entities";
 import { useConfig } from "./config";
@@ -13,10 +15,6 @@ const UseReservableManifestations = ({
   type?: string;
 }) => {
   const config = useConfig();
-  const blacklistBranches = config("blacklistedAvailabilityBranchesConfig", {
-    transformer: "stringToArray"
-  });
-
   const faustIds = getAllFaustIds(manifestations);
 
   const [reservableManifestations, setReservableManifestations] = useState<
@@ -37,10 +35,8 @@ const UseReservableManifestations = ({
 
     const fetchAvailability = async (m: Manifestation[]) => {
       // Fetch availability data.
-      const data = await getAvailabilityV3({
-        recordid: faustIds,
-        ...(blacklistBranches ? { exclude: blacklistBranches } : {})
-      });
+      const data = await getAvailability({ faustIds, config });
+
       // If we for some reason do not get any data, we return empty arrays.
       if (!data) {
         return { reservable: [], unReservable: [] };
@@ -79,7 +75,8 @@ const UseReservableManifestations = ({
     faustIds,
     type,
     reservableManifestations,
-    unReservableManifestations
+    unReservableManifestations,
+    config
   ]);
 
   return {

--- a/src/core/utils/UseReservableManifestations.tsx
+++ b/src/core/utils/UseReservableManifestations.tsx
@@ -3,6 +3,7 @@ import { filterManifestationsByType } from "../../apps/material/helper";
 import { getAvailabilityV3 } from "../fbs/fbs";
 import { convertPostIdToFaustId, getAllFaustIds } from "./helpers/general";
 import { Manifestation } from "./types/entities";
+import { useConfig } from "./config";
 
 const UseReservableManifestations = ({
   manifestations,
@@ -11,6 +12,11 @@ const UseReservableManifestations = ({
   manifestations: Manifestation[];
   type?: string;
 }) => {
+  const config = useConfig();
+  const blacklistBranches = config("blacklistedAvailabilityBranchesConfig", {
+    transformer: "stringToArray"
+  });
+
   const faustIds = getAllFaustIds(manifestations);
 
   const [reservableManifestations, setReservableManifestations] = useState<
@@ -32,7 +38,8 @@ const UseReservableManifestations = ({
     const fetchAvailability = async (m: Manifestation[]) => {
       // Fetch availability data.
       const data = await getAvailabilityV3({
-        recordid: faustIds
+        recordid: faustIds,
+        ...(blacklistBranches ? { exclude: blacklistBranches } : {})
       });
       // If we for some reason do not get any data, we return empty arrays.
       if (!data) {

--- a/src/core/utils/useGetAvailability.ts
+++ b/src/core/utils/useGetAvailability.ts
@@ -1,0 +1,29 @@
+import { UseQueryOptions } from "react-query";
+import { getAvailabilityV3, useGetAvailabilityV3 } from "../fbs/fbs";
+import { UseConfigFunction } from "./config";
+import { FaustId } from "./types/ids";
+import { getBlacklistedArgs } from "../../apps/material/helper";
+
+const useGetAvailability = ({
+  faustIds,
+  config,
+  options
+}: {
+  faustIds: FaustId[];
+  config: UseConfigFunction;
+  options?: {
+    query?: UseQueryOptions<Awaited<ReturnType<typeof getAvailabilityV3>>>;
+  };
+}) => {
+  const { data, isLoading, isError } = useGetAvailabilityV3(
+    getBlacklistedArgs(
+      faustIds,
+      config,
+      "blacklistedAvailabilityBranchesConfig"
+    ),
+    options
+  );
+  return { data, isLoading, isError };
+};
+
+export default useGetAvailability;

--- a/src/core/utils/useGetAvailability.ts
+++ b/src/core/utils/useGetAvailability.ts
@@ -2,7 +2,7 @@ import { UseQueryOptions } from "react-query";
 import { getAvailabilityV3, useGetAvailabilityV3 } from "../fbs/fbs";
 import { UseConfigFunction } from "./config";
 import { FaustId } from "./types/ids";
-import { getBlacklistedArgs } from "../../apps/material/helper";
+import { getBlacklistedQueryArgs } from "../../apps/material/helper";
 
 const useGetAvailability = ({
   faustIds,
@@ -16,11 +16,7 @@ const useGetAvailability = ({
   };
 }) => {
   const { data, isLoading, isError } = useGetAvailabilityV3(
-    getBlacklistedArgs(
-      faustIds,
-      config,
-      "blacklistedAvailabilityBranchesConfig"
-    ),
+    getBlacklistedQueryArgs(faustIds, config, "availability"),
     options
   );
   return { data, isLoading, isError };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-499

#### Description

This pull request aims to fix issues related to parallel reservations by addressing two specific problems with the `work-of:870970-basis:46143736`. Firstly, the branch `DK-775164` (Egå skolebibliotek) needs to be blacklisted, and secondly, we need to include the blacklist in the `UseReservableManifestations`.

To address these issues, this pull request introduces new hooks - `useGetAvailability`, `getAvailability`, and `useGetAvailability` - which serve as a wrapper around existing hooks. These new hooks handle cases where 'blacklistedConfig' needs to be considered while fetching data. By using the `getBlacklistedArgs` function, the wrapper ensures that blacklisted branches are appropriately excluded from the query results.

#### Additional comments or questions

While working on this task, I realized that we are unable to manage situations where a parallel reservation includes an item that has already been reserved. As a result, I modified the `handleErrorText` function to handle an array of strings instead of just a single string."

#### Screenshot of the result

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.