### PR TITLE
Add Vitest in source testing

### DIFF
--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -307,6 +307,21 @@ They have to be placed in `src/tests/unit`.
 Or they can also be placed next to the code at the end of a file as described
 [here](https://vitest.dev/guide/in-source.html#setup).
 
+```typescript
+export const sum = (...numbers: number[]) =>
+  numbers.reduce((total, number) => total + number, 0);
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe("sum", () => {
+    it("should sum numbers", () => {
+      expect(sum(1, 2, 3)).toBe(6);
+    });
+  });
+}
+```
+
 In that way it helps us to test and mock unexported functions.
 
 ### Testing hooks

--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -304,6 +304,11 @@ By using that we can test functions (and therefore also hooks) and classes.
 
 They have to be placed in `src/tests/unit`.
 
+Or they can also be placed next to the code at the end of a file as described
+[here](https://vitest.dev/guide/in-source.html#setup).
+
+In that way it helps us to test and mock unexported functions.
+
 ### Testing hooks
 
 For testing hooks we are using the library

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "jsx": "react",
     "types": [
       "cypress",
-      "node"
+      "node",
+      "vitest/importMeta"
     ],
   },
   "ts-node": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: {
+    "import.meta.vitest": "undefined"
+  },
+
   test: {
     environment: "happy-dom",
     include: ["./src/tests/unit/*.test.(ts|tsx)"],
+    includeSource: ["src/**/*.{ts,tsx}"],
     coverage: {
       all: true,
       provider: "istanbul",


### PR DESCRIPTION
#### Description
While creating tests for some link component functionality I ran into an issue with testing/mocking a function that originally was an unexported function. There are other questionable hacks you can do
that is not a part of the Vitest recommended practices. However does Vitest have the [in source testing concept](https://vitest.dev/guide/in-source.html#setup) that solves the issue. I suggest we make use of that.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
