### PR TITLE
5892: Added a formatdatetime for displaying the time aswell

### DIFF
--- a/src/apps/loan-list/utils/helpers.ts
+++ b/src/apps/loan-list/utils/helpers.ts
@@ -15,6 +15,9 @@ export const removeLoansWithDuplicateDueDate = (
 export const formatDate = (date: string) => {
   return dayjs(date).format("DD-MM-YYYY");
 };
+export const formatDateTime = (date: string) => {
+  return dayjs(date).format("DD-MM-YYYY HH:mm");
+};
 export const loansAreEmpty = (list: LoanType[] | null) =>
   Array.isArray(list) && list.length === 0;
 

--- a/src/apps/reservation-list/modal/reservation-details/digital-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/digital-list-details.tsx
@@ -4,7 +4,7 @@ import LoansIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icon
 import { useText } from "../../../../core/utils/text";
 import { ReservationType } from "../../../../core/utils/types/reservation-type";
 import { MaterialProps } from "../../../loan-list/materials/utils/material-fetch-hoc";
-import { formatDate } from "../../../loan-list/utils/helpers";
+import { formatDateTime } from "../../../loan-list/utils/helpers";
 import ListDetails from "../../../../components/list-details/list-details";
 
 export interface DigitalListDetailsProps {
@@ -25,7 +25,7 @@ const DigitalListDetails: FC<DigitalListDetailsProps & MaterialProps> = ({
           icon={ReservationsIcon}
           title={t("reservationDetailsStatusTitleText")}
           labels={t("reservationDetailsExpiresText", {
-            placeholders: { "@date": formatDate(expiryDate) }
+            placeholders: { "@date": formatDateTime(expiryDate) }
           })}
         />
       )}
@@ -34,14 +34,14 @@ const DigitalListDetails: FC<DigitalListDetailsProps & MaterialProps> = ({
           icon={ReservationsIcon}
           title={t("reservationDetailsStatusTitleText")}
           labels={t("reservationDetailsBorrowBeforeText", {
-            placeholders: { "@date": formatDate(pickupDeadline) }
+            placeholders: { "@date": formatDateTime(pickupDeadline) }
           })}
         />
       )}
       {dateOfReservation && (
         <ListDetails
           icon={LoansIcon}
-          labels={formatDate(dateOfReservation)}
+          labels={formatDateTime(dateOfReservation)}
           title={t("reservationDetailsDateOfReservationTitleText")}
         />
       )}

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -213,7 +213,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023 23:37!");
+      .should("have.text", "Your reservation expires 27-01-2023 22:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.get(".modal-details__list")
@@ -328,7 +328,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Borrow before 27-01-2023 23:37");
+      .should("have.text", "Borrow before 27-01-2023 22:37");
   });
 
   it("It shows physical reservation details modal", () => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -213,7 +213,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023 20:37!");
+      .should("have.text", "Your reservation expires 27-01-2023 19:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.get(".modal-details__list")

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -213,7 +213,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023!");
+      .should("have.text", "Your reservation expires 27-01-2023 20:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.get(".modal-details__list")
@@ -227,7 +227,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(1)
       .find(".text-small-caption")
-      .should("have.text", "16-08-2022");
+      .should("have.text", "16-08-2022 12:52");
   });
 
   it("It shows digital reservation details modal, material queued", () => {
@@ -328,7 +328,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Borrow before 27-01-2023");
+      .should("have.text", "Borrow before 27-01-2023 20:37");
   });
 
   it("It shows physical reservation details modal", () => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -85,8 +85,8 @@ describe("Reservation details modal test", () => {
             createdDateUtc: "2022-08-16T10:52:39.932Z",
             status: 2,
             productTitle: "Bargums synder",
-            expireDateUtc: "2023-01-27T21:37:15.63Z",
-            expectedRedeemDateUtc: "2023-01-27T21:37:15.63Z"
+            expireDateUtc: "2023-01-27T22:37:15.63Z",
+            expectedRedeemDateUtc: "2023-01-27T22:37:15.63Z"
           }
         ],
         code: 101,
@@ -213,7 +213,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023 22:37!");
+      .should("have.text", "Your reservation expires 27-01-2023 23:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.get(".modal-details__list")
@@ -261,8 +261,8 @@ describe("Reservation details modal test", () => {
             createdDateUtc: "2022-08-16T12:52:39.932Z",
             status: 1,
             productTitle: "Bargums synder",
-            expireDateUtc: "2023-01-27T21:37:15.63Z",
-            expectedRedeemDateUtc: "2023-01-27T21:37:15.63Z"
+            expireDateUtc: "2023-01-27T22:37:15.63Z",
+            expectedRedeemDateUtc: "2023-01-27T22:37:15.63Z"
           }
         ],
         code: 101,
@@ -328,7 +328,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Borrow before 27-01-2023 22:37");
+      .should("have.text", "Borrow before 27-01-2023 23:37");
   });
 
   it("It shows physical reservation details modal", () => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -85,8 +85,8 @@ describe("Reservation details modal test", () => {
             createdDateUtc: "2022-08-16T10:52:39.932Z",
             status: 2,
             productTitle: "Bargums synder",
-            expireDateUtc: "2023-01-27T22:37:15.63Z",
-            expectedRedeemDateUtc: "2023-01-27T22:37:15.63Z"
+            expireDateUtc: "2023-01-27T21:37:15.63Z",
+            expectedRedeemDateUtc: "2023-01-27T21:37:15.63Z"
           }
         ],
         code: 101,
@@ -213,7 +213,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023 23:37!");
+      .should("have.text", "Your reservation expires 27-01-2023 22:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.get(".modal-details__list")

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -227,7 +227,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(1)
       .find(".text-small-caption")
-      .should("have.text", "16-08-2022 12:52");
+      .should("have.text", "16-08-2022 10:52");
   });
 
   it("It shows digital reservation details modal, material queued", () => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -85,8 +85,8 @@ describe("Reservation details modal test", () => {
             createdDateUtc: "2022-08-16T10:52:39.932Z",
             status: 2,
             productTitle: "Bargums synder",
-            expireDateUtc: "2023-01-27T19:37:15.63Z",
-            expectedRedeemDateUtc: "2023-01-27T19:37:15.63Z"
+            expireDateUtc: "2023-01-27T22:37:15.63Z",
+            expectedRedeemDateUtc: "2023-01-27T22:37:15.63Z"
           }
         ],
         code: 101,
@@ -213,7 +213,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023 19:37!");
+      .should("have.text", "Your reservation expires 27-01-2023 23:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.get(".modal-details__list")
@@ -258,11 +258,11 @@ describe("Reservation details modal test", () => {
           {
             productId: "0ddd10d0-d69f-4734-8a27-ac4546f4b912",
             identifier: "9788740047905",
-            createdDateUtc: "2022-08-16T10:52:39.932Z",
+            createdDateUtc: "2022-08-16T12:52:39.932Z",
             status: 1,
             productTitle: "Bargums synder",
-            expireDateUtc: "2023-01-27T19:37:15.63Z",
-            expectedRedeemDateUtc: "2023-01-27T19:37:15.63Z"
+            expireDateUtc: "2023-01-27T21:37:15.63Z",
+            expectedRedeemDateUtc: "2023-01-27T21:37:15.63Z"
           }
         ],
         code: 101,
@@ -328,7 +328,7 @@ describe("Reservation details modal test", () => {
       .find(".list-details")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Borrow before 27-01-2023 20:37");
+      .should("have.text", "Borrow before 27-01-2023 22:37");
   });
 
   it("It shows physical reservation details modal", () => {
@@ -570,8 +570,8 @@ describe("Reservation details modal test", () => {
             createdDateUtc: "2022-08-16T10:52:39.932Z",
             status: 1,
             productTitle: "Bargums synder",
-            expireDateUtc: "2023-01-27T19:37:15.63Z",
-            expectedRedeemDateUtc: "2023-01-27T19:37:15.63Z"
+            expireDateUtc: "2023-01-27T22:37:15.63Z",
+            expectedRedeemDateUtc: "2023-01-27T22:37:15.63Z"
           }
         ],
         code: 101,


### PR DESCRIPTION
#### Link to issue

[Please add a link to the issue being addressed by this change.](https://platform.dandigbib.org/issues/5892)

#### Description

Reservation expiration time until now only shown as date. This PR introduces the time as well.

#### Screenshot of the result

<img width="1794" alt="Screenshot 2023-08-09 at 09 31 46" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/106669866/4a032340-a166-4f8c-aa16-70b0b6e57e34">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
