### PR TITLE
Use newest atosuggest-material classes for singular & two items

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-6b5400e64cc34e15c612671c5f58efb120e9bbbe",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.8.1",

--- a/src/components/autosuggest-material/autosuggest-material.tsx
+++ b/src/components/autosuggest-material/autosuggest-material.tsx
@@ -1,5 +1,6 @@
 import { UseComboboxPropGetters } from "downshift";
 import React from "react";
+import clsx from "clsx";
 import { useText } from "../../core/utils/text";
 import { Suggestion, Suggestions } from "../../core/utils/types/autosuggest";
 import { Cover } from "../cover/cover";
@@ -52,12 +53,12 @@ const AutosuggestMaterial: React.FC<AutosuggestMaterialProps> = ({
 
         return (
           <li
-            className={`autosuggest__material-item
-              ${
+            className={clsx("autosuggest__material-item", {
+              "autosuggest__material-item--two": materialData.length === 2,
+              "autosuggest__material-item--one": materialData.length === 1,
+              "autosuggest__material-item--highlight":
                 highlightedIndex === index
-                  ? "autosuggest__material-item--highlight"
-                  : ""
-              }`}
+            })}
             key={item.work?.workId}
             {...getItemProps({ item, index })}
             data-cy={dataCy}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,10 +1749,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66":
-  version "0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-d9c59613b4a4098efde7f75df4ccfe6834dd4e66/788acaf1ef8e4b74bc2c1ba07209a1bbdd0a4f3f#788acaf1ef8e4b74bc2c1ba07209a1bbdd0a4f3f"
-  integrity sha512-PxLLfTk1LfYdMRYIGmKGWVxA6WjjnbUI4wdcrOq0OVCniioHfwfl0/gUF4q/qUl5ijRjshbT7kR6H1ZZHcFhgg==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-6b5400e64cc34e15c612671c5f58efb120e9bbbe":
+  version "0.0.0-6b5400e64cc34e15c612671c5f58efb120e9bbbe"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-6b5400e64cc34e15c612671c5f58efb120e9bbbe/6a797bdac11451adfb460c62c30cf5a004927c95#6a797bdac11451adfb460c62c30cf5a004927c95"
+  integrity sha512-XqikSPd042abBJ6Z/ZusO067LHCOSBLzJEz52TBDefihhgW+Ie6F9RQi1UdXNdWfP+Qgq3uMQ5z6GzzW3/2xBA==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-520

#### Description
This PR uses the newest dpl-design-system package to solve a bug described in [this PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/218), where autosuggest dividers were not spanning the full width of the element. 

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/28546954/235608068-fc381354-63f8-4f8f-bd7f-11e7f0a5fe6c.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a