### PR TITLE
Mail should not be required in user info

### DIFF
--- a/src/apps/create-patron-user-info/UserInfo.tsx
+++ b/src/apps/create-patron-user-info/UserInfo.tsx
@@ -75,6 +75,7 @@ const UserInfo: FC<UserInfoProps> = ({ cpr }) => {
             inLine
             changePatron={changePatron}
             patron={patron}
+            requiredFields={["email"]}
           />
           <PincodeSection required changePincode={setPin} />
           {t("createPatronChangePickupHeaderText") && (

--- a/src/components/contact-info-section/ContactInfoSection.tsx
+++ b/src/components/contact-info-section/ContactInfoSection.tsx
@@ -51,7 +51,6 @@ const ContactInfoSection: FC<ContactInfoSectionProps> = ({
           changePatron={changePatron}
           patron={patron}
           showCheckboxes={showCheckboxes}
-          isRequired
         />
       </ContactInfoInputs>
     </section>

--- a/src/components/contact-info-section/ContactInfoSection.tsx
+++ b/src/components/contact-info-section/ContactInfoSection.tsx
@@ -13,13 +13,15 @@ interface ContactInfoSectionProps {
   inLine: boolean;
   changePatron: ChangePatronProps;
   showCheckboxes: boolean;
+  requiredFields?: ("email" | "phone")[];
 }
 
 const ContactInfoSection: FC<ContactInfoSectionProps> = ({
   patron,
   inLine,
   changePatron,
-  showCheckboxes
+  showCheckboxes,
+  requiredFields = []
 }) => {
   const t = useText();
   const inputsClass = clsx("dpl-input", { input__desktop: inLine });
@@ -42,6 +44,7 @@ const ContactInfoSection: FC<ContactInfoSectionProps> = ({
           className={inputsClass}
           changePatron={changePatron}
           patron={patron}
+          isRequired={requiredFields.includes("phone")}
           showCheckboxes={showCheckboxes && textNotificationsEnabledConfig}
         />
         <ContactInfoEmail
@@ -50,6 +53,7 @@ const ContactInfoSection: FC<ContactInfoSectionProps> = ({
           })}
           changePatron={changePatron}
           patron={patron}
+          isRequired={requiredFields.includes("email")}
           showCheckboxes={showCheckboxes}
         />
       </ContactInfoInputs>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-208
https://reload.atlassian.net/browse/DDFLSBP-110

#### Description

There has been some confusion about mail and phone no., wether they should be required or not.
Apparently the rule is:
None of them are required, except mail on the user registration form.
