### PR TITLE
DDFSOEG-508 Check for logged-in user before fetching Patron Information

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -38,7 +38,7 @@ import MaterialSkeleton from "../../components/material/MaterialSkeleton";
 import DisclosureSummary from "../../components/Disclosures/DisclosureSummary";
 import MaterialDisclosure from "./MaterialDisclosure";
 import { useGetPatronInformationByPatronIdV2 } from "../../core/fbs/fbs";
-import { canReserve } from "../../core/utils/helpers/user";
+import { canReserve, isAnonymous } from "../../core/utils/helpers/user";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -55,7 +55,9 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     wid
   });
 
-  const { data: userData } = useGetPatronInformationByPatronIdV2();
+  const { data: userData } = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
   const patron = userData?.patron;
   const userCanReserve = patron && canReserve(patron);
 

--- a/src/apps/menu/menu-logged-in/menu-logged-in.tsx
+++ b/src/apps/menu/menu-logged-in/menu-logged-in.tsx
@@ -28,6 +28,7 @@ import {
 import { useConfig } from "../../../core/utils/config";
 import { ThresholdType } from "../../../core/utils/types/threshold-type";
 import { useText } from "../../../core/utils/text";
+import { isAnonymous } from "../../../core/utils/helpers/user";
 
 export interface MenuLoggedInProps {
   closePatronMenu: () => void;
@@ -39,7 +40,9 @@ interface MenuNavigationDataType {
 }
 
 const MenuLoggedIn: FC<MenuLoggedInProps> = ({ closePatronMenu }) => {
-  const { data: patronData } = useGetPatronInformationByPatronIdV2();
+  const { data: patronData } = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
   const { data: patronReservations } = useGetReservationsV2();
   const { data: publizonData } = useGetV1UserLoans();
   const { data: fbsData } = useGetLoansV2();

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -17,6 +17,7 @@ import StatusSection from "./sections/StatusSection";
 import PauseReservation from "../reservation-list/modal/pause-reservation/pause-reservation";
 import { getModalIds } from "../../core/utils/helpers/general";
 import { useUrls } from "../../core/utils/url";
+import { isAnonymous } from "../../core/utils/helpers/user";
 
 const PatronPage: FC = () => {
   const queryClient = useQueryClient();
@@ -24,7 +25,9 @@ const PatronPage: FC = () => {
   const { mutate } = useUpdateV5();
   const { pauseReservation } = getModalIds();
 
-  const { data: patronData } = useGetPatronInformationByPatronIdV2();
+  const { data: patronData } = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
 
   const { deletePatronUrl } = useUrls();
   const [patron, setPatron] = useState<PatronV5 | null>(null);

--- a/src/apps/reservation-list/list/reservation-list.tsx
+++ b/src/apps/reservation-list/list/reservation-list.tsx
@@ -36,6 +36,7 @@ import ReservationDetails from "../modal/reservation-details/reservation-details
 import { getUrlQueryParam } from "../../../core/utils/helpers/url";
 import { getDetailsModalId } from "../../../core/utils/helpers/modal-helpers";
 import { getFromListByKey } from "../../loan-list/utils/helpers";
+import { isAnonymous } from "../../../core/utils/helpers/user";
 
 export interface ReservationListProps {
   pageSize: number;
@@ -50,7 +51,9 @@ const ReservationList: FC<ReservationListProps> = ({ pageSize }) => {
   const [reservation, setReservation] = useState<ReservationType | null>(null);
   const [reservationToDelete, setReservationToDelete] =
     useState<ReservationType | null>(null);
-  const { data: userData } = useGetPatronInformationByPatronIdV2();
+  const { data: userData } = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
   const [modalDetailsId, setModalDetailsId] = useState<string | null>(null);
   const [modalDeleteId, setModalDeleteId] = useState<string | null>(null);
   // Data fetch

--- a/src/components/material/digital-modal/DigitalModal.tsx
+++ b/src/components/material/digital-modal/DigitalModal.tsx
@@ -9,6 +9,7 @@ import { Pid, WorkId } from "../../../core/utils/types/ids";
 import DigitalModalBody from "./DigitalModalBody";
 import DigitalModalFeedback from "./DigitalModalFeedback";
 import { createDigitalModalId, getResponseMessage } from "./helper";
+import { isAnonymous } from "../../../core/utils/helpers/user";
 
 type DigitalModalProps = {
   pid: Pid;
@@ -54,7 +55,9 @@ const DigitalModal: React.FunctionComponent<DigitalModalProps> = ({
   };
 
   // Pre fill the email field with the patron's email or set it to an empty string
-  const { data: patronData } = useGetPatronInformationByPatronIdV2();
+  const { data: patronData } = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
   useEffect(() => {
     if (!patronData) return;
     if (patronData.patron?.emailAddress) {

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -54,6 +54,7 @@ import PromoBar from "../promo-bar/PromoBar";
 import InstantLoan from "../instant-loan/InstantLoan";
 import { excludeBlacklistedBranches } from "../../core/utils/branches";
 import { InstantLoanConfigType } from "../../core/utils/types/instant-loan";
+import { isAnonymous } from "../../core/utils/helpers/user";
 
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
@@ -100,7 +101,9 @@ export const ReservationModalBody = ({
   const allPids = getAllPids(selectedManifestations);
   const faustIds = convertPostIdsToFaustIds(allPids);
   const { mutate } = useAddReservationsV2();
-  const userResponse = useGetPatronInformationByPatronIdV2();
+  const userResponse = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
   const holdingsResponse = useGetHoldingsV3({
     recordid: faustIds
   });

--- a/src/core/utils/withIsPatronBlockedHoc.tsx
+++ b/src/core/utils/withIsPatronBlockedHoc.tsx
@@ -9,6 +9,7 @@ import { setHasBeenVisible } from "../blockedModal.slice";
 import { RootState, useSelector } from "../store";
 import BlockedTypes from "./types/BlockedTypes";
 import { redirectTo } from "./helpers/url";
+import { isAnonymous } from "./helpers/user";
 
 export interface PatronProps {
   patron: AuthenticatedPatronV6 | null | undefined;
@@ -39,7 +40,9 @@ const withIsPatronBlockedHoc =
     const [blockedFromViewingContent, setBlockedFromViewingContent] = useState<
       boolean | null
     >(null);
-    const { data: patronData } = useGetPatronInformationByPatronIdV2();
+    const { data: patronData } = useGetPatronInformationByPatronIdV2({
+      enabled: !isAnonymous()
+    });
 
     // Used to check whether the modal has been opened by another component,
     // the modal should really only be showed once.


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-508

#### Description

This pull request adds a check to ensure the user is logged in before attempting to fetch Patron Information. Previously, if there was no user token (i.e., the user was not logged in), the FBS fetcher would send the library token instead. 

This would cause issues when trying to fetch from `https://fbs-openplatform.dbc.dk/external/agencyid/patrons/patronid/v2`, resulting in an error after 3 failed attempts. To resolve this issue, we now check for a valid user before fetching Patron Information.

#### Screenshot of the result


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions