### PR TITLE
DONT MERGE BEFORE CONFIRMATION: Availability labels bug fix

### DIFF
--- a/src/apps/material/__snapshots__/helper.ts.snap
+++ b/src/apps/material/__snapshots__/helper.ts.snap
@@ -1,0 +1,385 @@
+// Vitest Snapshot v1
+
+exports[`divideManifestationsByMaterialType > should divide manifestations by material type 1`] = `
+{
+  "bog": [
+    {
+      "access": [
+        {
+          "__typename": "InterLibraryLoan",
+          "loanIsPossible": true,
+        },
+      ],
+      "accessTypes": [
+        {
+          "code": "PHYSICAL",
+        },
+      ],
+      "audience": {
+        "generalAudience": [],
+      },
+      "contributors": [],
+      "creators": [
+        {
+          "__typename": "Person",
+          "display": "Isaac Asimov",
+        },
+      ],
+      "dateFirstEdition": null,
+      "edition": {
+        "publicationYear": {
+          "display": "2000",
+        },
+        "summary": "2. edition, 2000",
+      },
+      "fictionNonfiction": {
+        "code": "FICTION",
+        "display": "skønlitteratur",
+      },
+      "genreAndForm": [
+        "noveller",
+      ],
+      "identifiers": [
+        {
+          "value": "0-19-423069-4",
+        },
+      ],
+      "languages": {
+        "main": [
+          {
+            "display": "engelsk",
+            "isoCode": "eng",
+          },
+        ],
+      },
+      "materialTypes": [
+        {
+          "specific": "bog",
+        },
+      ],
+      "physicalDescriptions": [
+        {
+          "numberOfPages": 104,
+          "playingTime": null,
+        },
+      ],
+      "pid": "870970-basis:23798255",
+      "publisher": [
+        "Oxford University Press",
+      ],
+      "shelfmark": {
+        "postfix": "Asimov",
+        "shelfmark": "83.8",
+      },
+      "source": [
+        "Bibliotekskatalog",
+      ],
+      "titles": {
+        "main": [
+          "I, Robot (Oxford bookworms library, ved Rowena Akinyemi)",
+        ],
+        "original": [],
+      },
+      "workYear": null,
+    },
+  ],
+  "e-bog": [
+    {
+      "access": [
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "link.overdrive.com",
+          "url": "http://link.overdrive.com/?websiteID=100515&titleID=39136",
+        },
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "samples.overdrive.com",
+          "url": "https://samples.overdrive.com/?crid=9AB7D235-9D58-4180-8DF3-57A4A60CD51E&.epub-sample.overdrive.com",
+        },
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "img1.od-cdn.com",
+          "url": "https://img1.od-cdn.com/ImageType-100/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg100.jpg",
+        },
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "img1.od-cdn.com",
+          "url": "https://img1.od-cdn.com/ImageType-200/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg200.jpg",
+        },
+      ],
+      "accessTypes": [
+        {
+          "code": "ONLINE",
+        },
+      ],
+      "audience": {
+        "generalAudience": [
+          "Text Difficulty 3 - Text Difficulty 5",
+          "UG/Upper grades (9th-12)",
+          "820. Lexile",
+          "6.1. ATOS Level",
+        ],
+      },
+      "contributors": [],
+      "creators": [
+        {
+          "__typename": "Person",
+          "display": "Isaac Asimov",
+        },
+      ],
+      "dateFirstEdition": null,
+      "edition": {
+        "publicationYear": {
+          "display": "2004",
+        },
+        "summary": "2004",
+      },
+      "fictionNonfiction": {
+        "code": "FICTION",
+        "display": "skønlitteratur",
+      },
+      "genreAndForm": [],
+      "identifiers": [
+        {
+          "value": "9780553900330",
+        },
+      ],
+      "languages": {
+        "main": [
+          {
+            "display": "engelsk",
+            "isoCode": "eng",
+          },
+        ],
+      },
+      "materialTypes": [
+        {
+          "specific": "e-bog",
+        },
+      ],
+      "physicalDescriptions": [
+        {
+          "numberOfPages": null,
+          "playingTime": null,
+        },
+      ],
+      "pid": "150061-ebog:ODN0000039136",
+      "publisher": [],
+      "shelfmark": null,
+      "source": [
+        "eReolen Global",
+      ],
+      "titles": {
+        "main": [
+          "I, Robot",
+        ],
+        "original": [],
+      },
+      "workYear": null,
+    },
+  ],
+  "lydbog (online)": [
+    {
+      "access": [
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "link.overdrive.com",
+          "url": "http://link.overdrive.com/?websiteID=100515&titleID=105225",
+        },
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "samples.overdrive.com",
+          "url": "https://samples.overdrive.com/?crid=A6AAE8CE-F944-44F3-960D-4E9A7715CDD5&.epub-sample.overdrive.com",
+        },
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "img1.od-cdn.com",
+          "url": "https://img1.od-cdn.com/ImageType-100/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg100.jpg",
+        },
+        {
+          "__typename": "AccessUrl",
+          "loginRequired": false,
+          "origin": "img1.od-cdn.com",
+          "url": "https://img1.od-cdn.com/ImageType-200/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg200.jpg",
+        },
+      ],
+      "accessTypes": [
+        {
+          "code": "ONLINE",
+        },
+      ],
+      "audience": {
+        "generalAudience": [
+          "Text Difficulty 3 - Text Difficulty 4",
+          "820. Lexile",
+        ],
+      },
+      "contributors": [],
+      "creators": [
+        {
+          "__typename": "Person",
+          "display": "Isaac Asimov",
+        },
+        {
+          "__typename": "Person",
+          "display": "Scott Brick",
+        },
+      ],
+      "dateFirstEdition": null,
+      "edition": {
+        "publicationYear": {
+          "display": "2004",
+        },
+        "summary": "Unabridged, 2004",
+      },
+      "fictionNonfiction": {
+        "code": "NOT_SPECIFIED",
+        "display": "vides ikke",
+      },
+      "genreAndForm": [],
+      "identifiers": [
+        {
+          "value": "9780739346273",
+        },
+      ],
+      "languages": {
+        "main": [
+          {
+            "display": "engelsk",
+            "isoCode": "eng",
+          },
+        ],
+      },
+      "materialTypes": [
+        {
+          "specific": "lydbog (online)",
+        },
+      ],
+      "physicalDescriptions": [
+        {
+          "numberOfPages": null,
+          "playingTime": null,
+        },
+      ],
+      "pid": "150061-netlydbog:ODN0000105225",
+      "publisher": [
+        "Random House Audio",
+      ],
+      "shelfmark": null,
+      "source": [
+        "eReolen Global",
+      ],
+      "titles": {
+        "main": [
+          "I, Robot",
+        ],
+        "original": [],
+      },
+      "workYear": null,
+    },
+  ],
+  "lydoptagelse (cd)": [
+    {
+      "access": [
+        {
+          "__typename": "InterLibraryLoan",
+          "loanIsPossible": true,
+        },
+      ],
+      "accessTypes": [
+        {
+          "code": "PHYSICAL",
+        },
+      ],
+      "audience": {
+        "generalAudience": [],
+      },
+      "contributors": [],
+      "creators": [
+        {
+          "__typename": "Person",
+          "display": "Isaac Asimov",
+        },
+        {
+          "__typename": "Person",
+          "display": "Tricia Reilly",
+        },
+      ],
+      "dateFirstEdition": {
+        "display": "1950",
+        "year": 1950,
+      },
+      "edition": {
+        "publicationYear": {
+          "display": "2008",
+        },
+        "summary": "2008",
+      },
+      "fictionNonfiction": {
+        "code": "FICTION",
+        "display": "skønlitteratur",
+      },
+      "genreAndForm": [
+        "noveller",
+      ],
+      "identifiers": [
+        {
+          "value": "9780230026810",
+        },
+        {
+          "value": "9780230026827",
+        },
+      ],
+      "languages": {
+        "main": [
+          {
+            "display": "engelsk",
+            "isoCode": "eng",
+          },
+        ],
+      },
+      "materialTypes": [
+        {
+          "specific": "lydoptagelse (cd)",
+        },
+        {
+          "specific": "bog",
+        },
+      ],
+      "physicalDescriptions": [
+        {
+          "numberOfPages": 95,
+          "playingTime": "2t., 31 min.",
+        },
+      ],
+      "pid": "870970-basis:44504928",
+      "publisher": [
+        "Macmillan",
+      ],
+      "shelfmark": {
+        "postfix": "Asimov",
+        "shelfmark": "83.8",
+      },
+      "source": [
+        "Bibliotekskatalog",
+      ],
+      "titles": {
+        "main": [
+          "I, Robot (Ved Tricia Reilly)",
+        ],
+        "original": [],
+      },
+      "workYear": {
+        "year": 1950,
+      },
+    },
+  ],
+}
+`;

