### PR TITLE
Skip release workflow for Dependabot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Upload Release Asset
 
 on:
-  push
+  push:
+    branches-ignore:
+      # Dependabot does not have permissions to create releases
+      - 'dependabot/**'
 
 jobs:
   build:


### PR DESCRIPTION
#### Description

Dependabot does not have permissions to create releases. This causes the workflow to fail when running ghr with the following error:

Failed to create GitHub release page: failed to create a release: POST https://api.github.com/repos/danskernesdigitalebibliotek/dpl-react/releases: 403 Resource not accessible by integration []

According to GitHub having Dependabot run with read-only scopes is intentional and the recommended approach is to skip running such  workflows based on branch naming:
https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/resource-not-accessible-by-integration

#### Screenshot of the result

Before:

<img width="1992" alt="dpl-react@dca6122 2023-09-20 16-45-37" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/73966/2f1716d7-cd5d-4d7b-ab9d-d205534ee098">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
