### PR TITLE
Make availability label texts translatable

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -50,7 +50,7 @@ Cypress.Commands.add(
     fixtureFilePath,
     statusCode = 200
   }: InterceptGraphqlParams) => {
-    cy.intercept("POST", "**/opac/graphql", (req) => {
+    cy.intercept("POST", "**/next/graphql", (req) => {
       if (hasOperationName(req, operationName)) {
         if (fixtureFilePath) {
           req.reply({ fixture: fixtureFilePath, statusCode });

--- a/graphql.config.json
+++ b/graphql.config.json
@@ -4,7 +4,7 @@
   "extensions": {
     "endpoints": {
       "Default GraphQL Endpoint": {
-        "url": "https://next-prototype-gateway.dbc.dk/775100/opac/graphql"
+        "url": "https://next-prototype-gateway.dbc.dk/775100/next/graphql"
       }
     }
   }

--- a/src/apps/dashboard/dashboard.test.tsx
+++ b/src/apps/dashboard/dashboard.test.tsx
@@ -281,7 +281,7 @@ describe("Dashboard", () => {
       }
     ).as("reservations");
 
-    cy.intercept("POST", "**/opac/**", {
+    cy.intercept("POST", "**/next/**", {
       statusCode: 200,
       body: {
         data: {

--- a/src/apps/favorites-list/favorites-list.test.ts
+++ b/src/apps/favorites-list/favorites-list.test.ts
@@ -30,7 +30,7 @@ describe("Favorites list", () => {
     });
 
     cy.interceptRest({
-      url: "**/opac/**",
+      url: "**/next/**",
       httpMethod: "POST",
       fixtureFilePath: "favorites-list/work.json",
       aliasName: "work"

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -84,7 +84,7 @@ describe("Fee list", () => {
       ]
     }).as("fees");
 
-    cy.intercept("POST", "**/opac/**", {
+    cy.intercept("POST", "**/next/**", {
       statusCode: 200,
       body: {
         data: {

--- a/src/apps/loan-list/list/loan-list.test.ts
+++ b/src/apps/loan-list/list/loan-list.test.ts
@@ -168,7 +168,7 @@ describe("Loan list", () => {
       })
       .as("cover");
 
-    cy.intercept("POST", "**/opac/**", {
+    cy.intercept("POST", "**/next/**", {
       statusCode: 200,
       body: {
         data: {

--- a/src/apps/loan-list/modal/modals.test.tsx
+++ b/src/apps/loan-list/modal/modals.test.tsx
@@ -39,7 +39,7 @@ describe("Modals", () => {
       ]
     }).as("loans");
 
-    cy.intercept("POST", "**/opac/**", {
+    cy.intercept("POST", "**/next/**", {
       statusCode: 200,
       body: {
         data: {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -52,6 +52,16 @@ export default {
         '[\n   {\n      "branchId":"DK-775120",\n      "title":"Højbjerg"\n   },\n   {\n      "branchId":"DK-775122",\n      "title":"Beder-Malling"\n   },\n   {\n      "branchId":"DK-775144",\n      "title":"Gellerup"\n   },\n   {\n      "branchId":"DK-775167",\n      "title":"Lystrup"\n   },\n   {\n      "branchId":"DK-775146",\n      "title":"Harlev"\n   },\n   {\n      "branchId":"DK-775168",\n      "title":"Skødstrup"\n   },\n   {\n      "branchId":"FBS-751010",\n      "title":"Arresten"\n   },\n   {\n      "branchId":"DK-775147",\n      "title":"Hasle"\n   },\n   {\n      "branchId":"FBS-751032",\n      "title":"Må ikke benyttes"\n   },\n   {\n      "branchId":"FBS-751031",\n      "title":"Fjernlager 1"\n   },\n   {\n      "branchId":"DK-775126",\n      "title":"Solbjerg"\n   },\n   {\n      "branchId":"FBS-751030",\n      "title":"ITK"\n   },\n   {\n      "branchId":"DK-775149",\n      "title":"Sabro"\n   },\n   {\n      "branchId":"DK-775127",\n      "title":"Tranbjerg"\n   },\n   {\n      "branchId":"DK-775160",\n      "title":"Risskov"\n   },\n   {\n      "branchId":"DK-775162",\n      "title":"Hjortshøj"\n   },\n   {\n      "branchId":"DK-775140",\n      "title":"Åby"\n   },\n   {\n      "branchId":"FBS-751009",\n      "title":"Fjernlager 2"\n   },\n   {\n      "branchId":"FBS-751029",\n      "title":"Stadsarkivet"\n   },\n   {\n      "branchId":"FBS-751027",\n      "title":"Intern"\n   },\n   {\n      "branchId":"FBS-751026",\n      "title":"Fælles undervejs"\n   },\n   {\n      "branchId":"FBS-751025",\n      "title":"Fællessekretariatet"\n   },\n   {\n      "branchId":"DK-775133",\n      "title":"Bavnehøj"\n   },\n   {\n      "branchId":"FBS-751024",\n      "title":"Fjernlånte materialer"\n   },\n   {\n      "branchId":"DK-775100",\n      "title":"Hovedbiblioteket"\n   },\n   {\n      "branchId":"DK-775170",\n      "title":"Trige"\n   },\n   {\n      "branchId":"DK-775150",\n      "title":"Tilst"\n   },\n   {\n      "branchId":"DK-775130",\n      "title":"Viby"\n   },\n   {\n      "branchId":"DK-775164",\n      "title":"Egå"\n   }\n]',
       control: { type: "text" }
     },
+    availabilityAvailableText: {
+      name: "Availability: available text",
+      defaultValue: "Available",
+      control: { type: "text" }
+    },
+    availabilityUnavailableText: {
+      name: "Availability: unavailable text",
+      defaultValue: "Unavailable",
+      control: { type: "text" }
+    },
     materialHeaderAllEditionsText: {
       name: "Text for the fiction edition text",
       defaultValue: "All editions",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -13,6 +13,8 @@ interface MaterialEntryTextProps {
   alertErrorMessageText: string;
   alreadyReservedText: string;
   approveReservationText: string;
+  availabilityAvailableText: string;
+  availabilityUnavailableText: string;
   blockedButtonText: string;
   cantReserveText: string;
   cantViewText: string;

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -92,7 +92,7 @@ describe("Material", () => {
       .should("have.length", 1);
   });
 
-  it("Shows the book availability as unavailable", () => {
+  it("Shows the book availability as available", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -107,7 +107,7 @@ describe("Material", () => {
       .contains("bog")
       .parent()
       .find('[data-cy="availability-label-status"]')
-      .should("have.text", "unavailable");
+      .should("have.text", "Available");
   });
 
   it("Can open material details", () => {

--- a/src/apps/reservation-list/list/reservation-list-pagination.test.ts
+++ b/src/apps/reservation-list/list/reservation-list-pagination.test.ts
@@ -288,7 +288,7 @@ describe("Reservation list pagination", () => {
       }
     }).as("digital_reservations");
 
-    cy.intercept("POST", "**/opac/**", {
+    cy.intercept("POST", "**/next/**", {
       statusCode: 200,
       body: {
         data: {

--- a/src/apps/reservation-list/list/reservation-list.test.ts
+++ b/src/apps/reservation-list/list/reservation-list.test.ts
@@ -13,7 +13,7 @@ describe("Reservation list", () => {
     cy.interceptRest({
       aliasName: "work",
       httpMethod: "POST",
-      url: "**/opac/**",
+      url: "**/next/**",
       fixtureFilePath: "reservation-list/work.json"
     });
 

--- a/src/apps/reservation-list/modal/delete-reservation/delete-reservation.test.ts
+++ b/src/apps/reservation-list/modal/delete-reservation/delete-reservation.test.ts
@@ -155,7 +155,7 @@ describe("Delete reservation modal test", () => {
       ]
     });
 
-    cy.intercept("POST", "**/opac/**", {
+    cy.intercept("POST", "**/next/**", {
       statusCode: 200,
       body: {
         data: {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -355,7 +355,7 @@ describe("Reservation details modal test", () => {
     cy.interceptRest({
       aliasName: "work",
       httpMethod: "POST",
-      url: "**/opac/**",
+      url: "**/next/**",
       fixtureFilePath: "reservation-list/work.json"
     });
 
@@ -603,7 +603,7 @@ describe("Reservation details modal test", () => {
     cy.interceptRest({
       aliasName: "work",
       httpMethod: "POST",
-      url: "**/opac/**",
+      url: "**/next/**",
       fixtureFilePath: "reservation-list/work.json"
     });
 

--- a/src/apps/search-header/search-header.test.ts
+++ b/src/apps/search-header/search-header.test.ts
@@ -4,7 +4,7 @@ describe("Search header app", () => {
   beforeEach(() => {
     cy.fixture("search-header-data.json")
       .then((result) => {
-        cy.intercept("POST", "**/opac/graphql", {
+        cy.intercept("POST", "**/next/graphql", {
           statusCode: 200,
           body: result
         });

--- a/src/apps/search-result/search-result.test.ts
+++ b/src/apps/search-result/search-result.test.ts
@@ -100,7 +100,7 @@ describe("Search Result", () => {
     // Intercept graphql search query.
     cy.fixture("search-result/fbi-api.json")
       .then((result) => {
-        cy.intercept("POST", "**/opac/graphql**", result);
+        cy.intercept("POST", "**/next/graphql**", result);
       })
       .as("Graphql search query");
     // Intercept all images from Cloudinary.

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -47,7 +47,9 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     isbn: isbns ? isbns[0] : null
   });
 
-  const availabilityText = isAvailable ? t("available") : t("unavailable");
+  const availabilityText = isAvailable
+    ? t("availabilityAvailableText")
+    : t("availabilityUnavailableText");
 
   useDeepCompareEffect(() => {
     // Track material availability (status) if the button is active - also meaning

--- a/src/core/storybook/serviceUrlArgs.ts
+++ b/src/core/storybook/serviceUrlArgs.ts
@@ -28,7 +28,7 @@ export default {
   },
   [serviceUrlKeys.fbi]: {
     name: "Base url for the FBI API",
-    defaultValue: "https://fbi-api.dbc.dk/opac/graphql",
+    defaultValue: "https://fbi-api.dbc.dk/next/graphql",
     control: { type: "text" }
   }
 };


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFDPDEL-216

#### Description

The definition of the availability texts where defined halfways. This PR names them with a "availability" prefix that makes it clear what the purpose of the strings are. The [PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/381) in the dpl-cms repository will make sure that these strings are added as well.


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
