### PR TITLE
DDFLSBP 202 brugeroprettelse fortryd knappen virker ikke

### DIFF
--- a/src/apps/create-patron-user-info/CreatePatron.dev.tsx
+++ b/src/apps/create-patron-user-info/CreatePatron.dev.tsx
@@ -27,6 +27,10 @@ export default {
       defaultValue: "https://login.bib.dk/userinfo",
       control: { type: "text" }
     },
+    logOutUrl: {
+      defaultValue: "/Logout",
+      control: { type: "text" }
+    },
     textNotificationsEnabledConfig: {
       defaultValue: "1",
       control: { type: "text" }

--- a/src/apps/create-patron-user-info/UserInfo.tsx
+++ b/src/apps/create-patron-user-info/UserInfo.tsx
@@ -17,6 +17,7 @@ export interface UserInfoProps {
 
 const UserInfo: FC<UserInfoProps> = ({ cpr }) => {
   const t = useText();
+  const { logoutUrl } = useUrls();
   const config = useConfig();
   const formRef = useRef<HTMLFormElement>(null);
   const { redirectOnUserCreatedUrl } = useUrls();
@@ -103,8 +104,9 @@ const UserInfo: FC<UserInfoProps> = ({ cpr }) => {
             <button
               type="button"
               className="link-tag mx-16"
-              // todo, click cancel, what then?
-              onClick={() => {}}
+              onClick={() => {
+                redirectTo(logoutUrl);
+              }}
             >
               {t("createPatronCancelButtonText")}
             </button>

--- a/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
+++ b/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
@@ -64,7 +64,7 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   const [loansSoonOverdue, setLoansSoonOverdue] = useState<number>(0);
   const [reservationsReadyForPickup, setReservationsReadyForPickup] =
     useState<number>(0);
-  const { menuViewYourProfileTextUrl, menuLogOutUrl } = useUrls();
+  const { menuViewYourProfileTextUrl, logoutUrl } = useUrls();
 
   // Set user data
   useEffect(() => {
@@ -171,7 +171,7 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
         <div className="modal-profile__btn-logout mx-32">
           <Link
             className="btn-primary btn-filled btn-large arrow__hover--right-small"
-            href={menuLogOutUrl}
+            href={logoutUrl}
           >
             {t("menuLogOutText")}
           </Link>

--- a/src/apps/menu/menu.dev.tsx
+++ b/src/apps/menu/menu.dev.tsx
@@ -123,7 +123,7 @@ export default {
       defaultValue: "Profile links",
       control: { type: "text" }
     },
-    menuLogOutUrl: {
+    logoutUrl: {
       defaultValue: "/Logout",
       control: { type: "text" }
     },

--- a/src/apps/menu/menu.entry.tsx
+++ b/src/apps/menu/menu.entry.tsx
@@ -28,7 +28,7 @@ export interface MenuProps {
   menuLogOutText: string;
   loansSoonOverdueText: string;
   loansOverdueText: string;
-  menuLogOutUrl: string;
+  logoutUrl: string;
   thresholdConfig: string;
   feeListDaysText: string;
   menuLoginText: string;


### PR DESCRIPTION

#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-202

#### Description
When a user clicks "Cancel" on the user registration form the user is logged out and redirected to the frontpage of the mounting application.

- Refactor menuLogOutUrl to logoutUrl
- Make the cancel button go to the logout path
