### PR TITLE
Correct old availability text keys

### DIFF
--- a/src/components/Disclosures/DisclosureSummary.tsx
+++ b/src/components/Disclosures/DisclosureSummary.tsx
@@ -44,7 +44,11 @@ const DisclosureSummary: React.FunctionComponent<DisclosureSummaryProps> = ({
       </Heading>
       {isAvailable !== undefined && (
         <Pagefold
-          text={isAvailable ? t("available") : t("unavailable")}
+          text={
+            isAvailable
+              ? t("availabilityAvailableText")
+              : t("availabilityUnavailableText")
+          }
           state={isAvailable ? "success" : "alert"}
         />
       )}

--- a/src/components/Disclosures/DisclosureSummary.tsx
+++ b/src/components/Disclosures/DisclosureSummary.tsx
@@ -12,6 +12,7 @@ export type DisclosureSummaryProps = {
   isAvailable?: boolean;
   itemRef?: React.MutableRefObject<null>;
   className?: string;
+  dataCy?: string;
 };
 
 const DisclosureSummary: React.FunctionComponent<DisclosureSummaryProps> = ({
@@ -20,13 +21,15 @@ const DisclosureSummary: React.FunctionComponent<DisclosureSummaryProps> = ({
   mainIconPath,
   isAvailable,
   itemRef,
-  className
+  className,
+  dataCy = "disclosure-summary"
 }) => {
   const t = useText();
   return (
     <summary
       ref={itemRef}
       className={clsx("disclosure__headline text-body-large ", className)}
+      data-cy={dataCy}
     >
       {mainIconPath && (
         <div className="disclosure__icon bg-identity-tint-120">

--- a/src/components/availability-label/availability-label-visual.tsx
+++ b/src/components/availability-label/availability-label-visual.tsx
@@ -25,7 +25,10 @@ const AvailabilityLabelVisual: React.FunctionComponent<
   const t = useText();
 
   const getAvailabilityText =
-    availabilityText || (isAvailable ? t("available") : t("unavailable"));
+    availabilityText ||
+    (isAvailable
+      ? t("availabilityAvailableText")
+      : t("availabilityUnavailableText"));
 
   return (
     <div

--- a/src/components/find-on-shelf/FindOnShelfModalBody.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModalBody.tsx
@@ -185,6 +185,7 @@ const FindOnShelfModalBody: FC<FindOnShelfModalBodyProps> = ({
                 key={libraryBranch[0].holding.branch.branchId}
                 open={finalData.length === 1}
                 className="disclosure--full-width"
+                dataCy="find-on-shelf-modal-body-disclosure"
                 summary={
                   <DisclosureSummary
                     title={libraryBranch[0].holding.branch.title}

--- a/src/components/find-on-shelf/find-on-shelf.test.ts
+++ b/src/components/find-on-shelf/find-on-shelf.test.ts
@@ -79,23 +79,27 @@ describe("Find on shelf modal - periodical", () => {
   });
 
   it("Shows the main branch first", () => {
-    cy.get("summary").eq(0).contains("Hovedbiblioteket");
+    cy.getBySel("disclosure-summary").eq(0).contains("Hovedbiblioteket");
   });
 
   it("Contains a summary for the main branch with no available speciments", () => {
-    cy.get("summary")
+    cy.getBySel("disclosure-summary")
       .contains("Hovedbiblioteket")
       .parent()
-      .contains("unavailable");
+      .contains("Unavailable");
   });
 
-  it("Updates branches upon selecting a different volume", () => {
-    cy.get("summary").contains("Beder-Malling").parent().contains("available");
-    cy.get("select").eq(1).select("35");
-    cy.get("summary")
+  it.only("Updates branches upon selecting a different volume", () => {
+    cy.getBySel("disclosure-summary")
       .contains("Beder-Malling")
       .parent()
-      .contains("unavailable");
+      .contains("Available");
+
+    cy.get("select").eq(1).select("35");
+    cy.getBySel("disclosure-summary")
+      .contains("Beder-Malling")
+      .parent()
+      .contains("Unavailable");
   });
 });
 

--- a/src/components/pagefold/Pagefold.tsx
+++ b/src/components/pagefold/Pagefold.tsx
@@ -4,11 +4,15 @@ import { FC } from "react";
 export interface PagefoldProps {
   text: string;
   state: "success" | "alert";
+  dataCy?: string;
 }
 
-const Pagefold: FC<PagefoldProps> = ({ text, state }) => {
+const Pagefold: FC<PagefoldProps> = ({ text, state, dataCy = "page-fold" }) => {
   return (
-    <div className="pagefold-parent--xsmall availability-label--unselected text-label availability-label">
+    <div
+      data-cy={dataCy}
+      className="pagefold-parent--xsmall availability-label--unselected text-label availability-label"
+    >
       <div
         className={`pagefold-triangle--xsmall pagefold-triangle--${state}`}
       />


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-553

#### Description

Availability texts has changed keys. This PR corrects some keys that escaped the first refactoring.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
