### PR TITLE
Cleaning up getParams

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,12 @@
   "settings": {
     "react": {
       "version": "16.11.0"
-    }
+    },
+    // Since we use vitest alongside our production code we have to instruct eslint
+    // not to throw the import/no-extraneous-dependencies error when doing so.
+    "import/core-modules": [
+      "vitest"
+    ]
   },
   "env": {
     "browser": true,

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import dayjs from "dayjs";
 import { uniq } from "lodash";
+import { vi } from "vitest";
 import { CoverProps } from "../../../components/cover/cover";
 import { UseTextFunction } from "../text";
 import configuration, {
@@ -166,15 +167,16 @@ export const convertPostIdsToFaustIds = (postIds: Pid[]) => {
 
 // Get params if they are defined as props use those
 // otherwise try to fetch them from the url.
-export const getParams = <T, K extends keyof T>(props: T) => {
-  const params = {} as T;
-
-  Object.entries(props).forEach(([property, value]) => {
-    params[property as K] = value || (getUrlQueryParam(property) as string);
-  });
-
-  return params;
-};
+export const getParams = (props: Record<string, string | undefined>) =>
+  Object.entries(props).reduce<Record<string, string>>(
+    (acc, [property, value]) => {
+      return {
+        ...acc,
+        [property]: String(value || getUrlQueryParam(property))
+      };
+    },
+    {}
+  );
 
 export const sortByDueDate = (list: LoanType[]) => {
   // Todo figure out what to do if loan does not have loan date
@@ -543,6 +545,24 @@ if (import.meta.vitest) {
       expect(constructModalId("some-modal-id", ["one", "two"])).toBe(
         "some-modal-id-one-two"
       );
+    });
+  });
+
+  describe("getParams", () => {
+    it("should fill in with url params if property value is undefined", () => {
+      // We'll fake the url param getter to return a value.
+      // So when we request the url param, we'll get the value: "some-url-param-value"
+      vi.mock("./url", () => ({
+        getUrlQueryParam: vi
+          .fn()
+          .mockImplementation(() => "some-url-param-value")
+      }));
+
+      // We'll test the undefined value will be replaced with the url param equivalent.
+      expect(getParams({ "some-url-param": undefined, foo: "bar" })).toEqual({
+        "some-url-param": "some-url-param-value",
+        foo: "bar"
+      });
     });
   });
 }

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -537,6 +537,7 @@ export const getContributors = (short: boolean, creators: string[]) => {
 
 export default {};
 
+/* ********************************* Vitest Section  ********************************* */
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
 


### PR DESCRIPTION
#### Description

Got tired of ts warnings and thought [getParams](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/511/files#diff-a09d47a1eb335411b7f4c67799d5a4d59bac0b55e8dcf3d3142c99f86d309378L169-L177) could get more lean.
Also wrote a test for it.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
