### PR TITLE
Fix e-resource availability

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ src/core/cover-service-api/cover-service.ts
 src/core/dpl-cms/model
 src/core/dpl-cms/dpl-cms.ts
 src/core/fbs/fbs.ts
+src/core/publizon/publizon.ts

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -95,6 +95,13 @@ export default defineConfig({
         },
         query: {
           useQuery: true
+        },
+        operations: {
+          // The reason why we add this here is to be able to use "enabled" option in the
+          // useGetV1LoanstatusIdentifier query. This lets us call it conditionally.
+          getV1LoanstatusIdentifier: {
+            requestOptions: false
+          }
         }
       },
       prettier: true

--- a/src/apps/favorites-list/favorites-list.test.ts
+++ b/src/apps/favorites-list/favorites-list.test.ts
@@ -56,10 +56,8 @@ describe("Favorites list", () => {
       .should("have.text", "3 materials");
 
     // 2.e. accessibility on material type
-    cy.get(".card-list-page")
-      .find(".card-list-item")
+    cy.getBySel("card-list-item-availability")
       .eq(0)
-      .find(".card-list-item__availability")
       .should(
         "have.text",
         "billedbogavailablelydbog (net)availablelydbog (cd)availablebilledbog (net)availableebogavailable"

--- a/src/apps/favorites-list/favorites-list.test.ts
+++ b/src/apps/favorites-list/favorites-list.test.ts
@@ -62,7 +62,7 @@ describe("Favorites list", () => {
       .find(".card-list-item__availability")
       .should(
         "have.text",
-        "billedbogavailablelydbog (net)unavailablelydbog (cd)availablebilledbog (net)unavailableebogunavailable"
+        "billedbogavailablelydbog (net)availablelydbog (cd)availablebilledbog (net)availableebogavailable"
       );
 
     // 2.f. Link on material to work page

--- a/src/apps/favorites-list/favorites-list.test.ts
+++ b/src/apps/favorites-list/favorites-list.test.ts
@@ -59,7 +59,7 @@ describe("Favorites list", () => {
       .eq(0)
       .should(
         "have.text",
-        "billedbogavailablelydbog (net)availablelydbog (cd)availablebilledbog (net)availableebogavailable"
+        "billedbogavailablelydbog (net)unavailablelydbog (cd)availablebilledbog (net)unavailableebogunavailable"
       );
 
     // 2.f. Link on material to work page

--- a/src/apps/favorites-list/favorites-list.test.ts
+++ b/src/apps/favorites-list/favorites-list.test.ts
@@ -43,7 +43,6 @@ describe("Favorites list", () => {
     });
 
     cy.visit("/iframe.html?path=/story/apps-favorite-list--favorites-list");
-    cy.wait(["@favorites"]);
   });
 
   it("Favorites list basics", () => {

--- a/src/components/availability-label/AvailabilitySkeleton.tsx
+++ b/src/components/availability-label/AvailabilitySkeleton.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import { FC } from "react";
+
+const AvailabilitySkeleton: FC = () => {
+  return <div className="ssc-line w-100" style={{ width: "40px" }} />;
+};
+
+export default AvailabilitySkeleton;

--- a/src/components/availability-label/AvailabilitySkeleton.tsx
+++ b/src/components/availability-label/AvailabilitySkeleton.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { FC } from "react";
 
-const AvailabilitySkeleton: FC = () => {
-  return <div className="ssc-line w-100" style={{ width: "40px" }} />;
-};
+const AvailabilitySkeleton: FC = () => (
+  <div className="ssc-line w-100" style={{ width: "40px" }} />
+);
 
 export default AvailabilitySkeleton;

--- a/src/components/availability-label/availability-label-inside.tsx
+++ b/src/components/availability-label/availability-label-inside.tsx
@@ -1,9 +1,11 @@
 import clsx from "clsx";
 import React from "react";
 import CheckIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Check.svg";
+import AvailabilitySkeleton from "./AvailabilitySkeleton";
 
 type Props = {
   selected?: boolean;
+  isLoading: boolean;
   isAvailable?: boolean;
   manifestText: string;
   availabilityText?: string;
@@ -12,6 +14,7 @@ type Props = {
 
 const AvailabilityLabelInside: React.FunctionComponent<Props> = ({
   selected,
+  isLoading,
   isAvailable,
   manifestText,
   availabilityText,
@@ -51,7 +54,7 @@ const AvailabilityLabelInside: React.FunctionComponent<Props> = ({
         } mr-8`}
         data-cy="availability-label-status"
       >
-        {availabilityText}
+        {isLoading ? <AvailabilitySkeleton /> : availabilityText}
       </p>
       {quantity && (
         <>

--- a/src/components/availability-label/availability-label-visual.tsx
+++ b/src/components/availability-label/availability-label-visual.tsx
@@ -37,6 +37,7 @@ const AvailabilityLabelVisual: React.FunctionComponent<
         manifestText={manifestText}
         availabilityText={getAvailabilityText}
         quantity={quantity}
+        isLoading={false}
       />
     </div>
   );

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -69,7 +69,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     <AvailabilityLabelInside
       selected={selected}
       isLoading={!!isLoading}
-      isAvailable={isAvailable}
+      isAvailable={!!isAvailable}
       manifestText={manifestText}
       availabilityText={availabilityText}
     />

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -5,13 +5,17 @@ import LinkNoStyle from "../atoms/links/LinkNoStyle";
 import { useStatistics } from "../../core/statistics/useStatistics";
 import { statistics } from "../../core/statistics/statistics";
 import { getParentAvailabilityLabelClass, useAvailabilityData } from "./helper";
-import { AccessTypeCode } from "../../core/dbc-gateway/generated/graphql";
+import {
+  Access,
+  AccessTypeCode
+} from "../../core/dbc-gateway/generated/graphql";
 import AvailabilityLabelInside from "./availability-label-inside";
 import { FaustId } from "../../core/utils/types/ids";
 
 export interface AvailabilityLabelProps {
   manifestText: string;
   accessTypes: AccessTypeCode[];
+  access: Access["__typename"][];
   selected?: boolean;
   url?: URL;
   faustIds: FaustId[];
@@ -24,6 +28,7 @@ export interface AvailabilityLabelProps {
 export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   manifestText,
   accessTypes,
+  access,
   selected = false,
   url,
   faustIds,
@@ -35,8 +40,9 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   const { track } = useStatistics();
   const t = useText();
 
-  const { isAvailable } = useAvailabilityData({
+  const { isLoading, isAvailable } = useAvailabilityData({
     accessTypes,
+    access,
     faustIds,
     isbn: isbns ? isbns[0] : null
   });
@@ -62,6 +68,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   const availabilityLabel = (
     <AvailabilityLabelInside
       selected={selected}
+      isLoading={!!isLoading}
       isAvailable={isAvailable}
       manifestText={manifestText}
       availabilityText={availabilityText}

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -50,6 +50,12 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
           })
           .flat();
 
+        const access = manifestationsOfMaterialType
+          .map((manifest) => {
+            return manifest.access.map((acc) => acc.__typename);
+          })
+          .flat();
+
         return (
           <AvailabilityLabel
             key={faustIds.join("-")}
@@ -58,6 +64,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             faustIds={faustIds}
             manifestText={materialType}
             accessTypes={accessTypesCodes}
+            access={access}
             selected={
               selectedManifestations &&
               materialType === getMaterialTypes(selectedManifestations)[0]

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -45,9 +45,9 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
         const identifiers = getAllIdentifiers(manifestationsOfMaterialType);
         const url = constructMaterialUrl(materialUrl, workId, materialType);
         const accessTypesCodes = manifestationsOfMaterialType
-          .map((manifest) => {
-            return manifest.accessTypes.map((accessType) => accessType.code);
-          })
+          .map((manifest) =>
+            manifest.accessTypes.map((accessType) => accessType.code)
+          )
           .flat();
 
         const access = manifestationsOfMaterialType

--- a/src/components/availability-label/helper.ts
+++ b/src/components/availability-label/helper.ts
@@ -95,7 +95,7 @@ export const useAvailabilityData = ({
 
   useEffect(() => {
     setIsLoading(
-      !!(isLoadingAvailability || isLoadingIdentifier || isLoadingProductInfo)
+      isLoadingAvailability || isLoadingIdentifier || isLoadingProductInfo
     );
   }, [isLoadingAvailability, isLoadingIdentifier, isLoadingProductInfo]);
 

--- a/src/components/availability-label/helper.ts
+++ b/src/components/availability-label/helper.ts
@@ -1,25 +1,81 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import clsx from "clsx";
-import { useGetV1ProductsIdentifier } from "../../core/publizon/publizon";
+import {
+  useGetV1LoanstatusIdentifier,
+  useGetV1ProductsIdentifier
+} from "../../core/publizon/publizon";
 import { useConfig } from "../../core/utils/config";
-import { AccessTypeCode } from "../../core/dbc-gateway/generated/graphql";
+import {
+  Access,
+  AccessTypeCode
+} from "../../core/dbc-gateway/generated/graphql";
 import { FaustId } from "../../core/utils/types/ids";
 import useGetAvailability from "../../core/utils/useGetAvailability";
+import { publizonProductStatuses } from "./types";
 
 export const useAvailabilityData = ({
   accessTypes,
+  access,
   faustIds,
   isbn
 }: {
   accessTypes: AccessTypeCode[];
+  access: Access["__typename"][];
   faustIds: FaustId[] | null;
   isbn: string | null;
 }) => {
   const [isAvailable, setIsAvailable] = useState(false);
   const config = useConfig();
   const isOnline = accessTypes?.includes(AccessTypeCode.Online) ?? false;
+  const [isCostFree, setIsCostFree] = useState<null | boolean>(null);
+  const [isLoading, setIsLoading] = useState<null | boolean>(null);
 
-  useGetAvailability({
+  useEffect(() => {
+    // An online material is by default always available.
+    if (isOnline && isCostFree !== false) {
+      setIsAvailable(true);
+    }
+  }, [isOnline, isCostFree]);
+
+  const { isLoading: isLoadingIdentifier } = useGetV1ProductsIdentifier(
+    isbn ?? "",
+    {
+      query: {
+        // Publizon / useGetV1ProductsIdentifier is responsible for online
+        // materials. It requires an ISBN to do lookups.
+        enabled: isOnline && isbn !== null,
+        onSuccess: (res) => {
+          // If an online material isn't cost-free we need to check whether there is a queue
+          // to reserve it (via useGetV1LoanstatusIdentifier below in the code)
+          if (res?.product?.costFree === false) {
+            setIsCostFree(false);
+          }
+        }
+      }
+    }
+  );
+
+  const { isLoading: isLoadingProductInfo } = useGetV1LoanstatusIdentifier(
+    isbn || "",
+    {
+      query: {
+        // Publizon / useGetV1LoanstatusIdentifier shows loan status per material.
+        // This status is only available for products found on Ereol. Other online
+        // materials are always supposed to be shown as "available"
+        enabled: isOnline && !!isbn && access.some((acc) => acc === "Ereol"),
+        onSuccess: (res) => {
+          if (res && res.loanStatus) {
+            setIsAvailable(publizonProductStatuses[res.loanStatus].isAvailable);
+            return;
+          }
+          // In case the load status data doesn't exist we assume it isn't available
+          setIsAvailable(false);
+        }
+      }
+    }
+  );
+
+  const { isLoading: isLoadingAvailability } = useGetAvailability({
     faustIds: faustIds ?? [],
     config,
     options: {
@@ -37,24 +93,13 @@ export const useAvailabilityData = ({
     }
   });
 
-  useGetV1ProductsIdentifier(isbn ?? "", {
-    query: {
-      // Publizon / useGetV1ProductsIdentifier is responsible for online
-      // materials. It requires an ISBN to do lookups.
-      enabled: isOnline && isbn !== null,
-      onSuccess: () => {
-        // For now we always consider online materials available at publizon
-        // as available. In the future this can be improved by checking
-        // 1. Whether the material has a quota (res?.product?.costFree)
-        // 2. If the product has a quota:
-        //    1. If the user has any quota loans available for the material type
-        //    2. If the library has a queue on the material
-        setIsAvailable(true);
-      }
-    }
-  });
+  useEffect(() => {
+    setIsLoading(
+      !!(isLoadingAvailability || isLoadingIdentifier || isLoadingProductInfo)
+    );
+  }, [isLoadingAvailability, isLoadingIdentifier, isLoadingProductInfo]);
 
-  return { isAvailable };
+  return { isLoading, isAvailable };
 };
 
 type GetParrentAvailabilityLabelClassProps = {

--- a/src/components/availability-label/types.ts
+++ b/src/components/availability-label/types.ts
@@ -1,0 +1,42 @@
+// Publizon API useGetV1LoanstatusIdentifier return data a property "loanStatus"
+// which can be a number between 0 - 7. These are codes for specific statuses
+// a given product can be in - e.g. code 5 means that there is a reservation queue
+// on the product.
+// #5 is also the only one we know the exact meaning of. The rest of the numbers
+// should be updated in the future when we figure out what they mean.
+export const publizonProductStatuses = {
+  0: {
+    isAvailable: true,
+    meaning: "Unknown"
+  },
+  1: {
+    isAvailable: true,
+    meaning: "Unknown"
+  },
+  2: {
+    isAvailable: true,
+    meaning: "Unknown"
+  },
+  3: {
+    isAvailable: true,
+    meaning: "Unknown"
+  },
+  4: {
+    isAvailable: true,
+    meaning: "Reservable"
+  },
+  5: {
+    isAvailable: false,
+    meaning: "Reservation queue on the material"
+  },
+  6: {
+    isAvailable: true,
+    meaning: "Unknown"
+  },
+  7: {
+    isAvailable: true,
+    meaning: "Unknown"
+  }
+};
+
+export default {};

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -104,6 +104,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   ];
 
   const accessTypesCodes = manifestation.accessTypes.map((item) => item.code);
+  const access = manifestation.access.map((acc) => acc.__typename);
   const detailsId = `material-details-${pid}`;
 
   return (
@@ -114,6 +115,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           faustIds={[faustId]}
           isbns={identifiers.map((identifier) => identifier.value)}
           accessTypes={accessTypesCodes}
+          access={access}
         />
       </div>
       <div className="material-manifestation-item__cover">

--- a/src/core/publizon/publizon-adapter.yaml
+++ b/src/core/publizon/publizon-adapter.yaml
@@ -340,6 +340,7 @@ paths:
     get:
       tags:
         - LoanStatus
+      operationId: "getV1LoanstatusIdentifier"
       summary: Get loan status of a specific product.
       parameters:
         - name: clientId

--- a/src/core/publizon/publizon.ts
+++ b/src/core/publizon/publizon.ts
@@ -474,22 +474,18 @@ export const useGetV1LoanstatusIdentifier = <
   TError = ErrorType<unknown>
 >(
   identifier: string,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof getV1LoanstatusIdentifier>>,
-      TError,
-      TData
-    >;
-  }
+  queryOptions?: UseQueryOptions<
+    Awaited<ReturnType<typeof getV1LoanstatusIdentifier>>,
+    TError,
+    TData
+  >
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const { query: queryOptions } = options ?? {};
-
   const queryKey =
     queryOptions?.queryKey ?? getGetV1LoanstatusIdentifierQueryKey(identifier);
 
   const queryFn: QueryFunction<
     Awaited<ReturnType<typeof getV1LoanstatusIdentifier>>
-  > = ({ signal }) => getV1LoanstatusIdentifier(identifier, signal);
+  > = ({ signal }) => getV1LoanstatusIdentifier(identifier);
 
   const query = useQuery<
     Awaited<ReturnType<typeof getV1LoanstatusIdentifier>>,


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-517

#### Description
This PR fixes availability exposing for e-resources, and introduces loading state to availability labels. 
The e-resource availability is a bit tricky - they are per default always available, unless they can be accessed from Ereolen and they are not blue titles (unlimited loans) and there is a queue on them.

#### Screenshot of the result
![image](https://github.com/reload/dpl-react/assets/28546954/cdf57a31-bfc9-4e5d-8403-a71226722ffd)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a