### PR TITLE
5843: readd renew button, classes were set wrong

### DIFF
--- a/src/apps/loan-list/modal/renew-button.tsx
+++ b/src/apps/loan-list/modal/renew-button.tsx
@@ -48,13 +48,12 @@ const RenewButton: FC<RenewButtonProps> = ({
   );
 
   return (
-    <div className="modal-details__buttons">
+    <div className={`modal-details__buttons ${classNames}`}>
       <Button
         size="small"
         variant="filled"
         disabled={!renewable}
         onClick={() => renew(loanId)}
-        classNames={classNames}
         label={t("materialDetailsRenewLoanButtonText")}
         buttonType="none"
         collapsible={false}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5843

#### Description

- classes were set on button instead of outer div, it is now fixed

