### PR TITLE
Group dependabot updates for certain vendors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,13 @@ updates:
       timezone: Europe/Copenhagen
     labels:
       - dependencies
+    groups:
+      babel:
+        patterns:
+          - "@babel/*"
+      graphql-codegen:
+        patterns:
+          - "@graphql-codegen/*"
+      storybook:
+        patterns:
+          - "@storybook/*"


### PR DESCRIPTION
#### Description

We use many packages from Storybook, GraphQL Codegen and Babel. These are often updated in parallel and may have dependencies between them. Thus is makes sense to group these updates of these packages in Dependabot to ensure that we get an update to e.g. Storybook 7, GraphQL Codegen 5, Babel 8 in the same pull request