### PR TITLE
Switch to use `clsx` instead of template strings in `Disclosure`

### DIFF
--- a/src/components/Disclosures/DisclosureControllable.tsx
+++ b/src/components/Disclosures/DisclosureControllable.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import React, { FC, ReactNode, useCallback, useState } from "react";
 
 export interface DisclosureControllableProps {
@@ -42,7 +43,7 @@ const DisclosureControllable: FC<DisclosureControllableProps> = ({
   const disclosureId = `disclosure-${id}`;
 
   return (
-    <div className={`disclosure text-body-large ${className}`}>
+    <div className={clsx("disclosure text-body-large", className)}>
       <div
         data-cy={cyData}
         onClick={handleClick}

--- a/src/components/Disclosures/DisclosureSummary.tsx
+++ b/src/components/Disclosures/DisclosureSummary.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ExpandMoreIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
+import clsx from "clsx";
 import Heading, { HeadingLevelType } from "../Heading/Heading";
 import Pagefold from "../pagefold/Pagefold";
 import { useText } from "../../core/utils/text";
@@ -25,7 +26,7 @@ const DisclosureSummary: React.FunctionComponent<DisclosureSummaryProps> = ({
   return (
     <summary
       ref={itemRef}
-      className={`disclosure__headline text-body-large ${className}`}
+      className={clsx("disclosure__headline text-body-large ", className)}
     >
       {mainIconPath && (
         <div className="disclosure__icon bg-identity-tint-120">

--- a/src/components/Disclosures/disclosure.tsx
+++ b/src/components/Disclosures/disclosure.tsx
@@ -1,4 +1,5 @@
 import React, { FC, ReactElement, ReactNode } from "react";
+import clsx from "clsx";
 import { useItemHasBeenVisible } from "../../core/utils/helpers/lazy-load";
 import { DisclosureSummaryProps } from "./DisclosureSummary";
 
@@ -25,7 +26,7 @@ const Disclosure: FC<DisclosureProps> = ({
 
   return (
     <details
-      className={`disclosure text-body-large ${className}`}
+      className={clsx("disclosure text-body-large", className)}
       open={open}
       data-cy={dataCy}
     >


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-521

#### Description

This pull request improves the `Disclosure` component's className handling by replacing template strings with the `clsx` library. The previous approach resulted in undefined class names when no class was passed, leading to potential issues and inconsistencies.

#### Screenshot of the result
<img width="1607" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/bbae3c65-8cbb-43df-9c48-b2893e31b76c">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions