### PR TITLE
Add missing 'interestPeriod*ConfigText's to fix `NoInterestAfterModal`

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -786,6 +786,26 @@ export default {
       control: { type: "text" },
       defaultValue:
         '{\n        "threshold": "1",\n        "matchString": "14 dages lån - bogligt (kan ikke reserveres)",\n        "enabled": "true"      }'
+    },
+    interestPeriodOneMonthConfigText: {
+      defaultValue: "1",
+      control: { type: "text" }
+    },
+    interestPeriodTwoMonthsConfigText: {
+      defaultValue: "1",
+      control: { type: "text" }
+    },
+    interestPeriodThreeMonthsConfigText: {
+      defaultValue: "1",
+      control: { type: "text" }
+    },
+    interestPeriodSixMonthsConfigText: {
+      defaultValue: "1",
+      control: { type: "text" }
+    },
+    interestPeriodOneYearConfigText: {
+      defaultValue: "1",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -71,6 +71,11 @@ interface MaterialEntryTextProps {
   instantLoanSubTitleText: string;
   instantLoanTitleText: string;
   instantLoanUnderlineDescriptionText: string;
+  interestPeriodOneMonthConfigText: string;
+  interestPeriodOneYearConfigText: string;
+  interestPeriodSixMonthsConfigText: string;
+  interestPeriodThreeMonthsConfigText: string;
+  interestPeriodTwoMonthsConfigText: string;
   librariesHaveTheMaterialText: string;
   listenOnlineText: string;
   loadingText: string;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-516

#### Description
This PR addresses the issue where no options were being displayed in the `NoInterestAfterModal`. By adding the missing 'interestPeriod*ConfigText' entries, the `getInterestPeriods` function can now correctly utilize the `isConfigValueOne` method to generate and display the appropriate options.

#### Screenshot of the result

https://user-images.githubusercontent.com/49920322/235914805-d32378b7-4f52-464a-a84c-a0eee75b3678.mov

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

**This was introduced by PR:**
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/397