--- a/src/apps/material/__vitest_data__/helper.ts
+++ b/src/apps/material/__vitest_data__/helper.ts
@@ -1,0 +1,353 @@
+import { Manifestation } from "../../../core/utils/types/entities";
+
+export default {
+  divideManifestationsByMaterialType: {
+    manifestations: [
+      {
+        pid: "870970-basis:44504928",
+        genreAndForm: ["noveller"],
+        source: ["Bibliotekskatalog"],
+        languages: {
+          main: [
+            {
+              display: "engelsk",
+              isoCode: "eng"
+            }
+          ]
+        },
+        titles: {
+          main: ["I, Robot (Ved Tricia Reilly)"],
+          original: []
+        },
+        fictionNonfiction: {
+          display: "skønlitteratur",
+          code: "FICTION"
+        },
+        materialTypes: [
+          {
+            specific: "lydoptagelse (cd)"
+          },
+          {
+            specific: "bog"
+          }
+        ],
+        creators: [
+          {
+            display: "Isaac Asimov",
+            __typename: "Person"
+          },
+          {
+            display: "Tricia Reilly",
+            __typename: "Person"
+          }
+        ],
+        publisher: ["Macmillan"],
+        identifiers: [
+          {
+            value: "9780230026810"
+          },
+          {
+            value: "9780230026827"
+          }
+        ],
+        contributors: [],
+        edition: {
+          summary: "2008",
+          publicationYear: {
+            display: "2008"
+          }
+        },
+        dateFirstEdition: {
+          display: "1950",
+          year: 1950
+        },
+        audience: {
+          generalAudience: []
+        },
+        physicalDescriptions: [
+          {
+            numberOfPages: 95,
+            playingTime: "2t., 31 min."
+          }
+        ],
+        accessTypes: [
+          {
+            code: "PHYSICAL"
+          }
+        ],
+        access: [
+          {
+            __typename: "InterLibraryLoan",
+            loanIsPossible: true
+          }
+        ],
+        shelfmark: {
+          postfix: "Asimov",
+          shelfmark: "83.8"
+        },
+        workYear: {
+          year: 1950
+        }
+      },
+      {
+        pid: "150061-ebog:ODN0000039136",
+        genreAndForm: [],
+        source: ["eReolen Global"],
+        languages: {
+          main: [
+            {
+              display: "engelsk",
+              isoCode: "eng"
+            }
+          ]
+        },
+        titles: {
+          main: ["I, Robot"],
+          original: []
+        },
+        fictionNonfiction: {
+          display: "skønlitteratur",
+          code: "FICTION"
+        },
+        materialTypes: [
+          {
+            specific: "e-bog"
+          }
+        ],
+        creators: [
+          {
+            display: "Isaac Asimov",
+            __typename: "Person"
+          }
+        ],
+        publisher: [],
+        identifiers: [
+          {
+            value: "9780553900330"
+          }
+        ],
+        contributors: [],
+        edition: {
+          summary: "2004",
+          publicationYear: {
+            display: "2004"
+          }
+        },
+        dateFirstEdition: null,
+        audience: {
+          generalAudience: [
+            "Text Difficulty 3 - Text Difficulty 5",
+            "UG/Upper grades (9th-12)",
+            "820. Lexile",
+            "6.1. ATOS Level"
+          ]
+        },
+        physicalDescriptions: [
+          {
+            numberOfPages: null,
+            playingTime: null
+          }
+        ],
+        accessTypes: [
+          {
+            code: "ONLINE"
+          }
+        ],
+        access: [
+          {
+            __typename: "AccessUrl",
+            origin: "link.overdrive.com",
+            url: "http://link.overdrive.com/?websiteID=100515&titleID=39136",
+            loginRequired: false
+          },
+          {
+            __typename: "AccessUrl",
+            origin: "samples.overdrive.com",
+            url: "https://samples.overdrive.com/?crid=9AB7D235-9D58-4180-8DF3-57A4A60CD51E&.epub-sample.overdrive.com",
+            loginRequired: false
+          },
+          {
+            __typename: "AccessUrl",
+            origin: "img1.od-cdn.com",
+            url: "https://img1.od-cdn.com/ImageType-100/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg100.jpg",
+            loginRequired: false
+          },
+          {
+            __typename: "AccessUrl",
+            origin: "img1.od-cdn.com",
+            url: "https://img1.od-cdn.com/ImageType-200/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg200.jpg",
+            loginRequired: false
+          }
+        ],
+        shelfmark: null,
+        workYear: null
+      },
+      {
+        pid: "150061-netlydbog:ODN0000105225",
+        genreAndForm: [],
+        source: ["eReolen Global"],
+        languages: {
+          main: [
+            {
+              display: "engelsk",
+              isoCode: "eng"
+            }
+          ]
+        },
+        titles: {
+          main: ["I, Robot"],
+          original: []
+        },
+        fictionNonfiction: {
+          display: "vides ikke",
+          code: "NOT_SPECIFIED"
+        },
+        materialTypes: [
+          {
+            specific: "lydbog (online)"
+          }
+        ],
+        creators: [
+          {
+            display: "Isaac Asimov",
+            __typename: "Person"
+          },
+          {
+            display: "Scott Brick",
+            __typename: "Person"
+          }
+        ],
+        publisher: ["Random House Audio"],
+        identifiers: [
+          {
+            value: "9780739346273"
+          }
+        ],
+        contributors: [],
+        edition: {
+          summary: "Unabridged, 2004",
+          publicationYear: {
+            display: "2004"
+          }
+        },
+        dateFirstEdition: null,
+        audience: {
+          generalAudience: [
+            "Text Difficulty 3 - Text Difficulty 4",
+            "820. Lexile"
+          ]
+        },
+        physicalDescriptions: [
+          {
+            numberOfPages: null,
+            playingTime: null
+          }
+        ],
+        accessTypes: [
+          {
+            code: "ONLINE"
+          }
+        ],
+        access: [
+          {
+            __typename: "AccessUrl",
+            origin: "link.overdrive.com",
+            url: "http://link.overdrive.com/?websiteID=100515&titleID=105225",
+            loginRequired: false
+          },
+          {
+            __typename: "AccessUrl",
+            origin: "samples.overdrive.com",
+            url: "https://samples.overdrive.com/?crid=A6AAE8CE-F944-44F3-960D-4E9A7715CDD5&.epub-sample.overdrive.com",
+            loginRequired: false
+          },
+          {
+            __typename: "AccessUrl",
+            origin: "img1.od-cdn.com",
+            url: "https://img1.od-cdn.com/ImageType-100/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg100.jpg",
+            loginRequired: false
+          },
+          {
+            __typename: "AccessUrl",
+            origin: "img1.od-cdn.com",
+            url: "https://img1.od-cdn.com/ImageType-200/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg200.jpg",
+            loginRequired: false
+          }
+        ],
+        shelfmark: null,
+        workYear: null
+      },
+      {
+        pid: "870970-basis:23798255",
+        genreAndForm: ["noveller"],
+        source: ["Bibliotekskatalog"],
+        languages: {
+          main: [
+            {
+              display: "engelsk",
+              isoCode: "eng"
+            }
+          ]
+        },
+        titles: {
+          main: ["I, Robot (Oxford bookworms library, ved Rowena Akinyemi)"],
+          original: []
+        },
+        fictionNonfiction: {
+          display: "skønlitteratur",
+          code: "FICTION"
+        },
+        materialTypes: [
+          {
+            specific: "bog"
+          }
+        ],
+        creators: [
+          {
+            display: "Isaac Asimov",
+            __typename: "Person"
+          }
+        ],
+        publisher: ["Oxford University Press"],
+        identifiers: [
+          {
+            value: "0-19-423069-4"
+          }
+        ],
+        contributors: [],
+        edition: {
+          summary: "2. edition, 2000",
+          publicationYear: {
+            display: "2000"
+          }
+        },
+        dateFirstEdition: null,
+        audience: {
+          generalAudience: []
+        },
+        physicalDescriptions: [
+          {
+            numberOfPages: 104,
+            playingTime: null
+          }
+        ],
+        accessTypes: [
+          {
+            code: "PHYSICAL"
+          }
+        ],
+        access: [
+          {
+            __typename: "InterLibraryLoan",
+            loanIsPossible: true
+          }
+        ],
+        shelfmark: {
+          postfix: "Asimov",
+          shelfmark: "83.8"
+        },
+        workYear: null
+      }
+    ] as Manifestation[]
+  }
+};

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -2,7 +2,6 @@ import { compact, groupBy, uniqBy, uniq, head } from "lodash";
 import { UseQueryOptions } from "react-query";
 import {
   constructModalId,
-  getMaterialTypes,
   getManifestationType,
   orderManifestationsByYear,
   flattenCreators
@@ -31,6 +30,7 @@ import {
   getHoldingsV3,
   useGetHoldingsV3
 } from "../../core/fbs/fbs";
+import vitestData from "./__vitest_data__/helper";
 
 export const getWorkManifestation = (
   work: Work,
@@ -313,10 +313,13 @@ export const divideManifestationsByMaterialType = (
   const dividedManifestationsArrays = uniqueMaterialTypes.map(
     (uniqueMaterialType) => {
       return manifestations.filter((manifest) => {
-        const manifestationMaterialTypes = manifest.materialTypes.map(
-          (materialType) => materialType.specific
+        // For some reason we sometimes have multiple material types
+        // we only want the first one.
+        // TODO: Double check with DDF that this is a viable solution.
+        return (
+          manifest.materialTypes.length &&
+          manifest.materialTypes[0].specific === uniqueMaterialType
         );
-        return manifestationMaterialTypes.includes(uniqueMaterialType);
       });
     }
   );
@@ -454,3 +457,20 @@ export const useGetHoldings = ({
   );
   return { data, isLoading, isError };
 };
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe("divideManifestationsByMaterialType", () => {
+    it("should divide manifestations by material type", () => {
+      const {
+        divideManifestationsByMaterialType: { manifestations }
+      } = vitestData;
+
+      const dividedManifestations =
+        divideManifestationsByMaterialType(manifestations);
+
+      expect(dividedManifestations).toMatchSnapshot();
+    });
+  });
+}

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -308,29 +308,25 @@ export const getInfomediaIds = (manifestations: Manifestation[]) => {
 
 export const divideManifestationsByMaterialType = (
   manifestations: Manifestation[]
-) => {
-  const uniqueMaterialTypes = getMaterialTypes(manifestations);
-  const dividedManifestationsArrays = uniqueMaterialTypes.map(
-    (uniqueMaterialType) => {
-      return manifestations.filter((manifest) => {
-        // For some reason we sometimes have multiple material types
-        // we only want the first one.
-        // TODO: Double check with DDF that this is a viable solution.
-        return (
-          manifest.materialTypes.length &&
-          manifest.materialTypes[0].specific === uniqueMaterialType
-        );
-      });
-    }
-  );
-  return dividedManifestationsArrays.reduce<{ [key: string]: Manifestation[] }>(
-    (result, current, index) => {
-      const materialType = uniqueMaterialTypes[index];
-      return { ...result, [materialType]: current };
+) =>
+  manifestations.reduce<{ [key: string]: Manifestation[] }>(
+    (result, manifestation) => {
+      if (
+        !manifestation.materialTypes.length ||
+        !manifestation.materialTypes[0].specific
+      ) {
+        return result;
+      }
+
+      // For some reason we sometimes have multiple material types
+      // we only want the first one.
+      // TODO: Double check with DDF that this is a viable solution.
+      const type = manifestation.materialTypes[0].specific;
+
+      return { ...result, [type]: [...(result[type] ?? []), manifestation] };
     },
     {}
   );
-};
 
 export const getAllIdentifiers = (manifestations: Manifestation[]) => {
   return manifestations

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -353,11 +353,30 @@ export const filterLoansSoonOverdue = (loans: LoanType[], warning: number) => {
   });
 };
 
-export const getMaterialTypes = (manifestations: Manifestation[]) => {
-  const allMaterialTypes = manifestations
-    .map((manifest) => manifest.materialTypes.map((type) => type.specific))
-    .flat();
-  return uniq(allMaterialTypes) as ManifestationMaterialType[];
+export const getMaterialTypes = (
+  manifestations: Manifestation[],
+  onlyFirstType = true
+) => {
+  // If the manifestation has several types we only are interested in the first one.
+  if (onlyFirstType) {
+    return uniq(
+      manifestations
+        .map((manifest) =>
+          manifest.materialTypes.map((type, i) =>
+            i === 0 ? type.specific : null
+          )
+        )
+        .flat()
+        .filter((type) => type !== null)
+    ) as ManifestationMaterialType[];
+  }
+
+  // In this case we aggreate all types even if a manifestation has multiple types.
+  return uniq(
+    manifestations
+      .map((manifest) => manifest.materialTypes.map((type) => type.specific))
+      .flat()
+  ) as ManifestationMaterialType[];
 };
 
 export const getManifestationType = (manifestations: Manifestation[]) => {
@@ -537,6 +556,31 @@ export default {};
 
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
+
+  describe("getMaterialTypes", () => {
+    const manifestations = [
+      {
+        materialTypes: [
+          {
+            specific: "artikel"
+          },
+          {
+            specific: "artikel (online)"
+          }
+        ]
+      }
+    ] as Manifestation[];
+
+    it("should be able to return only first entry material types from manifestations (default)", () => {
+      const types = getMaterialTypes(manifestations);
+      expect(types).toEqual(["artikel"]);
+    });
+
+    it("should be able to return all available material types from manifestations", () => {
+      const types = getMaterialTypes(manifestations, false);
+      expect(types).toEqual(["artikel", "artikel (online)"]);
+    });
+  });
 
   describe("constructModalId", () => {
     it("should create a modal id with hypens", () => {


### PR DESCRIPTION
We need to have ITK to confirm that we only look at the first material type on each manifestation in order to decide which type it is. We should not merge before it is confirmed.

#### Link to issue

https://reload.atlassian.net/browse/DSC-43

#### Description

    Fix weird availability-label click behaviour

    Solved by ignoring all other specific material types
    on manifestations except the first one.
    This behaviour has to be double checked with DDF.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
