### PR TITLE
Add `useGetPatronInformationByPatronId` hook to ensure the user is login

### DIFF
--- a/src/apps/dashboard/dashboard.test.tsx
+++ b/src/apps/dashboard/dashboard.test.tsx
@@ -1,15 +1,14 @@
-import { TOKEN_LIBRARY_KEY } from "../../core/token";
-
 describe("Dashboard", () => {
   beforeEach(() => {
-    cy.window().then((win) => {
+    cy.createFakeAuthenticatedSession();
+    cy.createFakeLibrarySession();
+    cy.window().then(() => {
       const wednesday20220603 = new Date("2023-01-09T10:00:00.000").getTime();
 
       // Sets time to a specific date
       // https://github.com/cypress-io/cypress/issues/7577
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       cy.clock(wednesday20220603).then((clock: any) => clock.bind(window));
-      win.sessionStorage.setItem(TOKEN_LIBRARY_KEY, "random-token");
     });
 
     cy.intercept("GET", "**/external/agencyid/patron/patronid/fees/v2**", {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -29,8 +29,10 @@ import { UseConfigFunction } from "../../core/utils/config";
 import {
   getAvailabilityV3,
   getHoldingsV3,
-  useGetHoldingsV3
+  useGetHoldingsV3,
+  useGetPatronInformationByPatronIdV2
 } from "../../core/fbs/fbs";
+import { isAnonymous } from "../../core/utils/helpers/user";
 
 export const getWorkManifestation = (
   work: Work,
@@ -453,4 +455,12 @@ export const useGetHoldings = ({
     options
   );
   return { data, isLoading, isError };
+};
+
+export const useGetPatronInformationByPatronId = () => {
+  const { data, isLoading } = useGetPatronInformationByPatronIdV2({
+    enabled: !isAnonymous()
+  });
+
+  return { data, isLoading };
 };

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -20,7 +20,8 @@ import {
   divideManifestationsByMaterialType,
   getBestMaterialTypeForWork,
   getManifestationsOrderByTypeAndYear,
-  isParallelReservation
+  isParallelReservation,
+  useGetPatronInformationByPatronId
 } from "./helper";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import { getManifestationPid } from "../../core/utils/helpers/general";
@@ -35,7 +36,6 @@ import MaterialHeader from "../../components/material/MaterialHeader";
 import MaterialSkeleton from "../../components/material/MaterialSkeleton";
 import DisclosureSummary from "../../components/Disclosures/DisclosureSummary";
 import MaterialDisclosure from "./MaterialDisclosure";
-import { useGetPatronInformationByPatronIdV2 } from "../../core/fbs/fbs";
 import { isAnonymous, isBlocked } from "../../core/utils/helpers/user";
 import ReservationFindOnShelfModals from "./ReservationFindOnShelfModals";
 
@@ -53,9 +53,7 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const { data, isLoading } = useGetMaterialQuery({
     wid
   });
-  const { data: userData } = useGetPatronInformationByPatronIdV2({
-    enabled: !isAnonymous()
-  });
+  const { data: userData } = useGetPatronInformationByPatronId();
   const [isUserBlocked, setIsUserBlocked] = useState<boolean | null>(null);
   const { track } = useStatistics();
 

--- a/src/apps/menu/menu-logged-in/menu-logged-in.tsx
+++ b/src/apps/menu/menu-logged-in/menu-logged-in.tsx
@@ -6,7 +6,6 @@ import MenuNotification from "../menu-notification/menu-notification";
 import { AuthenticatedPatronV6 } from "../../../core/fbs/model";
 import { useUrls } from "../../../core/utils/url";
 import {
-  useGetPatronInformationByPatronIdV2,
   useGetLoansV2,
   useGetReservationsV2,
   useGetFeesV2
@@ -28,6 +27,7 @@ import { ThresholdType } from "../../../core/utils/types/threshold-type";
 import { useText } from "../../../core/utils/text";
 import Modal from "../../../core/utils/modal";
 import { Button } from "../../../components/Buttons/Button";
+import { useGetPatronInformationByPatronId } from "../../material/helper";
 
 export interface MenuLoggedInProps {
   closePatronMenu: () => void;
@@ -40,7 +40,7 @@ interface MenuNavigationDataType {
 
 const MenuLoggedIn: FC = () => {
   const { userMenuAuthenticated: userMenuAuthenticatedModalId } = getModalIds();
-  const { data: patronData } = useGetPatronInformationByPatronIdV2();
+  const { data: patronData } = useGetPatronInformationByPatronId();
   const { data: patronReservations } = useGetReservationsV2();
   const { data: publizonData } = useGetV1UserLoans();
   const { data: fbsData } = useGetLoansV2();

--- a/src/apps/patron-page/PatronPage.test.tsx
+++ b/src/apps/patron-page/PatronPage.test.tsx
@@ -1,10 +1,7 @@
-import { TOKEN_LIBRARY_KEY } from "../../core/token";
-
 describe("Patron page", () => {
   before(() => {
-    cy.window().then((win) => {
-      win.sessionStorage.setItem(TOKEN_LIBRARY_KEY, "random-token");
-    });
+    cy.createFakeAuthenticatedSession();
+    cy.createFakeLibrarySession();
 
     cy.intercept({
       method: "PUT",

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -3,7 +3,6 @@ import { set } from "lodash";
 import { useQueryClient } from "react-query";
 import { PatronV5, UpdatePatronRequestV4 } from "../../core/fbs/model";
 import {
-  useGetPatronInformationByPatronIdV2,
   useUpdateV5,
   getGetPatronInformationByPatronIdV2QueryKey
 } from "../../core/fbs/fbs";
@@ -17,6 +16,7 @@ import StatusSection from "./sections/StatusSection";
 import PauseReservation from "../reservation-list/modal/pause-reservation/pause-reservation";
 import { getModalIds } from "../../core/utils/helpers/general";
 import { useUrls } from "../../core/utils/url";
+import { useGetPatronInformationByPatronId } from "../material/helper";
 
 const PatronPage: FC = () => {
   const queryClient = useQueryClient();
@@ -24,7 +24,7 @@ const PatronPage: FC = () => {
   const { mutate } = useUpdateV5();
   const { pauseReservation } = getModalIds();
 
-  const { data: patronData } = useGetPatronInformationByPatronIdV2();
+  const { data: patronData } = useGetPatronInformationByPatronId();
 
   const { deletePatronUrl } = useUrls();
   const [patron, setPatron] = useState<PatronV5 | null>(null);

--- a/src/apps/reservation-list/list/reservation-list-pagination.test.ts
+++ b/src/apps/reservation-list/list/reservation-list-pagination.test.ts
@@ -1,10 +1,7 @@
-import { TOKEN_LIBRARY_KEY } from "../../../core/token";
-
 describe("Reservation list pagination", () => {
   before(() => {
-    cy.window().then((win) => {
-      win.sessionStorage.setItem(TOKEN_LIBRARY_KEY, "random-token");
-    });
+    cy.createFakeAuthenticatedSession();
+    cy.createFakeLibrarySession();
 
     const wednesday20220603 = new Date("2023-02-03T12:30:00.000Z").getTime();
 

--- a/src/apps/reservation-list/list/reservation-list.test.ts
+++ b/src/apps/reservation-list/list/reservation-list.test.ts
@@ -1,10 +1,7 @@
-import { TOKEN_LIBRARY_KEY } from "../../../core/token";
-
 describe("Reservation list", () => {
   beforeEach(() => {
-    cy.window().then((win) => {
-      win.sessionStorage.setItem(TOKEN_LIBRARY_KEY, "random-token");
-    });
+    cy.createFakeAuthenticatedSession();
+    cy.createFakeLibrarySession();
 
     const wednesday20220603 = new Date("2023-02-03T12:30:00.000Z").getTime();
 

--- a/src/apps/reservation-list/list/reservation-list.tsx
+++ b/src/apps/reservation-list/list/reservation-list.tsx
@@ -18,10 +18,7 @@ import {
   mapPublizonReservationToReservationType
 } from "../../../core/utils/helpers/list-mapper";
 import ReservationPauseToggler from "./reservation-pause-toggler";
-import {
-  useGetPatronInformationByPatronIdV2,
-  useGetReservationsV2
-} from "../../../core/fbs/fbs";
+import { useGetReservationsV2 } from "../../../core/fbs/fbs";
 import { PatronV5, ReservationDetailsV2 } from "../../../core/fbs/model";
 import EmptyReservations from "./EmptyReservations";
 import PauseReservation from "../modal/pause-reservation/pause-reservation";
@@ -36,6 +33,7 @@ import ReservationDetails from "../modal/reservation-details/reservation-details
 import { getUrlQueryParam } from "../../../core/utils/helpers/url";
 import { getDetailsModalId } from "../../../core/utils/helpers/modal-helpers";
 import { getFromListByKey } from "../../loan-list/utils/helpers";
+import { useGetPatronInformationByPatronId } from "../../material/helper";
 
 export interface ReservationListProps {
   pageSize: number;
@@ -50,7 +48,7 @@ const ReservationList: FC<ReservationListProps> = ({ pageSize }) => {
   const [reservation, setReservation] = useState<ReservationType | null>(null);
   const [reservationToDelete, setReservationToDelete] =
     useState<ReservationType | null>(null);
-  const { data: userData } = useGetPatronInformationByPatronIdV2();
+  const { data: userData } = useGetPatronInformationByPatronId();
   const [modalDetailsId, setModalDetailsId] = useState<string | null>(null);
   const [modalDeleteId, setModalDeleteId] = useState<string | null>(null);
   // Data fetch

--- a/src/apps/reservation-list/modal/delete-reservation/pause-reservations.test.ts
+++ b/src/apps/reservation-list/modal/delete-reservation/pause-reservations.test.ts
@@ -1,10 +1,7 @@
-import { TOKEN_LIBRARY_KEY } from "../../../../core/token";
-
 describe("Pause reservation modal test", () => {
   beforeEach(() => {
-    cy.window().then((win) => {
-      win.sessionStorage.setItem(TOKEN_LIBRARY_KEY, "random-token");
-    });
+    cy.createFakeAuthenticatedSession();
+    cy.createFakeLibrarySession();
     const clockDate = new Date(
       "Sat Oct 08 2022 20:10:25 GMT+0200 (Central European Summer Time)"
     );

--- a/src/components/blocked-patron/BlockedPatron.test.ts
+++ b/src/components/blocked-patron/BlockedPatron.test.ts
@@ -1,8 +1,7 @@
 describe("Patron page", () => {
   before(() => {
-    cy.window().then(() => {
-      cy.createFakeLibrarySession();
-    });
+    cy.createFakeAuthenticatedSession();
+    cy.createFakeLibrarySession();
   });
 
   it("Patron not blocked", () => {

--- a/src/components/material/digital-modal/DigitalModal.tsx
+++ b/src/components/material/digital-modal/DigitalModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { usePlaceCopyMutation } from "../../../core/dbc-gateway/generated/graphql";
-import { useGetPatronInformationByPatronIdV2 } from "../../../core/fbs/fbs";
 import { statistics } from "../../../core/statistics/statistics";
 import { useStatistics } from "../../../core/statistics/useStatistics";
 import Modal from "../../../core/utils/modal";
@@ -9,7 +8,7 @@ import { Pid, WorkId } from "../../../core/utils/types/ids";
 import DigitalModalBody from "./DigitalModalBody";
 import DigitalModalFeedback from "./DigitalModalFeedback";
 import { createDigitalModalId, getResponseMessage } from "./helper";
-import { isAnonymous } from "../../../core/utils/helpers/user";
+import { useGetPatronInformationByPatronId } from "../../../apps/material/helper";
 
 type DigitalModalProps = {
   pid: Pid;
@@ -55,9 +54,7 @@ const DigitalModal: React.FunctionComponent<DigitalModalProps> = ({
   };
 
   // Pre fill the email field with the patron's email or set it to an empty string
-  const { data: patronData } = useGetPatronInformationByPatronIdV2({
-    enabled: !isAnonymous()
-  });
+  const { data: patronData } = useGetPatronInformationByPatronId();
   useEffect(() => {
     if (!patronData) return;
     if (patronData.patron?.emailAddress) {

--- a/src/components/material/infomedia/InfomediaModal.tsx
+++ b/src/components/material/infomedia/InfomediaModal.tsx
@@ -5,9 +5,8 @@ import { useText } from "../../../core/utils/text";
 import { Pid } from "../../../core/utils/types/ids";
 import InfomediaModalBody from "./InfomediaModalBody";
 import { Manifestation } from "../../../core/utils/types/entities";
-import { useGetPatronInformationByPatronIdV2 } from "../../../core/fbs/fbs";
 import InfomediaSkeleton from "./InfomediaSkeleton";
-import { isAnonymous } from "../../../core/utils/helpers/user";
+import { useGetPatronInformationByPatronId } from "../../../apps/material/helper";
 
 export const infomediaModalId = (pid: Pid) => `infomedia-modal-${pid}`;
 
@@ -27,7 +26,7 @@ const InfomediaModal: React.FunctionComponent<InfomediaModalProps> = ({
     string | null | undefined
   > | null>(null);
   const { data: patronData, isLoading: isLoadingPatron } =
-    useGetPatronInformationByPatronIdV2({ enabled: !isAnonymous() });
+    useGetPatronInformationByPatronId();
 
   useEffect(() => {
     if (patronData?.patron?.resident !== undefined) {

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -3,8 +3,7 @@ import {
   getAllFaustIds,
   getManifestationType
 } from "../../../../core/utils/helpers/general";
-import { useGetPatronInformationByPatronIdV2 } from "../../../../core/fbs/fbs";
-import { isAnonymous, isBlocked } from "../../../../core/utils/helpers/user";
+import { isBlocked } from "../../../../core/utils/helpers/user";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import UseReservableManifestations from "../../../../core/utils/UseReservableManifestations";
@@ -13,6 +12,7 @@ import MaterialButtonReservePhysical from "./MaterialButtonPhysical";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
 import { useText } from "../../../../core/utils/text";
+import { useGetPatronInformationByPatronId } from "../../../../apps/material/helper";
 
 export interface MaterialButtonsPhysicalProps {
   manifestations: Manifestation[];
@@ -30,9 +30,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   const { reservableManifestations } = UseReservableManifestations({
     manifestations
   });
-  const { data: userData, isLoading } = useGetPatronInformationByPatronIdV2({
-    enabled: !isAnonymous()
-  });
+  const { data: userData, isLoading } = useGetPatronInformationByPatronId();
   const isUserBlocked = !!(userData?.patron && isBlocked(userData?.patron));
 
   if (isLoading) {

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -25,12 +25,12 @@ import {
   getTotalHoldings,
   getTotalReservations,
   reservationModalId,
-  useGetHoldings
+  useGetHoldings,
+  useGetPatronInformationByPatronId
 } from "../../apps/material/helper";
 import {
   getGetHoldingsV3QueryKey,
-  useAddReservationsV2,
-  useGetPatronInformationByPatronIdV2
+  useAddReservationsV2
 } from "../../core/fbs/fbs";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import {
@@ -54,7 +54,6 @@ import PromoBar from "../promo-bar/PromoBar";
 import InstantLoan from "../instant-loan/InstantLoan";
 import { excludeBlacklistedBranches } from "../../core/utils/branches";
 import { InstantLoanConfigType } from "../../core/utils/types/instant-loan";
-import { isAnonymous } from "../../core/utils/helpers/user";
 
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
@@ -101,9 +100,7 @@ export const ReservationModalBody = ({
   const allPids = getAllPids(selectedManifestations);
   const faustIds = convertPostIdsToFaustIds(allPids);
   const { mutate } = useAddReservationsV2();
-  const userResponse = useGetPatronInformationByPatronIdV2({
-    enabled: !isAnonymous()
-  });
+  const userResponse = useGetPatronInformationByPatronId();
   const holdingsResponse = useGetHoldings({ faustIds, config });
   const { track } = useStatistics();
   const { otherManifestationPreferred } = useAlternativeAvailableManifestation(

--- a/src/core/utils/withIsPatronBlockedHoc.tsx
+++ b/src/core/utils/withIsPatronBlockedHoc.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, ComponentType, FC } from "react";
 import { useDispatch } from "react-redux";
-import { useGetPatronInformationByPatronIdV2 } from "../fbs/fbs";
 import BlockedModal from "../../components/blocked-patron/blocked-modal/BlockedModal";
 import { AuthenticatedPatronV6 } from "../fbs/model";
 import { useModalButtonHandler } from "./modal";
@@ -9,6 +8,7 @@ import { setHasBeenVisible } from "../blockedModal.slice";
 import { RootState, useSelector } from "../store";
 import BlockedTypes from "./types/BlockedTypes";
 import { redirectTo } from "./helpers/url";
+import { useGetPatronInformationByPatronId } from "../../apps/material/helper";
 
 export interface PatronProps {
   patron: AuthenticatedPatronV6 | null | undefined;
@@ -39,7 +39,7 @@ const withIsPatronBlockedHoc =
     const [blockedFromViewingContent, setBlockedFromViewingContent] = useState<
       boolean | null
     >(null);
-    const { data: patronData } = useGetPatronInformationByPatronIdV2();
+    const { data: patronData } = useGetPatronInformationByPatronId();
 
     // Used to check whether the modal has been opened by another component,
     // the modal should really only be showed once.


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-508

#### Description
This PR introduces a new hook, `useGetPatronInformationByPatronId`, which is used to ensure the user is logged in before fetching patron data.

The introduction of this hook improves the maintainability of the code, as it centralizes and standardizes the user check logic across several components.

#### Checklist
- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.