### PR TITLE
Update/ghr in release.yml GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           zip -r -j dist.zip dist/
       - name: Install GHR
         run: |
-          curl --fail --silent --location --output ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.13.0/ghr_v0.13.0_linux_amd64.tar.gz
+          curl --fail --silent --location --output ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.16.1/ghr_v0.16.1_linux_amd64.tar.gz
           tar -zxf ghr.tar.gz
           echo "./ghr_v0.13.0_linux_amd64" >> $GITHUB_PATH
       - name: Create release with asset


### PR DESCRIPTION
#### Link to issue
n/a

#### Description

We experienced some issues where GHR sometimes marks a GH release as a draft, and sometimes as pre-release without a clear reasoning. We hope that this update will fix this inconsistancy.

#### Screenshot of the result
n/a

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
n/a
