### PR TITLE
Feature/order from another library

### DIFF
--- a/cypress/fixtures/material-buttons/material-buttons-fbi-api.json
+++ b/cypress/fixtures/material-buttons/material-buttons-fbi-api.json
@@ -538,7 +538,8 @@
             "shelfmark": {
               "postfix": "Riley",
               "shelfmark": "83"
-            }
+            },
+            "danMARC2": "OVE"
           },
           {
             "pid": "870970-basis:52590302",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -82,6 +82,11 @@ export default {
       defaultValue: "Reserve",
       control: { type: "text" }
     },
+    reserveFromAnotherLibraryText: {
+      name: "Reserve from another library",
+      defaultValue: "Reserve @materialType elsewhere",
+      control: { type: "text" }
+    },
     findOnBookshelfText: {
       name: "Find on bookshelf",
       defaultValue: "Find on shelf",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -87,6 +87,11 @@ export default {
       defaultValue: "Reserve @materialType elsewhere",
       control: { type: "text" }
     },
+    reserveFromAnotherLibraryWithoutMaterialTypeText: {
+      name: "Reserve from another library",
+      defaultValue: "Reserve elsewhere",
+      control: { type: "text" }
+    },
     findOnBookshelfText: {
       name: "Find on bookshelf",
       defaultValue: "Find on shelf",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -811,6 +811,12 @@ export default {
       defaultValue:
         '[\n   {\n      "value":"30",\n      "label":"1 month"\n   },\n   {\n      "value":"60",\n      "label":"2 months"\n   },\n   {\n      "value":"90",\n      "label":"3 months"\n   },\n   {\n      "value":"180",\n      "label":"6 months"\n   },\n   {\n      "value":"360",\n      "label":"1 year"\n   }\n]',
       control: { type: "text" }
+    },
+    reservationSuccessFluidOrderText: {
+      name: "Reservation success fluid order text",
+      defaultValue:
+        "The material has now been ordered from another library. You will be notified when you can collect the material from your library. As the order is from another library, it cannot be seen immediately under your borrower status. The order expires if the material cannot be obtained within 3 months.",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof MaterialEntry>;

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -82,8 +82,13 @@ export default {
       defaultValue: "Reserve",
       control: { type: "text" }
     },
+    reserveMaterialTypeText: {
+      name: "Reserve material type",
+      defaultValue: "Reserve @materialType",
+      control: { type: "text" }
+    },
     reserveFromAnotherLibraryText: {
-      name: "Reserve from another library",
+      name: "Reserve material type from another library",
       defaultValue: "Reserve @materialType elsewhere",
       control: { type: "text" }
     },

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -141,6 +141,7 @@ interface MaterialEntryTextProps {
   reservationSuccesTitleText: string;
   reserveBookText: string;
   reserveFromAnotherLibraryText: string;
+  reserveFromAnotherLibraryWithoutMaterialTypeText: string;
   reserveText: string;
   reviewsText: string;
   saveButtonText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -140,6 +140,7 @@ interface MaterialEntryTextProps {
   reservationSuccessPreferredPickupBranchText: string;
   reservationSuccesTitleText: string;
   reserveBookText: string;
+  reserveFromAnotherLibraryText: string;
   reserveText: string;
   reviewsText: string;
   saveButtonText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -140,6 +140,7 @@ interface MaterialEntryTextProps {
   reservationSuccessPreferredPickupBranchText: string;
   reservationSuccesTitleText: string;
   reserveBookText: string;
+  reserveMaterialTypeText: string;
   reserveFromAnotherLibraryText: string;
   reserveFromAnotherLibraryWithoutMaterialTypeText: string;
   reserveText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -15,8 +15,8 @@ interface MaterialEntryTextProps {
   approveReservationText: string;
   blockedButtonText: string;
   cantReserveText: string;
-  cantViewText: string;
   cantViewReviewText: string;
+  cantViewText: string;
   changeEmailText: string;
   changeInterestPeriodText: string;
   changePickupLocationText: string;
@@ -71,10 +71,10 @@ interface MaterialEntryTextProps {
   infomediaModalScreenReaderModalDescriptionText: string;
   inSameSeriesText: string;
   inSeriesText: string;
-  interestPeriodsConfig: string;
   instantLoanSubTitleText: string;
   instantLoanTitleText: string;
   instantLoanUnderlineDescriptionText: string;
+  interestPeriodsConfig: string;
   librariesHaveTheMaterialText: string;
   listenOnlineText: string;
   loadingText: string;
@@ -137,12 +137,13 @@ interface MaterialEntryTextProps {
   reservationModalCloseModalAriaLabelText: string;
   reservationModalScreenReaderModalDescriptionText: string;
   reservationSuccesIsReservedForYouText: string;
+  reservationSuccessFluidOrderText: string;
   reservationSuccessPreferredPickupBranchText: string;
   reservationSuccesTitleText: string;
   reserveBookText: string;
-  reserveMaterialTypeText: string;
   reserveFromAnotherLibraryText: string;
   reserveFromAnotherLibraryWithoutMaterialTypeText: string;
+  reserveMaterialTypeText: string;
   reserveText: string;
   reviewsText: string;
   saveButtonText: string;

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -212,6 +212,45 @@ describe("Material", () => {
       .click();
   });
 
+  it("Renders a 'fluid-order' reservation, approve a fluid reservation", () => {
+    cy.createFakeAuthenticatedSession();
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/unavailability.json"
+    });
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material-buttons/material-buttons-fbi-api.json"
+    });
+
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=lydbog+%28cd-mp3%29"
+    );
+
+    cy.getBySel("material-description").scrollIntoView();
+
+    cy.getBySel("material-header-buttons-physical")
+      .should("exist")
+      .and("contain", "lydbog (cd-mp3)")
+      .and("contain", "elsewhere")
+      .click();
+
+    cy.getBySel("reservation-modal-submit-button", true)
+      .should("be.visible")
+      .and("contain", "Approve reservation");
+
+    // We need to wait here because no other fixes work.
+    // eslint-disable-next-line
+    cy.wait(500);
+
+    cy.getBySel("reservation-modal-submit-button").click();
+
+    cy.getBySel("reservation-success-fluid-order-text")
+      .should("be.visible")
+      .and("contain", "The material has now been ordered from another library");
+  });
+
   it("Renders reviews", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -183,6 +183,10 @@ describe("Material", () => {
 
     cy.getBySel("material-description").scrollIntoView();
 
+    // We need to wait here because no other fixes work.
+    // eslint-disable-next-line
+    cy.wait(1000);
+
     cy.getBySel("material-header-buttons-physical")
       .should("be.visible")
       .and("contain", "Reserve bog")
@@ -212,7 +216,7 @@ describe("Material", () => {
       .click();
   });
 
-  it("Renders a 'fluid-order' reservation, approve a fluid reservation", () => {
+  it.only("Renders a 'fluid-order' reservation, approve a fluid reservation", () => {
     cy.createFakeAuthenticatedSession();
     cy.interceptRest({
       aliasName: "Availability",

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -4,7 +4,12 @@ import { AccessTypeCode } from "../../../core/dbc-gateway/generated/graphql";
 import { getAllFaustIds } from "../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../core/utils/types/button";
 import { Manifestation } from "../../../core/utils/types/entities";
-import { hasCorrectAccess, hasCorrectAccessType, isArticle } from "./helper";
+import {
+  SpecialManifestation,
+  hasCorrectAccess,
+  hasCorrectAccessType,
+  isArticle
+} from "./helper";
 import { WorkId } from "../../../core/utils/types/ids";
 import MaterialButtonsOnline from "./online/MaterialButtonsOnline";
 import MaterialButtonsFindOnShelf from "./physical/MaterialButtonsFindOnShelf";
@@ -35,7 +40,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
         !isArticle(manifestations) && (
           <>
             <MaterialButtonsPhysical
-              manifestations={manifestations}
+              manifestations={manifestations as SpecialManifestation[]}
               size={size}
               dataCy={`${dataCy}-physical`}
             />

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -63,8 +63,16 @@ export type SpecialManifestation = Manifestation & SpecialManifestationProps;
 // TODO: Fix type when API has .danMARC2 property
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const isFluidOrderWork = (manifestations: SpecialManifestation[]) => {
+  if (manifestations.length !== 1) {
+    return false;
+  }
+
+  const manifestation = manifestations[0];
+
+  return manifestation.danMARC2 === "OVE";
+
   // Delete the return true; line after API has .danMARC2 property
-  return true;
+  // return true;
   // return !!manifestations.find((manifestation) => {
   //   return manifestation.danMARC2.startsWith("OVE");
   // });

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -4,6 +4,8 @@ import {
   AccessTypeCode
 } from "../../../core/dbc-gateway/generated/graphql";
 import { Manifestation } from "../../../core/utils/types/entities";
+import { UseTextFunction } from "../../../core/utils/text";
+import { ButtonSize } from "../../../core/utils/types/button";
 
 export const hasCorrectAccess = (
   desiredAccess: NonNullable<Access["__typename"]>,
@@ -58,12 +60,50 @@ type SpecialManifestationProps = {
 };
 export type SpecialManifestation = Manifestation & SpecialManifestationProps;
 
+// TODO: Fix type when API has .danMARC2 property
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const isFluidOrderWork = (manifestations: SpecialManifestation[]) => {
   // Delete the return true; line after API has .danMARC2 property
   return true;
   // return !!manifestations.find((manifestation) => {
   //   return manifestation.danMARC2.startsWith("OVE");
   // });
+};
+
+export const getReserveButtonLabel = ({
+  t,
+  isFluid,
+  size,
+  materialType
+}: {
+  t: UseTextFunction;
+  isFluid: boolean;
+  size?: ButtonSize;
+  materialType: string;
+}) => {
+  // If the material is fluid we have special button texts.
+  if (isFluid) {
+    if (size === "small") {
+      return t("reserveFromAnotherLibraryWithoutMaterialTypeText");
+    }
+    return t("reserveFromAnotherLibraryText", {
+      placeholders: {
+        "@materialType": materialType
+      }
+    });
+  }
+
+  // If the button is small we show a simple reserve text.
+  if (size === "small") {
+    return t("reserveText");
+  }
+
+  // If the button is "full" we show the material type in the button text.
+  return t("reserveMaterialTypeText", {
+    placeholders: {
+      "@materialType": materialType
+    }
+  });
 };
 
 export default {};

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -51,4 +51,19 @@ export const areAnyAvailable = (availability: AvailabilityV3[]) => {
   return availability.some((item) => item.available);
 };
 
+// TODO: SpecialManifestationProps & SpecialManifestation type will need to be
+// deleted when the Manifestation type includes the danMARC2 property.
+type SpecialManifestationProps = {
+  danMARC2: string;
+};
+export type SpecialManifestation = Manifestation & SpecialManifestationProps;
+
+export const isFluidOrderWork = (manifestations: SpecialManifestation[]) => {
+  // Delete the return true; line after API has .danMARC2 property
+  return true;
+  // return !!manifestations.find((manifestation) => {
+  //   return manifestation.danMARC2.startsWith("OVE");
+  // });
+};
+
 export default {};

--- a/src/components/material/material-buttons/material-buttons.test.ts
+++ b/src/components/material/material-buttons/material-buttons.test.ts
@@ -10,7 +10,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("bog").first().click();
     cy.getBySel("material-header-buttons-find-on-shelf")
       .should("exist")
@@ -21,11 +20,8 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("ebog").first().click();
-
     cy.getBySel("material-description").scrollIntoView();
-
     cy.getBySel("material-header-buttons-find-on-shelf").should("not.exist");
   });
 
@@ -33,7 +29,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("bog").first().click();
     cy.getBySel("material-header-buttons-physical")
       .should("exist")
@@ -47,6 +42,26 @@ describe("Material buttons", () => {
       .and("contain", "lydbog (cd-mp3)");
   });
 
+  it("Renders a 'fluid-order' reservation button for non-reservable physical materials that can be ordered from another library", () => {
+    cy.interceptRest({
+      aliasName: "Availability",
+      url: "**/availability/v3?recordid=**",
+      fixtureFilePath: "material/unavailability.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
+      .getBySel("material-description")
+      .scrollIntoView();
+    cy.getBySel("availability-label")
+      .contains("lydbog (cd-mp3)")
+      .first()
+      .click();
+    cy.getBySel("material-header-buttons-physical")
+      .should("exist")
+      .and("contain", "lydbog (cd-mp3)")
+      .and("contain", "elsewhere");
+  });
+
   it("Renders reservation button disabled if a material isn't reservable", () => {
     cy.interceptRest({
       aliasName: "Availability",
@@ -56,7 +71,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("bog").first().click();
     cy.getBySel("material-header-buttons-cant-reserve")
       .should("be.disabled")
@@ -67,7 +81,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("ebog").first().click();
     cy.getBySel("material-buttons-online-external").contains("Go to ereolen");
   });
@@ -76,7 +89,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("film").first().click();
     cy.getBySel("material-buttons-online-external").contains(
       "Go to filmstriben"
@@ -87,7 +99,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("lydbog (net)").first().click();
     cy.getBySel("material-buttons-online-external").contains("Listen online");
   });
@@ -96,7 +107,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("availability-label").contains("musik").first().click();
     cy.getBySel("material-buttons-online-external").contains("See online");
   });
@@ -112,7 +122,6 @@ describe("Material buttons", () => {
     )
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("material-header-buttons-online-digital-article").contains(
       "Order digital copy"
     );
@@ -127,7 +136,6 @@ describe("Material buttons", () => {
     cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView();
-
     cy.getBySel("material-header-buttons-online-infomedia-article")
       .should("exist")
       .and("contain", "Read article");

--- a/src/components/material/material-buttons/material-buttons.test.ts
+++ b/src/components/material/material-buttons/material-buttons.test.ts
@@ -43,6 +43,7 @@ describe("Material buttons", () => {
   });
 
   it("Renders a 'fluid-order' reservation button for non-reservable physical materials that can be ordered from another library", () => {
+    cy.createFakeAuthenticatedSession();
     cy.interceptRest({
       aliasName: "Availability",
       url: "**/availability/v3?recordid=**",
@@ -59,7 +60,20 @@ describe("Material buttons", () => {
     cy.getBySel("material-header-buttons-physical")
       .should("exist")
       .and("contain", "lydbog (cd-mp3)")
-      .and("contain", "elsewhere");
+      .and("contain", "elsewhere")
+      .click();
+
+    cy.getBySel("reservation-modal-submit-button", true)
+      .should("be.visible")
+      .and("contain", "Approve reservation");
+    // We need to wait here because no other fixes work.
+    // eslint-disable-next-line
+    cy.wait(500);
+    cy.getBySel("reservation-modal-submit-button").click();
+
+    cy.getBySel("reservation-success-fluid-order-text")
+      .should("be.visible")
+      .and("contain", "The material has now been ordered from another library");
   });
 
   it("Renders reservation button disabled if a material isn't reservable", () => {

--- a/src/components/material/material-buttons/material-buttons.test.ts
+++ b/src/components/material/material-buttons/material-buttons.test.ts
@@ -43,7 +43,6 @@ describe("Material buttons", () => {
   });
 
   it("Renders a 'fluid-order' reservation button for non-reservable physical materials that can be ordered from another library", () => {
-    cy.createFakeAuthenticatedSession();
     cy.interceptRest({
       aliasName: "Availability",
       url: "**/availability/v3?recordid=**",
@@ -60,20 +59,7 @@ describe("Material buttons", () => {
     cy.getBySel("material-header-buttons-physical")
       .should("exist")
       .and("contain", "lydbog (cd-mp3)")
-      .and("contain", "elsewhere")
-      .click();
-
-    cy.getBySel("reservation-modal-submit-button", true)
-      .should("be.visible")
-      .and("contain", "Approve reservation");
-    // We need to wait here because no other fixes work.
-    // eslint-disable-next-line
-    cy.wait(500);
-    cy.getBySel("reservation-modal-submit-button").click();
-
-    cy.getBySel("reservation-success-fluid-order-text")
-      .should("be.visible")
-      .and("contain", "The material has now been ordered from another library");
+      .and("contain", "elsewhere");
   });
 
   it("Renders reservation button disabled if a material isn't reservable", () => {

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -6,6 +6,7 @@ import { ButtonSize } from "../../../../core/utils/types/button";
 import { FaustId } from "../../../../core/utils/types/ids";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
+import { getReserveButtonLabel } from "../helper";
 
 export interface MaterialButtonPhysicalProps {
   manifestationMaterialType: string;
@@ -31,28 +32,16 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
       modalId: reservationModalId(faustIds)
     });
   };
-  const getLabel = () => {
-    if (size === "small" && !isFluid) {
-      return t("reserveText");
-    }
-    if (size === "small" && isFluid) {
-      return t("reserveFromAnotherLibraryWithoutMaterialTypeText");
-    }
-    if (isFluid) {
-      return t("reserveFromAnotherLibraryText", {
-        placeholders: {
-          "@materialType": manifestationMaterialType
-        }
-      });
-    }
-    return `${t("reserveText")} ${manifestationMaterialType}`;
-  };
-  const label = getLabel();
 
   return (
     <Button
       dataCy={dataCy}
-      label={label}
+      label={getReserveButtonLabel({
+        isFluid,
+        size,
+        materialType: manifestationMaterialType,
+        t
+      })}
       buttonType="none"
       variant="filled"
       disabled={false}

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -12,33 +12,51 @@ export interface MaterialButtonPhysicalProps {
   size?: ButtonSize;
   faustIds: FaustId[];
   dataCy?: string;
+  isFluid: boolean;
 }
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   manifestationMaterialType,
   faustIds,
   size,
-  dataCy = "material-button-physical"
+  dataCy = "material-button-physical",
+  isFluid
 }) => {
   const t = useText();
   const { openGuarded } = useModalButtonHandler();
   const { authUrl } = useUrls();
-
   const onClick = () => {
     openGuarded({
       authUrl,
       modalId: reservationModalId(faustIds)
     });
   };
+  const getLabel = () => {
+    if (size === "small" && !isFluid) {
+      return t("reserveText");
+    }
+    if (size === "small" && isFluid) {
+      return t("reserveFromAnotherLibraryText", {
+        placeholders: {
+          "@materialType": ""
+        }
+      });
+    }
+    if (isFluid) {
+      return t("reserveFromAnotherLibraryText", {
+        placeholders: {
+          "@materialType": manifestationMaterialType
+        }
+      });
+    }
+    return `${t("reserveText")} ${manifestationMaterialType}`;
+  };
+  const label = getLabel();
 
   return (
     <Button
       dataCy={dataCy}
-      label={
-        size === "small"
-          ? t("reserveText")
-          : `${t("reserveText")} ${manifestationMaterialType}`
-      }
+      label={label}
       buttonType="none"
       variant="filled"
       disabled={false}

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -36,11 +36,7 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
       return t("reserveText");
     }
     if (size === "small" && isFluid) {
-      return t("reserveFromAnotherLibraryText", {
-        placeholders: {
-          "@materialType": ""
-        }
-      });
+      return t("reserveFromAnotherLibraryWithoutMaterialTypeText");
     }
     if (isFluid) {
       return t("reserveFromAnotherLibraryText", {

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -56,7 +56,10 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return <MaterialButtonLoading />;
   }
 
-  if (!reservableManifestations || reservableManifestations.length < 1) {
+  if (
+    (!reservableManifestations || reservableManifestations.length < 1) &&
+    !isFluidOrder
+  ) {
     return <MaterialButtonDisabled size={size} label={t("cantReserveText")} />;
   }
 

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -5,7 +5,6 @@ import {
 } from "../../../../core/utils/helpers/general";
 import { isBlocked } from "../../../../core/utils/helpers/user";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { Manifestation } from "../../../../core/utils/types/entities";
 import UseReservableManifestations from "../../../../core/utils/UseReservableManifestations";
 import MaterialButtonUserBlocked from "../generic/MaterialButtonUserBlocked";
 import MaterialButtonReservePhysical from "./MaterialButtonPhysical";

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -136,7 +136,7 @@ export const ReservationModalBody = ({
     selectedManifestations as SpecialManifestation[]
   );
 
-  const OpenOrderFakeMutate = (payload?: any) => {
+  const OpenOrderFakeMutate = (payload?: unknown) => {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         if (!payload) {

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -13,6 +13,7 @@ type ReservationSuccesProps = {
   numberInQueue?: number;
   reservationCount: number;
   holdings: number;
+  isFluidOrder?: boolean;
 };
 
 const ReservationSucces: React.FC<ReservationSuccesProps> = ({
@@ -21,7 +22,8 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   preferredPickupBranch,
   numberInQueue,
   reservationCount,
-  holdings
+  holdings,
+  isFluidOrder = false
 }) => {
   const dispatch = useDispatch();
   const t = useText();
@@ -39,31 +41,44 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         >
           {t("reservationSuccesTitleText")}
         </h2>
-        <p
-          data-cy="reservation-success-is-reserved-for-you-text"
-          className="text-body-medium-regular pb-24"
-        >
-          {title} {t("reservationSuccesIsReservedForYouText")}
-        </p>
-        <p
-          data-cy="number-in-queue-text"
-          className="text-body-medium-regular pb-24"
-        >
-          <StockAndReservationInfo
-            stockCount={holdings}
-            reservationCount={reservationCount}
-            numberInQueue={numberInQueue}
-          />
-        </p>
-        <p
-          data-cy="reservation-success-preferred-pickup-branch-text"
-          className="text-body-medium-regular pb-48"
-        >
-          {t("reservationSuccessPreferredPickupBranchText", {
-            placeholders: { "@branch": preferredPickupBranch }
-          })}
-          .
-        </p>
+
+        {isFluidOrder ? (
+          <p
+            data-cy="reservation-success-fluid-order-text"
+            className="text-body-medium-regular pb-24"
+          >
+            {t("reservationSuccessFluidOrderText")}
+          </p>
+        ) : (
+          <>
+            <p
+              data-cy="reservation-success-is-reserved-for-you-text"
+              className="text-body-medium-regular pb-24"
+            >
+              {title} {t("reservationSuccesIsReservedForYouText")}
+            </p>
+            <p
+              data-cy="number-in-queue-text"
+              className="text-body-medium-regular pb-24"
+            >
+              <StockAndReservationInfo
+                stockCount={holdings}
+                reservationCount={reservationCount}
+                numberInQueue={numberInQueue}
+              />
+            </p>
+            <p
+              data-cy="reservation-success-preferred-pickup-branch-text"
+              className="text-body-medium-regular pb-48"
+            >
+              {t("reservationSuccessPreferredPickupBranchText", {
+                placeholders: { "@branch": preferredPickupBranch }
+              })}
+              .
+            </p>
+          </>
+        )}
+
         <Button
           dataCy="reservation-success-close-button"
           classNames="reservation-modal__confirm-button"

--- a/src/tests/unit/getReserveButtonLabel.test.tsx
+++ b/src/tests/unit/getReserveButtonLabel.test.tsx
@@ -1,0 +1,79 @@
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import React, { ReactNode } from "react";
+import { Provider } from "react-redux";
+import { expect, test } from "vitest";
+import { act, renderHook } from "@testing-library/react-hooks";
+import textReducer from "../../core/text.slice";
+import { useText } from "../../core/utils/text";
+import { getReserveButtonLabel } from "../../components/material/material-buttons/helper";
+
+const store = configureStore({
+  reducer: combineReducers({
+    text: textReducer
+  }),
+  preloadedState: {
+    text: {
+      data: {
+        reserveText: "Reserve",
+        reserveMaterialTypeText: "Reserve @materialType",
+        reserveFromAnotherLibraryText: "Reserve @materialType elsewhere",
+        reserveFromAnotherLibraryWithoutMaterialTypeText: "Reserve elsewhere"
+      }
+    }
+  }
+});
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}> {children} </Provider>
+);
+
+test("Should be able to handle fluid reservation button labels", () => {
+  const { result } = renderHook(() => useText(), {
+    wrapper: Wrapper
+  });
+  // We name it t, because that is how we normally use it in the code.
+  const t = result.current;
+  act(() => {
+    const labelLargeButton = getReserveButtonLabel({
+      size: "xlarge",
+      isFluid: true,
+      materialType: "Book",
+      t
+    });
+    const labelSmallButton = getReserveButtonLabel({
+      size: "small",
+      isFluid: true,
+      materialType: "Book",
+      t
+    });
+
+    expect(labelLargeButton).toBe("Reserve Book elsewhere");
+    expect(labelSmallButton).toBe("Reserve elsewhere");
+  });
+});
+
+test("Should be able to handle 'normal' reservation button labels", () => {
+  const { result } = renderHook(() => useText(), {
+    wrapper: Wrapper
+  });
+  // We name it t, because that is how we normally use it in the code.
+  const t = result.current;
+
+  act(() => {
+    const labelLargeButton = getReserveButtonLabel({
+      size: "xlarge",
+      isFluid: false,
+      materialType: "Book",
+      t
+    });
+    const labelSmallButton = getReserveButtonLabel({
+      size: "small",
+      isFluid: false,
+      materialType: "Book",
+      t
+    });
+
+    expect(labelLargeButton).toBe("Reserve Book");
+    expect(labelSmallButton).toBe("Reserve");
+  });
+});


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-529

#### Description
This PR expands the MaterialButtonPhysical to be able to distinguish between regular physical material reservations and fluid reservations where the material is ordered from a different library because the local library doesn't have it.
The button label only enters this state (see pic) when the manifestations to be reserved support being ordered from elsewhere + there are no reservable manifestation of the selected material type in the local library.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/e981a613-d058-41ef-8bfb-089f523d6246)
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/cb1db10b-0cdb-4862-9658-2554dd4578dd)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
This will have to be developed further when the FBI API is ready with all the changes that support this solution.