### PR TITLE
5389: make room for fixed buttons/pager

### DIFF
--- a/src/apps/dashboard/modal/ReservationsGroupModal.tsx
+++ b/src/apps/dashboard/modal/ReservationsGroupModal.tsx
@@ -107,7 +107,6 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
   return (
     <Modal
       modalId={modalId}
-      classNames="modal-loan"
       closeModalAriaLabelText={t(
         "groupModalReservationsCloseModalAriaLabelText"
       )}

--- a/src/components/GroupModal/GroupModalLoansList.tsx
+++ b/src/components/GroupModal/GroupModalLoansList.tsx
@@ -90,7 +90,7 @@ const GroupModalLoansList: FC<GroupModalLoansListProps> = ({
           />
         ))}
       </ul>
-      <PagerComponent />
+      <PagerComponent classNames="result-pager--margin-bottom" />
     </>
   );
 };

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -97,7 +97,7 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
           )
         )}
       </ul>
-      <PagerComponent />
+      <PagerComponent classNames="result-pager--margin-bottom" />
     </>
   );
 };

--- a/src/components/GroupModal/LoansGroupModal.tsx
+++ b/src/components/GroupModal/LoansGroupModal.tsx
@@ -65,7 +65,6 @@ const LoansGroupModal: FC<LoansGroupModalProps> = ({
   return (
     <Modal
       modalId={modalIdUsed as string}
-      classNames="modal-loan"
       closeModalAriaLabelText={t("groupModalLoansCloseModalAriaLabelText")}
       screenReaderModalDescriptionText={t("groupModalLoansAriaDescriptionText")}
     >

--- a/src/components/result-pager/result-pager.tsx
+++ b/src/components/result-pager/result-pager.tsx
@@ -5,17 +5,19 @@ export interface ResultPagerProps {
   setPageHandler: () => void;
   itemsShown: number;
   hitcount: number;
+  classNames: string;
   isLoading?: boolean;
 }
 function ResultPager({
   setPageHandler,
   itemsShown,
   hitcount,
-  isLoading
+  isLoading,
+  classNames
 }: ResultPagerProps) {
   const t = useText();
   return (
-    <div className="result-pager">
+    <div className={`result-pager ${classNames}`}>
       <p className="text-small-caption result-pager__title">
         {t("resultPagerStatusText", {
           placeholders: { "@itemsShown": itemsShown, "@hitcount": hitcount }

--- a/src/components/result-pager/use-pager.tsx
+++ b/src/components/result-pager/use-pager.tsx
@@ -8,6 +8,7 @@ type PagerProps = {
 };
 
 type PagerComponentProps = {
+  classNames?: string;
   isLoading?: boolean;
 };
 
@@ -34,11 +35,15 @@ const usePager = ({ hitcount, pageSize, overrideItemsShown }: PagerProps) => {
     setPage(currentPage);
   };
 
-  const PagerComponent: React.FC<PagerComponentProps> = ({ isLoading }) =>
+  const PagerComponent: React.FC<PagerComponentProps> = ({
+    isLoading,
+    classNames = ""
+  }) =>
     hitcount ? (
       <ResultPager
         itemsShown={overrideItemsShown ? overrideItemsShown() : itemsShown}
         hitcount={hitcount}
+        classNames={classNames}
         setPageHandler={pagehandler}
         isLoading={isLoading}
       />


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5389

#### Description

In some situations the pager and the fixed button in the bottom of the modals had a bit of an unfortunate overlap

friends with: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/239

#### Screenshot of the result

<img width="811" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/15377965/49b7ca16-1e39-4229-aa0c-c6de3650d7fb">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

n/a