### PR TITLE
Fix back button issue by adding `e.stopPropagation()` to `CardListItem`

### DIFF
--- a/src/components/card-item-list/card-list-item/card-list-item.tsx
+++ b/src/components/card-item-list/card-list-item/card-list-item.tsx
@@ -118,7 +118,10 @@ const CardListItem: React.FC<CardListItemProps> = ({
       ref={itemRef}
       data-cy={dataCy}
       className="card-list-item arrow arrow__hover--right-small"
-      onClick={handleClick}
+      onClick={(e) => {
+        e.stopPropagation();
+        handleClick();
+      }}
       onKeyUp={(e) => e.key === "Enter" && handleClick}
     >
       <div className="card-list-item__cover">


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-484

#### Description

This PR introduces a fix for the issue where the back button wasn't working correctly after clicking the title link in the `CardListItem` component.

Changes:
- Added `e.stopPropagation()` to the onClick handler of the title link in the `CardListItem` component.

This change ensures that only the specific onClick event for the title link is triggered, which effectively prevents unintended event propagation. As a result, the back button now functions correctly after using the title link.

#### Screenshot of the result

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions