### PR TITLE
Add dataCy to openOrder Modal

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -327,7 +327,8 @@ export const ReservationModalBody = ({
           )}`}
           ctaButton={{
             text: t("okButtonText"),
-            modalId: reservationModalId(faustIds)
+            modalId: reservationModalId(faustIds),
+            dataCy: "reservation-success-close-button"
           }}
         >
           {openOrderResponse.submitOrder.status && (


### PR DESCRIPTION


#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Previously, there was a fixed cypress data attribute for selecting the `reservation-success-close-button` . It has been added again and should fix the failing Cypress test for openOrder

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
