### PR TITLE
Fix autosuggest middle section

### DIFF
--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -78,6 +78,7 @@ const SearchHeader: React.FC = () => {
       setSuggestItems(arrayOfResults);
     }
   }, [data]);
+
   const originalData = suggestItems;
   const textData: Suggestion[] = [];
   const materialData: Suggestion[] = [];
@@ -92,8 +93,9 @@ const SearchHeader: React.FC = () => {
 
     originalData.forEach((item: Suggestion) => {
       if (
-        item.type === SuggestionType.Composit ||
-        item.type === SuggestionType.Title
+        (item.type === SuggestionType.Composit ||
+          item.type === SuggestionType.Title) &&
+        item.work
       ) {
         if (materialData.length < 3) {
           materialData.push(item);


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-520

#### Description
This PR solves an issue where autosuggest shows fewer items in the middle section than there is in data. This happened because some of the suggestions doesn't have a work attached to them. We now filter these suggestions out of the material suggestion section.

#### Screenshot of the result
n/a

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a