### PR TITLE
Add possibility to filter on `workTypes` in `AutosuggestCategory`

### DIFF
--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -36,7 +36,8 @@ interface SearchResultProps {
 }
 
 const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
-  const { filters, addToFilter, clearFilter } = useFilterHandler();
+  const { filters, clearFilter, addFilterFromUrlParamListener } =
+    useFilterHandler();
   const cleanBranches = useGetCleanBranches();
   const [resultItems, setResultItems] = useState<Work[]>([]);
   const [hitcount, setHitCount] = useState<number>(0);
@@ -87,13 +88,8 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   // This is an initial, intentionally simple approach supporting what is required by the search header.
   // It could be reworked to support all filters and terms at a later point.
   useEffect(() => {
-    const materialTypeUrlFilter = getUrlQueryParam("materialType");
-    if (materialTypeUrlFilter) {
-      addToFilter({
-        facet: FacetField.MaterialTypes,
-        term: { key: materialTypeUrlFilter, term: materialTypeUrlFilter }
-      });
-    }
+    addFilterFromUrlParamListener(FacetField.MaterialTypes);
+    addFilterFromUrlParamListener(FacetField.WorkTypes);
     // We only want to do this once, so we need the dependency array empty
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/apps/search-result/useFilterHandler.tsx
+++ b/src/apps/search-result/useFilterHandler.tsx
@@ -45,9 +45,10 @@ const useFilterHandler = () => {
   const addFilterFromUrlParamListener = (facet: FacetField) => {
     const urlFilter = getUrlQueryParam(facet);
     if (urlFilter) {
+      // We only use term from the url, therefore key is not important here.
       addToFilter({
         facet,
-        term: { key: urlFilter, term: urlFilter }
+        term: { key: "key", term: urlFilter }
       });
     }
   };

--- a/src/apps/search-result/useFilterHandler.tsx
+++ b/src/apps/search-result/useFilterHandler.tsx
@@ -13,6 +13,7 @@ import {
   removeQueryParametersFromUrl,
   setQueryParametersInUrl
 } from "../../core/utils/helpers/url";
+import { FacetField } from "../../core/dbc-gateway/generated/graphql";
 
 const useFilterHandler = () => {
   const dispatch = useDispatch();
@@ -41,7 +42,23 @@ const useFilterHandler = () => {
     [dispatch]
   );
 
-  return { filters, addToFilter, removeFromFilter, clearFilter };
+  const addFilterFromUrlParamListener = (facet: FacetField) => {
+    const urlFilter = getUrlQueryParam(facet);
+    if (urlFilter) {
+      addToFilter({
+        facet,
+        term: { key: urlFilter, term: urlFilter }
+      });
+    }
+  };
+
+  return {
+    filters,
+    addToFilter,
+    removeFromFilter,
+    clearFilter,
+    addFilterFromUrlParamListener
+  };
 };
 
 export default useFilterHandler;

--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -5,13 +5,14 @@ import { FC } from "react";
 import { SuggestionsFromQueryStringQuery } from "../../core/dbc-gateway/generated/graphql";
 import { useText } from "../../core/utils/text";
 import { Suggestion } from "../../core/utils/types/autosuggest";
+import { AutosuggestCategoryList } from "../../core/utils/types/material-type";
 
 export interface AutosuggestCategoryProps {
   categoryData: SuggestionsFromQueryStringQuery["suggest"]["result"];
   getItemProps: UseComboboxPropGetters<Suggestion>["getItemProps"];
   highlightedIndex: number;
   textAndMaterialDataLength: number;
-  autosuggestCategoryList: { render: string; type: string }[];
+  autosuggestCategoryList: AutosuggestCategoryList[];
   dataCy?: string;
 }
 

--- a/src/components/autosuggest/autosuggest.tsx
+++ b/src/components/autosuggest/autosuggest.tsx
@@ -6,6 +6,7 @@ import { Suggestion, Suggestions } from "../../core/utils/types/autosuggest";
 import AutosuggestCategory from "../autosuggest-category/autosuggest-category";
 import AutosuggestMaterial from "../autosuggest-material/autosuggest-material";
 import { AutosuggestText } from "../autosuggest-text/autosuggest-text";
+import { AutosuggestCategoryList } from "../../core/utils/types/material-type";
 
 export interface AutosuggestProps {
   textData: SuggestionsFromQueryStringQuery["suggest"]["result"];
@@ -16,7 +17,7 @@ export interface AutosuggestProps {
   getItemProps: UseComboboxPropGetters<Suggestion>["getItemProps"];
   isOpen: boolean;
   categoryData?: SuggestionsFromQueryStringQuery["suggest"]["result"];
-  autosuggestCategoryList: { render: string; type: string }[];
+  autosuggestCategoryList: AutosuggestCategoryList[];
   isLoading: boolean;
   dataCy?: string;
 }

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -1,19 +1,3 @@
-export const enum FacetMaterialType {
-  book = "bog",
-  ebook = "e-bog",
-  movie = "film",
-  audioBook = "lydbog (net)",
-  audioBookGeneric = "lydbog",
-  music = "node",
-  game = "playstation 5",
-  animatedSeries = "tegneserie",
-  newspaperArticle = "tidsskriftsartikel",
-  earticle = "artikel",
-  boardGame = "spil",
-  cdRom = "cd",
-  magazine = "tidsskrift"
-}
-
 export const enum ManifestationMaterialType {
   book = "bog",
   ebook = "ebog",
@@ -29,5 +13,23 @@ export const enum ManifestationMaterialType {
   cdRom = "cd",
   magazine = "tidsskrift"
 }
+
+export const enum AutosuggestCategory {
+  book = "bog",
+  ebook = "e-bog",
+  movie = "Film",
+  audioBook = "lydbog (online)",
+  music = "Musik",
+  game = "Spil",
+  animatedSeries = "tegneserie"
+}
+
+export type AutosuggestCategoryFacet = "materialTypes" | "workTypes";
+
+export type AutosuggestCategoryList = {
+  render: string;
+  term: AutosuggestCategory;
+  facet: AutosuggestCategoryFacet;
+};
 
 export default {};


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-326

#### Description
This pull request introduces the possibility to filter on `workTypes` in `AutosuggestCategory`, which was previously limited to only `materialTypes`. 


This change will provide users with a more flexible and powerful way to search and filter results.


#### Screenshot of the result



#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
It also resolves the absent mouse functionality in `handleHighlightedIndexChange`, enabling users to use their mouse for navigating to the search page with filters within the `AutosuggestCategory`.
