### PR TITLE
Refactor `handleDropdownOnchange` in `FacetLineFilters`

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -46,6 +46,7 @@ const Dropdown: React.FunctionComponent<DropdownProps> = ({
 
   const checkHandleOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (handleOnChange && e.target.value) handleOnChange(e);
+    console.log("No handleOnChange function passed to Dropdown");
     return undefined;
   };
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -45,8 +45,9 @@ const Dropdown: React.FunctionComponent<DropdownProps> = ({
   };
 
   const checkHandleOnChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (handleOnChange && e.target.value) handleOnChange(e);
-    console.log("No handleOnChange function passed to Dropdown");
+    if (handleOnChange && e.target.value) {
+      handleOnChange(e);
+    }
     return undefined;
   };
 

--- a/src/components/facet-browser/__snapshots__/helper.ts.snap
+++ b/src/components/facet-browser/__snapshots__/helper.ts.snap
@@ -2,193 +2,136 @@
 
 exports[`createFacetsMap 1`] = `
 {
-  "fictionalCharacters:Batman": [
-    {
-      "key": "Batman",
-      "score": 4,
-      "term": "Batman",
-    },
-  ],
-  "fictionalCharacters:Harry Potter": [
-    {
-      "key": "Harry Potter",
-      "score": 3,
-      "term": "Harry Potter",
-    },
-  ],
-  "fictionalCharacters:Hermione Granger": [
-    {
-      "key": "Hermione Granger",
-      "score": 3,
-      "term": "Hermione Granger",
-    },
-  ],
-  "fictionalCharacters:Justice League": [
-    {
-      "key": "Justice League",
-      "score": 4,
-      "term": "Justice League",
-    },
-  ],
-  "fictionalCharacters:Ron Weasley": [
-    {
-      "key": "Ron Weasley",
-      "score": 3,
-      "term": "Ron Weasley",
-    },
-  ],
-  "mainLanguages:dan": [
-    {
-      "key": "dan",
-      "score": 427,
-      "term": "Dansk",
-    },
-  ],
-  "mainLanguages:eng": [
-    {
-      "key": "eng",
-      "score": 82,
-      "term": "Engelsk",
-    },
-  ],
-  "mainLanguages:fre": [
-    {
-      "key": "fre",
-      "score": 9,
-      "term": "Fransk",
-    },
-  ],
-  "mainLanguages:ger": [
-    {
-      "key": "ger",
-      "score": 9,
-      "term": "Tysk",
-    },
-  ],
-  "mainLanguages:ita": [
-    {
-      "key": "ita",
-      "score": 9,
-      "term": "Italiensk",
-    },
-  ],
-  "materialTypesGeneral:abekat": [
-    {
-      "key": "abekat",
-      "score": 0,
-      "term": "abekat",
-    },
-  ],
-  "materialTypesGeneral:artikler": [
-    {
-      "key": "artikler",
-      "score": 346,
-      "term": "artikler",
-    },
-  ],
-  "materialTypesGeneral:bøger": [
-    {
-      "key": "bøger",
-      "score": 74,
-      "term": "bøger",
-    },
-  ],
-  "materialTypesGeneral:computerspil": [
-    {
-      "key": "computerspil",
-      "score": 26,
-      "term": "computerspil",
-    },
-    {
-      "key": "computerspil",
-      "score": 26,
-      "term": "computerspil",
-    },
-  ],
-  "materialTypesGeneral:e-bøger": [
-    {
-      "key": "e-bøger",
-      "score": 38,
-      "term": "e-bøger",
-    },
-  ],
-  "materialTypesGeneral:film": [
-    {
-      "key": "film",
-      "score": 9,
-      "term": "film",
-    },
-  ],
-  "subjects:legetøj": [
-    {
-      "key": "legetøj",
-      "score": 165,
-      "term": "legetøj",
-    },
-  ],
-  "subjects:legetøjsindustri": [
-    {
-      "key": "legetøjsindustri",
-      "score": 126,
-      "term": "legetøjsindustri",
-    },
-  ],
-  "subjects:lego": [
-    {
-      "key": "lego",
-      "score": 101,
-      "term": "lego",
-    },
-  ],
-  "subjects:legoklodser": [
-    {
-      "key": "legoklodser",
-      "score": 98,
-      "term": "legoklodser",
-    },
-  ],
-  "subjects:virksomhedsledelse": [
-    {
-      "key": "virksomhedsledelse",
-      "score": 65,
-      "term": "virksomhedsledelse",
-    },
-  ],
-  "year:2013": [
-    {
-      "key": "2013",
-      "score": 27,
-      "term": "2013",
-    },
-  ],
-  "year:2014": [
-    {
-      "key": "2014",
-      "score": 31,
-      "term": "2014",
-    },
-  ],
-  "year:2015": [
-    {
-      "key": "2015",
-      "score": 33,
-      "term": "2015",
-    },
-  ],
-  "year:2017": [
-    {
-      "key": "2017",
-      "score": 35,
-      "term": "2017",
-    },
-  ],
-  "year:2018": [
-    {
-      "key": "2018",
-      "score": 29,
-      "term": "2018",
-    },
-  ],
+  "fictionalCharacters:Batman": {
+    "key": "Batman",
+    "score": 4,
+    "term": "Batman",
+  },
+  "fictionalCharacters:Harry Potter": {
+    "key": "Harry Potter",
+    "score": 3,
+    "term": "Harry Potter",
+  },
+  "fictionalCharacters:Hermione Granger": {
+    "key": "Hermione Granger",
+    "score": 3,
+    "term": "Hermione Granger",
+  },
+  "fictionalCharacters:Justice League": {
+    "key": "Justice League",
+    "score": 4,
+    "term": "Justice League",
+  },
+  "fictionalCharacters:Ron Weasley": {
+    "key": "Ron Weasley",
+    "score": 3,
+    "term": "Ron Weasley",
+  },
+  "mainLanguages:dan": {
+    "key": "dan",
+    "score": 427,
+    "term": "Dansk",
+  },
+  "mainLanguages:eng": {
+    "key": "eng",
+    "score": 82,
+    "term": "Engelsk",
+  },
+  "mainLanguages:fre": {
+    "key": "fre",
+    "score": 9,
+    "term": "Fransk",
+  },
+  "mainLanguages:ger": {
+    "key": "ger",
+    "score": 9,
+    "term": "Tysk",
+  },
+  "mainLanguages:ita": {
+    "key": "ita",
+    "score": 9,
+    "term": "Italiensk",
+  },
+  "materialTypesGeneral:abekat": {
+    "key": "abekat",
+    "score": 0,
+    "term": "abekat",
+  },
+  "materialTypesGeneral:artikler": {
+    "key": "artikler",
+    "score": 346,
+    "term": "artikler",
+  },
+  "materialTypesGeneral:bøger": {
+    "key": "bøger",
+    "score": 74,
+    "term": "bøger",
+  },
+  "materialTypesGeneral:computerspil": {
+    "key": "computerspil",
+    "score": 26,
+    "term": "computerspil",
+  },
+  "materialTypesGeneral:e-bøger": {
+    "key": "e-bøger",
+    "score": 38,
+    "term": "e-bøger",
+  },
+  "materialTypesGeneral:film": {
+    "key": "film",
+    "score": 9,
+    "term": "film",
+  },
+  "subjects:legetøj": {
+    "key": "legetøj",
+    "score": 165,
+    "term": "legetøj",
+  },
+  "subjects:legetøjsindustri": {
+    "key": "legetøjsindustri",
+    "score": 126,
+    "term": "legetøjsindustri",
+  },
+  "subjects:lego": {
+    "key": "lego",
+    "score": 101,
+    "term": "lego",
+  },
+  "subjects:legoklodser": {
+    "key": "legoklodser",
+    "score": 98,
+    "term": "legoklodser",
+  },
+  "subjects:virksomhedsledelse": {
+    "key": "virksomhedsledelse",
+    "score": 65,
+    "term": "virksomhedsledelse",
+  },
+  "year:2013": {
+    "key": "2013",
+    "score": 27,
+    "term": "2013",
+  },
+  "year:2014": {
+    "key": "2014",
+    "score": 31,
+    "term": "2014",
+  },
+  "year:2015": {
+    "key": "2015",
+    "score": 33,
+    "term": "2015",
+  },
+  "year:2017": {
+    "key": "2017",
+    "score": 35,
+    "term": "2017",
+  },
+  "year:2018": {
+    "key": "2018",
+    "score": 29,
+    "term": "2018",
+  },
 }
 `;
 

--- a/src/components/facet-browser/__snapshots__/helper.ts.snap
+++ b/src/components/facet-browser/__snapshots__/helper.ts.snap
@@ -1,5 +1,197 @@
 // Vitest Snapshot v1
 
+exports[`createFacetsMap 1`] = `
+{
+  "fictionalCharacters:Batman": [
+    {
+      "key": "Batman",
+      "score": 4,
+      "term": "Batman",
+    },
+  ],
+  "fictionalCharacters:Harry Potter": [
+    {
+      "key": "Harry Potter",
+      "score": 3,
+      "term": "Harry Potter",
+    },
+  ],
+  "fictionalCharacters:Hermione Granger": [
+    {
+      "key": "Hermione Granger",
+      "score": 3,
+      "term": "Hermione Granger",
+    },
+  ],
+  "fictionalCharacters:Justice League": [
+    {
+      "key": "Justice League",
+      "score": 4,
+      "term": "Justice League",
+    },
+  ],
+  "fictionalCharacters:Ron Weasley": [
+    {
+      "key": "Ron Weasley",
+      "score": 3,
+      "term": "Ron Weasley",
+    },
+  ],
+  "mainLanguages:dan": [
+    {
+      "key": "dan",
+      "score": 427,
+      "term": "Dansk",
+    },
+  ],
+  "mainLanguages:eng": [
+    {
+      "key": "eng",
+      "score": 82,
+      "term": "Engelsk",
+    },
+  ],
+  "mainLanguages:fre": [
+    {
+      "key": "fre",
+      "score": 9,
+      "term": "Fransk",
+    },
+  ],
+  "mainLanguages:ger": [
+    {
+      "key": "ger",
+      "score": 9,
+      "term": "Tysk",
+    },
+  ],
+  "mainLanguages:ita": [
+    {
+      "key": "ita",
+      "score": 9,
+      "term": "Italiensk",
+    },
+  ],
+  "materialTypesGeneral:abekat": [
+    {
+      "key": "abekat",
+      "score": 0,
+      "term": "abekat",
+    },
+  ],
+  "materialTypesGeneral:artikler": [
+    {
+      "key": "artikler",
+      "score": 346,
+      "term": "artikler",
+    },
+  ],
+  "materialTypesGeneral:bøger": [
+    {
+      "key": "bøger",
+      "score": 74,
+      "term": "bøger",
+    },
+  ],
+  "materialTypesGeneral:computerspil": [
+    {
+      "key": "computerspil",
+      "score": 26,
+      "term": "computerspil",
+    },
+    {
+      "key": "computerspil",
+      "score": 26,
+      "term": "computerspil",
+    },
+  ],
+  "materialTypesGeneral:e-bøger": [
+    {
+      "key": "e-bøger",
+      "score": 38,
+      "term": "e-bøger",
+    },
+  ],
+  "materialTypesGeneral:film": [
+    {
+      "key": "film",
+      "score": 9,
+      "term": "film",
+    },
+  ],
+  "subjects:legetøj": [
+    {
+      "key": "legetøj",
+      "score": 165,
+      "term": "legetøj",
+    },
+  ],
+  "subjects:legetøjsindustri": [
+    {
+      "key": "legetøjsindustri",
+      "score": 126,
+      "term": "legetøjsindustri",
+    },
+  ],
+  "subjects:lego": [
+    {
+      "key": "lego",
+      "score": 101,
+      "term": "lego",
+    },
+  ],
+  "subjects:legoklodser": [
+    {
+      "key": "legoklodser",
+      "score": 98,
+      "term": "legoklodser",
+    },
+  ],
+  "subjects:virksomhedsledelse": [
+    {
+      "key": "virksomhedsledelse",
+      "score": 65,
+      "term": "virksomhedsledelse",
+    },
+  ],
+  "year:2013": [
+    {
+      "key": "2013",
+      "score": 27,
+      "term": "2013",
+    },
+  ],
+  "year:2014": [
+    {
+      "key": "2014",
+      "score": 31,
+      "term": "2014",
+    },
+  ],
+  "year:2015": [
+    {
+      "key": "2015",
+      "score": 33,
+      "term": "2015",
+    },
+  ],
+  "year:2017": [
+    {
+      "key": "2017",
+      "score": 35,
+      "term": "2017",
+    },
+  ],
+  "year:2018": [
+    {
+      "key": "2018",
+      "score": 29,
+      "term": "2018",
+    },
+  ],
+}
+`;
+
 exports[`createFilters > should create filters 1`] = `
 {
   "accessTypes": [

--- a/src/components/facet-browser/__snapshots__/helper.ts.snap
+++ b/src/components/facet-browser/__snapshots__/helper.ts.snap
@@ -2,31 +2,6 @@
 
 exports[`createFacetsMap 1`] = `
 {
-  "fictionalCharacters:Batman": {
-    "key": "Batman",
-    "score": 4,
-    "term": "Batman",
-  },
-  "fictionalCharacters:Harry Potter": {
-    "key": "Harry Potter",
-    "score": 3,
-    "term": "Harry Potter",
-  },
-  "fictionalCharacters:Hermione Granger": {
-    "key": "Hermione Granger",
-    "score": 3,
-    "term": "Hermione Granger",
-  },
-  "fictionalCharacters:Justice League": {
-    "key": "Justice League",
-    "score": 4,
-    "term": "Justice League",
-  },
-  "fictionalCharacters:Ron Weasley": {
-    "key": "Ron Weasley",
-    "score": 3,
-    "term": "Ron Weasley",
-  },
   "mainLanguages:dan": {
     "key": "dan",
     "score": 427,
@@ -36,26 +11,6 @@ exports[`createFacetsMap 1`] = `
     "key": "eng",
     "score": 82,
     "term": "Engelsk",
-  },
-  "mainLanguages:fre": {
-    "key": "fre",
-    "score": 9,
-    "term": "Fransk",
-  },
-  "mainLanguages:ger": {
-    "key": "ger",
-    "score": 9,
-    "term": "Tysk",
-  },
-  "mainLanguages:ita": {
-    "key": "ita",
-    "score": 9,
-    "term": "Italiensk",
-  },
-  "materialTypesGeneral:abekat": {
-    "key": "abekat",
-    "score": 0,
-    "term": "abekat",
   },
   "materialTypesGeneral:artikler": {
     "key": "artikler",
@@ -81,56 +36,6 @@ exports[`createFacetsMap 1`] = `
     "key": "film",
     "score": 9,
     "term": "film",
-  },
-  "subjects:legetøj": {
-    "key": "legetøj",
-    "score": 165,
-    "term": "legetøj",
-  },
-  "subjects:legetøjsindustri": {
-    "key": "legetøjsindustri",
-    "score": 126,
-    "term": "legetøjsindustri",
-  },
-  "subjects:lego": {
-    "key": "lego",
-    "score": 101,
-    "term": "lego",
-  },
-  "subjects:legoklodser": {
-    "key": "legoklodser",
-    "score": 98,
-    "term": "legoklodser",
-  },
-  "subjects:virksomhedsledelse": {
-    "key": "virksomhedsledelse",
-    "score": 65,
-    "term": "virksomhedsledelse",
-  },
-  "year:2013": {
-    "key": "2013",
-    "score": 27,
-    "term": "2013",
-  },
-  "year:2014": {
-    "key": "2014",
-    "score": 31,
-    "term": "2014",
-  },
-  "year:2015": {
-    "key": "2015",
-    "score": 33,
-    "term": "2015",
-  },
-  "year:2017": {
-    "key": "2017",
-    "score": 35,
-    "term": "2017",
-  },
-  "year:2018": {
-    "key": "2018",
-    "score": 29,
-    "term": "2018",
   },
 }
 `;

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -134,26 +134,31 @@ export const getFacetFieldTranslation = (name: FacetField) => {
   }
 };
 
+type FacetMap = { [key: string]: FacetValue };
 // createFacetsMap generates a map for quick lookup and enhanced search
 // capabilities by combining facet name and term into a single string key.
 // Structure: { [facetName:termKey]: FacetValue }
 // Example Key: 'fictionalCharacters:Batman'
-export const createFacetsMap = (
-  facets: FacetResult[]
-): { [key: string]: FacetValue } => {
-  return facets.reduce(
-    (acc: { [key: string]: FacetValue }, facet: FacetResult) => {
-      const newAcc = { ...acc };
+export const createFacetsMap = (facets: FacetResult[]): FacetMap => {
+  return facets.reduce((acc: FacetMap, facet: FacetResult) => {
+    const newAcc = { ...acc };
 
-      facet.values.forEach((value) => {
-        const combinedKey = `${facet.name}:${value.key}`;
-        newAcc[combinedKey] = value;
-      });
+    facet.values.forEach((value) => {
+      const combinedKey = `${facet.name}:${value.key}`;
+      newAcc[combinedKey] = value;
+    });
 
-      return newAcc;
-    },
-    {}
-  );
+    return newAcc;
+  }, {});
+};
+
+export const findTermInFacetMap = (
+  facetName: string,
+  termName: string,
+  facetMap: FacetMap
+): FacetValue => {
+  const key = `${facetName}:${termName}`;
+  return facetMap[key];
 };
 
 export default {};

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -203,46 +203,6 @@ if (import.meta.vitest) {
       ]
     },
     {
-      name: "materialTypesGeneral",
-      values: [
-        {
-          key: "abekat",
-          term: "abekat",
-          score: 0
-        }
-      ]
-    },
-    {
-      name: "subjects",
-      values: [
-        {
-          key: "legetøj",
-          term: "legetøj",
-          score: 165
-        },
-        {
-          key: "legetøjsindustri",
-          term: "legetøjsindustri",
-          score: 126
-        },
-        {
-          key: "lego",
-          term: "lego",
-          score: 101
-        },
-        {
-          key: "legoklodser",
-          term: "legoklodser",
-          score: 98
-        },
-        {
-          key: "virksomhedsledelse",
-          term: "virksomhedsledelse",
-          score: 65
-        }
-      ]
-    },
-    {
       name: "mainLanguages",
       values: [
         {
@@ -254,21 +214,6 @@ if (import.meta.vitest) {
           key: "eng",
           term: "Engelsk",
           score: 82
-        },
-        {
-          key: "fre",
-          term: "Fransk",
-          score: 9
-        },
-        {
-          key: "ger",
-          term: "Tysk",
-          score: 9
-        },
-        {
-          key: "ita",
-          term: "Italiensk",
-          score: 9
         }
       ]
     },
@@ -299,66 +244,6 @@ if (import.meta.vitest) {
           key: "film",
           term: "film",
           score: 9
-        }
-      ]
-    },
-    {
-      name: "year",
-      values: [
-        {
-          key: "2017",
-          term: "2017",
-          score: 35
-        },
-        {
-          key: "2015",
-          term: "2015",
-          score: 33
-        },
-        {
-          key: "2014",
-          term: "2014",
-          score: 31
-        },
-        {
-          key: "2018",
-          term: "2018",
-          score: 29
-        },
-        {
-          key: "2013",
-          term: "2013",
-          score: 27
-        }
-      ]
-    },
-    {
-      name: "fictionalCharacters",
-      values: [
-        {
-          key: "Batman",
-          term: "Batman",
-          score: 4
-        },
-        {
-          key: "Justice League",
-          term: "Justice League",
-          score: 4
-        },
-        {
-          key: "Harry Potter",
-          term: "Harry Potter",
-          score: 3
-        },
-        {
-          key: "Hermione Granger",
-          term: "Hermione Granger",
-          score: 3
-        },
-        {
-          key: "Ron Weasley",
-          term: "Ron Weasley",
-          score: 3
         }
       ]
     }

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -1,6 +1,8 @@
 import { mapValues } from "lodash";
 import {
   FacetField,
+  FacetResult,
+  FacetValue,
   useSearchFacetQuery
 } from "../../core/dbc-gateway/generated/graphql";
 import useGetCleanBranches from "../../core/utils/branches";
@@ -132,8 +134,29 @@ export const getFacetFieldTranslation = (name: FacetField) => {
   }
 };
 
+export const createFacetsMap = (
+  facets: FacetResult[]
+): { [key: string]: FacetValue[] } => {
+  return facets.reduce(
+    (acc: { [key: string]: FacetValue[] }, facet: FacetResult) => {
+      const newAcc = { ...acc };
+
+      facet.values.forEach((value) => {
+        const combinedKey = `${facet.name}:${value.key}`;
+        newAcc[combinedKey] = newAcc[combinedKey]
+          ? [...newAcc[combinedKey], value]
+          : [value];
+      });
+
+      return newAcc;
+    },
+    {}
+  );
+};
+
 export default {};
 
+/* ********************************* Vitest Section  ********************************* */
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
 
@@ -161,6 +184,179 @@ if (import.meta.vitest) {
     }
   };
 
+  const facetsTestData: FacetResult[] = [
+    {
+      name: "materialTypesGeneral",
+      values: [
+        {
+          key: "computerspil",
+          term: "computerspil",
+          score: 26
+        }
+      ]
+    },
+    {
+      name: "materialTypesGeneral",
+      values: [
+        {
+          key: "abekat",
+          term: "abekat",
+          score: 0
+        }
+      ]
+    },
+    {
+      name: "subjects",
+      values: [
+        {
+          key: "legetøj",
+          term: "legetøj",
+          score: 165
+        },
+        {
+          key: "legetøjsindustri",
+          term: "legetøjsindustri",
+          score: 126
+        },
+        {
+          key: "lego",
+          term: "lego",
+          score: 101
+        },
+        {
+          key: "legoklodser",
+          term: "legoklodser",
+          score: 98
+        },
+        {
+          key: "virksomhedsledelse",
+          term: "virksomhedsledelse",
+          score: 65
+        }
+      ]
+    },
+    {
+      name: "mainLanguages",
+      values: [
+        {
+          key: "dan",
+          term: "Dansk",
+          score: 427
+        },
+        {
+          key: "eng",
+          term: "Engelsk",
+          score: 82
+        },
+        {
+          key: "fre",
+          term: "Fransk",
+          score: 9
+        },
+        {
+          key: "ger",
+          term: "Tysk",
+          score: 9
+        },
+        {
+          key: "ita",
+          term: "Italiensk",
+          score: 9
+        }
+      ]
+    },
+    {
+      name: "materialTypesGeneral",
+      values: [
+        {
+          key: "artikler",
+          term: "artikler",
+          score: 346
+        },
+        {
+          key: "bøger",
+          term: "bøger",
+          score: 74
+        },
+        {
+          key: "e-bøger",
+          term: "e-bøger",
+          score: 38
+        },
+        {
+          key: "computerspil",
+          term: "computerspil",
+          score: 26
+        },
+        {
+          key: "film",
+          term: "film",
+          score: 9
+        }
+      ]
+    },
+    {
+      name: "year",
+      values: [
+        {
+          key: "2017",
+          term: "2017",
+          score: 35
+        },
+        {
+          key: "2015",
+          term: "2015",
+          score: 33
+        },
+        {
+          key: "2014",
+          term: "2014",
+          score: 31
+        },
+        {
+          key: "2018",
+          term: "2018",
+          score: 29
+        },
+        {
+          key: "2013",
+          term: "2013",
+          score: 27
+        }
+      ]
+    },
+    {
+      name: "fictionalCharacters",
+      values: [
+        {
+          key: "Batman",
+          term: "Batman",
+          score: 4
+        },
+        {
+          key: "Justice League",
+          term: "Justice League",
+          score: 4
+        },
+        {
+          key: "Harry Potter",
+          term: "Harry Potter",
+          score: 3
+        },
+        {
+          key: "Hermione Granger",
+          term: "Hermione Granger",
+          score: 3
+        },
+        {
+          key: "Ron Weasley",
+          term: "Ron Weasley",
+          score: 3
+        }
+      ]
+    }
+  ];
+
   describe("getPlaceHolderFacets", () => {
     it("should get placeholder facets", () => {
       expect(getPlaceHolderFacets(allFacetFields)).toMatchSnapshot();
@@ -177,5 +373,9 @@ if (import.meta.vitest) {
     it("should create filters", () => {
       expect(createFilters(filters, branchIdList)).toMatchSnapshot();
     });
+  });
+
+  it("createFacetsMap", () => {
+    expect(createFacetsMap(facetsTestData)).toMatchSnapshot();
   });
 }

--- a/src/components/facet-browser/helper.ts
+++ b/src/components/facet-browser/helper.ts
@@ -134,18 +134,20 @@ export const getFacetFieldTranslation = (name: FacetField) => {
   }
 };
 
+// createFacetsMap generates a map for quick lookup and enhanced search
+// capabilities by combining facet name and term into a single string key.
+// Structure: { [facetName:termKey]: FacetValue }
+// Example Key: 'fictionalCharacters:Batman'
 export const createFacetsMap = (
   facets: FacetResult[]
-): { [key: string]: FacetValue[] } => {
+): { [key: string]: FacetValue } => {
   return facets.reduce(
-    (acc: { [key: string]: FacetValue[] }, facet: FacetResult) => {
+    (acc: { [key: string]: FacetValue }, facet: FacetResult) => {
       const newAcc = { ...acc };
 
       facet.values.forEach((value) => {
         const combinedKey = `${facet.name}:${value.key}`;
-        newAcc[combinedKey] = newAcc[combinedKey]
-          ? [...newAcc[combinedKey], value]
-          : [value];
+        newAcc[combinedKey] = value;
       });
 
       return newAcc;

--- a/src/components/facet-line/FacetLineFilters.tsx
+++ b/src/components/facet-line/FacetLineFilters.tsx
@@ -12,6 +12,7 @@ import Dropdown from "../Dropdown/Dropdown";
 import {
   FacetBrowserModalId,
   createFacetsMap,
+  findTermInFacetMap,
   getFacetFieldTranslation
 } from "../facet-browser/helper";
 
@@ -40,7 +41,7 @@ const FacetLineFilters: React.FunctionComponent<FacetLineFiltersProps> = ({
     e: React.ChangeEvent<HTMLSelectElement>,
     facet: string
   ) => {
-    const term = facetMap[`${facet}:${e.target.value}`];
+    const term = findTermInFacetMap(facet, e.target.value, facetMap);
 
     if (!term) return;
 

--- a/src/components/facet-line/FacetLineFilters.tsx
+++ b/src/components/facet-line/FacetLineFilters.tsx
@@ -11,6 +11,7 @@ import ButtonTag from "../Buttons/ButtonTag";
 import Dropdown from "../Dropdown/Dropdown";
 import {
   FacetBrowserModalId,
+  createFacetsMap,
   getFacetFieldTranslation
 } from "../facet-browser/helper";
 
@@ -24,6 +25,7 @@ const FacetLineFilters: React.FunctionComponent<FacetLineFiltersProps> = ({
   const t = useText();
   const { open } = useModalButtonHandler();
   const { filters, addToFilter } = useFilterHandler();
+  const facetMap = createFacetsMap(facets);
 
   const formatValuesToDropdown = (facet: string, values: FacetValue[]) => {
     return values.map((value) => {
@@ -38,9 +40,7 @@ const FacetLineFilters: React.FunctionComponent<FacetLineFiltersProps> = ({
     e: React.ChangeEvent<HTMLSelectElement>,
     facet: string
   ) => {
-    const term = facets
-      .find((item) => item.name === facet)
-      ?.values.find((item) => item.key === e.target.value);
+    const term = facetMap[`${facet}:${e.target.value}`][0];
 
     if (!term) return;
 

--- a/src/components/facet-line/FacetLineFilters.tsx
+++ b/src/components/facet-line/FacetLineFilters.tsx
@@ -40,7 +40,7 @@ const FacetLineFilters: React.FunctionComponent<FacetLineFiltersProps> = ({
     e: React.ChangeEvent<HTMLSelectElement>,
     facet: string
   ) => {
-    const term = facetMap[`${facet}:${e.target.value}`][0];
+    const term = facetMap[`${facet}:${e.target.value}`];
 
     if (!term) return;
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-525

#### Description

We identified that the intelligentFacets query can sometimes return facets with a term intended for shortcut buttons. This same facet might also be present with other terms. To handle this efficiently and enhance our search capabilities, we've made the following updates:

- Added `createFacetsMap` Function:
This function is aimed to transform the facets array into an object. The main objective behind this transformation is to enhance search capabilities within the facets.

- Refactored `handleDropdownOnchange` Logic:
Incorporated the use of `createFacetsMap` within this function.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/8ad57abf-0e00-4323-8f62-fd23a8323235


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions