### PR TITLE
adds the `PromoBar` component and a new custom hook `useNotificationMessage` to the `PatronPage`

### DIFF
--- a/src/apps/patron-page/PatronPage.dev.tsx
+++ b/src/apps/patron-page/PatronPage.dev.tsx
@@ -240,17 +240,17 @@ export default {
       defaultValue: "You used @this ebooks out of you quota of @that ebooks",
       control: { type: "text" }
     },
-    phoneInputMessageText: {
+    patronPagePhoneInputMessageText: {
       name: "Phone input validation message",
       defaultValue:
         "The phone number must be 6 to 15 characters in length and should be comprised solely of numbers or begin with a +",
       control: { type: "text" }
     },
-    handleResponseInformationText: {
+    patronPageHandleResponseInformationText: {
       defaultValue: "Your changes are saved.",
       control: { type: "text" }
     },
-    loadingText: {
+    patronPageLoadingText: {
       name: "Loading",
       defaultValue: "Loading..",
       control: { type: "text" }

--- a/src/apps/patron-page/PatronPage.dev.tsx
+++ b/src/apps/patron-page/PatronPage.dev.tsx
@@ -247,7 +247,7 @@ export default {
       control: { type: "text" }
     },
     handleResponseInformationText: {
-      defaultValue: "Dine ændringer er gemt.",
+      defaultValue: "Your changes are saved.",
       control: { type: "text" }
     },
     loadingText: {

--- a/src/apps/patron-page/PatronPage.dev.tsx
+++ b/src/apps/patron-page/PatronPage.dev.tsx
@@ -245,6 +245,15 @@ export default {
       defaultValue:
         "The phone number must be 6 to 15 characters in length and should be comprised solely of numbers or begin with a +",
       control: { type: "text" }
+    },
+    handleResponseInformationText: {
+      defaultValue: "Dine ændringer er gemt.",
+      control: { type: "text" }
+    },
+    loadingText: {
+      name: "Loading",
+      defaultValue: "Loading..",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof PatronPage>;

--- a/src/apps/patron-page/PatronPage.entry.tsx
+++ b/src/apps/patron-page/PatronPage.entry.tsx
@@ -71,6 +71,8 @@ interface PatronPageTextProps {
   patronPageStatusSectionOutOfAriaLabelAudioBooksText: string;
   patronPageStatusSectionOutOfAriaLabelEbooksText: string;
   phoneInputMessageText: string;
+  handleResponseInformationText: string;
+  loadingText: string;
 }
 
 export interface PatronPageProps

--- a/src/apps/patron-page/PatronPage.entry.tsx
+++ b/src/apps/patron-page/PatronPage.entry.tsx
@@ -70,9 +70,9 @@ interface PatronPageTextProps {
   patronPageStatusSectionOutOfText: string;
   patronPageStatusSectionOutOfAriaLabelAudioBooksText: string;
   patronPageStatusSectionOutOfAriaLabelEbooksText: string;
-  phoneInputMessageText: string;
-  handleResponseInformationText: string;
-  loadingText: string;
+  patronPagePhoneInputMessageText: string;
+  patronPageHandleResponseInformationText: string;
+  patronPageLoadingText: string;
 }
 
 export interface PatronPageProps

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -146,7 +146,9 @@ const PatronPage: FC = () => {
             type="submit"
             disabled={disableSubmitButton}
           >
-            {t("patronPageSaveButtonText")}
+            {disableSubmitButton
+              ? t("loadingText")
+              : t("patronPageSaveButtonText")}
           </button>
 
           <div className="text-body-small-regular mt-32">

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -17,6 +17,8 @@ import PauseReservation from "../reservation-list/modal/pause-reservation/pause-
 import { getModalIds } from "../../core/utils/helpers/general";
 import { useUrls } from "../../core/utils/url";
 import { usePatronData } from "../../components/material/helper";
+import PromoBar from "../../components/promo-bar/PromoBar";
+import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
 
 const PatronPage: FC = () => {
   const queryClient = useQueryClient();
@@ -33,6 +35,11 @@ const PatronPage: FC = () => {
   const [successPinMessage, setSuccessPinMessage] = useState<string | null>(
     null
   );
+  const [notificationMessage, handleNotificationMessage] =
+    useNotificationMessage({
+      scrollToTop: true,
+      timeout: 5000
+    });
 
   useEffect(() => {
     if (patronData && patronData.patron) {
@@ -86,6 +93,7 @@ const PatronPage: FC = () => {
               setSuccessPinMessage(t("patronPinSavedSuccessText"));
             }
             setDisableSubmitButton(false);
+            handleNotificationMessage(t("handleResponseInformationText"));
           },
           // todo error handling, missing in figma
           onError: () => {
@@ -105,6 +113,9 @@ const PatronPage: FC = () => {
     <>
       <form className="dpl-patron-page" onSubmit={(e) => handleSubmit(e)}>
         <h1 className="text-header-h1 my-32">{t("patronPageHeaderText")}</h1>
+        {notificationMessage && (
+          <PromoBar text={notificationMessage} type="info" />
+        )}
         {patron && <BasicDetailsSection patron={patron} />}
         <div className="patron-page-info">
           {patron && (

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -17,7 +17,6 @@ import PauseReservation from "../reservation-list/modal/pause-reservation/pause-
 import { getModalIds } from "../../core/utils/helpers/general";
 import { useUrls } from "../../core/utils/url";
 import { usePatronData } from "../../components/material/helper";
-import PromoBar from "../../components/promo-bar/PromoBar";
 import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
 
 const PatronPage: FC = () => {
@@ -35,11 +34,8 @@ const PatronPage: FC = () => {
   const [successPinMessage, setSuccessPinMessage] = useState<string | null>(
     null
   );
-  const [notificationMessage, handleNotificationMessage] =
-    useNotificationMessage({
-      scrollToTop: true,
-      timeout: 5000
-    });
+  const [NotificationComponent, handleNotificationMessage] =
+    useNotificationMessage();
 
   useEffect(() => {
     if (patronData && patronData.patron) {
@@ -113,9 +109,7 @@ const PatronPage: FC = () => {
     <>
       <form className="dpl-patron-page" onSubmit={(e) => handleSubmit(e)}>
         <h1 className="text-header-h1 my-32">{t("patronPageHeaderText")}</h1>
-        {notificationMessage && (
-          <PromoBar text={notificationMessage} type="info" />
-        )}
+        <NotificationComponent />
         {patron && <BasicDetailsSection patron={patron} />}
         <div className="patron-page-info">
           {patron && (

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -89,7 +89,9 @@ const PatronPage: FC = () => {
               setSuccessPinMessage(t("patronPinSavedSuccessText"));
             }
             setDisableSubmitButton(false);
-            handleNotificationMessage(t("handleResponseInformationText"));
+            handleNotificationMessage(
+              t("patronPageHandleResponseInformationText")
+            );
           },
           // todo error handling, missing in figma
           onError: () => {
@@ -141,7 +143,7 @@ const PatronPage: FC = () => {
             disabled={disableSubmitButton}
           >
             {disableSubmitButton
-              ? t("loadingText")
+              ? t("patronPageLoadingText")
               : t("patronPageSaveButtonText")}
           </button>
 

--- a/src/components/contact-info-section/ContactInfoPhone.tsx
+++ b/src/components/contact-info-section/ContactInfoPhone.tsx
@@ -30,13 +30,13 @@ const ContactInfoPhone: FC<ContactInfoPhoneProps> = ({
         required={isRequired}
         type="tel"
         pattern="\+?[0-9]{6,15}"
-        title={t("phoneInputMessageText")}
+        title={t("patronPagePhoneInputMessageText")}
         onChange={(newPhoneNumber) =>
           changePatron(newPhoneNumber, "phoneNumber")
         }
         value={patron?.phoneNumber}
         label={t("patronContactPhoneLabelText")}
-        placeholder={t("phoneInputMessageText")}
+        placeholder={t("patronPagePhoneInputMessageText")}
       />
       {showCheckboxes && (
         <CheckBox

--- a/src/components/notification/NotificationComponent.tsx
+++ b/src/components/notification/NotificationComponent.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import PromoBar from "../promo-bar/PromoBar";
+
+interface NotificationComponentProps {
+  notificationMessage: string | null;
+}
+
+const NotificationComponent: React.FC<NotificationComponentProps> = ({
+  notificationMessage
+}) => {
+  if (!notificationMessage) return null;
+  return <PromoBar text={notificationMessage} type="info" />;
+};
+
+export default NotificationComponent;

--- a/src/components/notification/NotificationComponent.tsx
+++ b/src/components/notification/NotificationComponent.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import PromoBar from "../promo-bar/PromoBar";
 
 interface NotificationComponentProps {
-  notificationMessage: string | null;
+  notificationMessage: string;
 }
 
 const NotificationComponent: React.FC<NotificationComponentProps> = ({
   notificationMessage
 }) => {
-  if (!notificationMessage) return null;
   return <PromoBar text={notificationMessage} type="info" />;
 };
 

--- a/src/components/promo-bar/PromoBarIcon.tsx
+++ b/src/components/promo-bar/PromoBarIcon.tsx
@@ -11,7 +11,7 @@ export const PromoBarIcon: React.FunctionComponent<PromoBarIconProps> = ({
   type
 }) => {
   if (type === "info") {
-    return <img src={IconInfo} alt="" />;
+    return <img src={IconInfo} alt="" className="ml-4" />;
   }
   return null;
 };

--- a/src/core/utils/useNotificationMessage.ts
+++ b/src/core/utils/useNotificationMessage.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+type UseNotificationOptionsType = {
+  timeout?: number;
+  scrollToTop?: boolean;
+};
+type UseNotificationReturnType = [string | null, (text: string) => void];
+
+export const useNotificationMessage = ({
+  timeout,
+  scrollToTop
+}: UseNotificationOptionsType): UseNotificationReturnType => {
+  const [notificationMessage, setNotificationMessage] = useState<string | null>(
+    null
+  );
+
+  const handleNotificationMessage = (text: string) => {
+    setNotificationMessage(text);
+    if (scrollToTop) {
+      window.scrollTo(0, 0);
+    }
+    if (timeout) {
+      setTimeout(() => {
+        setNotificationMessage(null);
+      }, timeout);
+    }
+  };
+
+  return [notificationMessage, handleNotificationMessage];
+};
+
+export default {};

--- a/src/core/utils/useNotificationMessage.tsx
+++ b/src/core/utils/useNotificationMessage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import PromoBar from "../../components/promo-bar/PromoBar";
+import NotificationComponent from "../../components/notification/NotificationComponent";
 
 type UseNotificationOptionsType = {
   timeout?: number;
@@ -27,12 +27,10 @@ export const useNotificationMessage = ({
     }
   };
 
-  const NotificationComponent: React.FC = () => {
-    if (!notificationMessage) return null;
-    return <PromoBar text={notificationMessage} type="info" />;
-  };
-
-  return [NotificationComponent, handleNotificationMessage];
+  return [
+    () => <NotificationComponent notificationMessage={notificationMessage} />,
+    handleNotificationMessage
+  ];
 };
 
 export default {};

--- a/src/core/utils/useNotificationMessage.tsx
+++ b/src/core/utils/useNotificationMessage.tsx
@@ -28,7 +28,10 @@ export const useNotificationMessage = ({
   };
 
   return [
-    () => <NotificationComponent notificationMessage={notificationMessage} />,
+    () =>
+      notificationMessage ? (
+        <NotificationComponent notificationMessage={notificationMessage} />
+      ) : null,
     handleNotificationMessage
   ];
 };

--- a/src/core/utils/useNotificationMessage.tsx
+++ b/src/core/utils/useNotificationMessage.tsx
@@ -1,15 +1,16 @@
-import { useState } from "react";
+import React, { useState } from "react";
+import PromoBar from "../../components/promo-bar/PromoBar";
 
 type UseNotificationOptionsType = {
   timeout?: number;
   scrollToTop?: boolean;
 };
-type UseNotificationReturnType = [string | null, (text: string) => void];
+type UseNotificationReturnType = [React.FC, (text: string) => void];
 
 export const useNotificationMessage = ({
-  timeout,
-  scrollToTop
-}: UseNotificationOptionsType): UseNotificationReturnType => {
+  timeout = 5000,
+  scrollToTop = true
+}: UseNotificationOptionsType = {}): UseNotificationReturnType => {
   const [notificationMessage, setNotificationMessage] = useState<string | null>(
     null
   );
@@ -26,7 +27,12 @@ export const useNotificationMessage = ({
     }
   };
 
-  return [notificationMessage, handleNotificationMessage];
+  const NotificationComponent: React.FC = () => {
+    if (!notificationMessage) return null;
+    return <PromoBar text={notificationMessage} type="info" />;
+  };
+
+  return [NotificationComponent, handleNotificationMessage];
 };
 
 export default {};

--- a/src/core/utils/useNotificationMessage.tsx
+++ b/src/core/utils/useNotificationMessage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import NotificationComponent from "../../components/notification/NotificationComponent";
 
-type UseNotificationOptionsType = {
+export type UseNotificationOptionsType = {
   timeout?: number;
   scrollToTop?: boolean;
 };

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -52,6 +52,7 @@ describe("useNotification hook", () => {
 
   it("Does shows a message if button is clicked", async () => {
     vi.spyOn(window, "scrollTo");
+    vi.spyOn(window, "setTimeout");
 
     const { getByTitle } = render(
       <ComponentWithNotificationMessage
@@ -66,6 +67,8 @@ describe("useNotification hook", () => {
 
     // We expect that the hook has scrolled to the top of the page.
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    // And the message is gone after 5 seconds.
+    expect(window.setTimeout).toHaveBeenCalledTimes(1);
     // And shows us a message.
     expect(wrapper).toMatchInlineSnapshot(`
       <div

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
+
+const ComponentWithNotificationMessage = ({
+  wrapperTitle,
+  buttonTitle
+}: {
+  wrapperTitle: string;
+  buttonTitle: string;
+}) => {
+  const [NotificationMessage, handler] = useNotificationMessage();
+
+  return (
+    <div title={wrapperTitle}>
+      <NotificationMessage />
+      <button
+        title={buttonTitle}
+        type="button"
+        onClick={() => handler("Some message")}
+      >
+        Click me
+      </button>
+    </div>
+  );
+};
+
+describe("useNotification hook", () => {
+  it("Does not show a message if button is not clicked", async () => {
+    const { getByTitle } = render(
+      <ComponentWithNotificationMessage
+        wrapperTitle="test-1"
+        buttonTitle="test-1-button"
+      />
+    );
+    const wrapper = getByTitle("test-1");
+
+    expect(wrapper).toMatchInlineSnapshot(`
+      <div
+        title="test-1"
+      >
+        <button
+          title="test-1-button"
+          type="button"
+        >
+          Click me
+        </button>
+      </div>
+    `);
+  });
+
+  it("Does shows a message if button is clicked", async () => {
+    const { getByTitle } = render(
+      <ComponentWithNotificationMessage
+        wrapperTitle="test-2"
+        buttonTitle="test-2-button"
+      />
+    );
+    const wrapper = getByTitle("test-2");
+    const button = getByTitle("test-2-button");
+
+    fireEvent.click(button);
+    expect(wrapper).toMatchInlineSnapshot(`
+      <div
+        title="test-2"
+      >
+        <section
+          class="promo-bar"
+        >
+          <img
+            alt=""
+            class="ml-4"
+            src="/node_modules/@danskernesdigitalebibliotek/dpl-design-system/build/icons/basic/icon-info.svg"
+          />
+          <p
+            class="text-small-caption"
+          >
+            Some message
+          </p>
+        </section>
+        <button
+          title="test-2-button"
+          type="button"
+        >
+          Click me
+        </button>
+      </div>
+    `);
+  });
+});

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -35,7 +35,7 @@ describe("useNotificationMessage hook", () => {
     cleanup();
   });
 
-  it("should not display a message before the button is clicked", async () => {
+  it("should not display a message before the button is clicked", () => {
     const { getByTestId } = render(<ComponentWithNotificationMessage />);
     const wrapper = getByTestId("wrapper");
 
@@ -57,7 +57,7 @@ describe("useNotificationMessage hook", () => {
     `);
   });
 
-  it("should display a message after the button is clicked", async () => {
+  it("should display a message after the button is clicked", () => {
     vi.spyOn(window, "scrollTo");
     vi.spyOn(window, "setTimeout");
 

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -57,7 +57,7 @@ describe("useNotificationMessage hook", () => {
     `);
   });
 
-  it("should display a message after the button is clicked", () => {
+  it("should display a message after button activation with default timeout and scrollToTop settings initialized", () => {
     vi.spyOn(window, "scrollTo");
     vi.spyOn(window, "setTimeout");
 

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import React from "react";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
 
 // Define a test component that utilizes the useNotificationMessage hook
@@ -29,6 +29,9 @@ describe("useNotificationMessage hook", () => {
   it("should not display a message before the button is clicked", async () => {
     const { getByTestId } = render(<ComponentWithNotificationMessage />);
     const wrapper = getByTestId("wrapper");
+
+    // Expectations before the button is clicked
+    expect(screen.queryByText(/Some message/)).toBeNull(); // Expect the message to not be displayed
 
     // Assert that the wrapper does not contain the message initially
     expect(wrapper).toMatchInlineSnapshot(`
@@ -59,7 +62,7 @@ describe("useNotificationMessage hook", () => {
     // Expectations after the button is clicked
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0); // Expect page to scroll to top
     expect(window.setTimeout).toHaveBeenCalledTimes(1); // Expect setTimeout to be called once
-    expect(wrapper.textContent).toMatch(/Some message/); // Expect the message to be displayed
+    expect(screen.queryByText(/Some message/)).toBeTruthy(); // Expect the message to be displayed
 
     // Assert final state of the wrapper
     expect(wrapper).toMatchInlineSnapshot(`

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -1,11 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import React from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
+import {
+  UseNotificationOptionsType,
+  useNotificationMessage
+} from "../../core/utils/useNotificationMessage";
 
 // Define a test component that utilizes the useNotificationMessage hook
-const ComponentWithNotificationMessage = () => {
-  const [NotificationMessage, handler] = useNotificationMessage();
+const ComponentWithNotificationMessage = ({
+  timeout,
+  scrollToTop
+}: UseNotificationOptionsType) => {
+  const [NotificationMessage, handler] = useNotificationMessage({
+    timeout,
+    scrollToTop
+  });
 
   return (
     <div data-testid="wrapper">
@@ -91,5 +100,37 @@ describe("useNotificationMessage hook", () => {
         </button>
       </div>
     `);
+  });
+
+  it("should keep displaying a message indefinitely if timeout is removed", () => {
+    vi.spyOn(window, "setTimeout");
+
+    const { getByTestId } = render(
+      <ComponentWithNotificationMessage timeout={0} />
+    );
+    const button = getByTestId("button");
+
+    // Simulate button click
+    fireEvent.click(button);
+
+    // Expectations
+    expect(window.setTimeout).not.toHaveBeenCalled(); // Expect setTimeout to not be called
+    expect(screen.queryByText(/Some message/)).toBeTruthy(); // Expect the message to be displayed indefinitely
+  });
+
+  it("should not scroll to top if scrollToTop is false", () => {
+    vi.spyOn(window, "scrollTo");
+
+    const { getByTestId } = render(
+      <ComponentWithNotificationMessage scrollToTop={false} />
+    );
+    const button = getByTestId("button");
+
+    // Simulate button click
+    fireEvent.click(button);
+
+    // Expectations
+    expect(window.scrollTo).not.toHaveBeenCalled(); // Expect page to not scroll to top
+    expect(screen.queryByText(/Some message/)).toBeTruthy(); // Expect the message to be displayed
   });
 });

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
@@ -51,6 +51,8 @@ describe("useNotification hook", () => {
   });
 
   it("Does shows a message if button is clicked", async () => {
+    vi.spyOn(window, "scrollTo");
+
     const { getByTitle } = render(
       <ComponentWithNotificationMessage
         wrapperTitle="test-2"
@@ -61,6 +63,10 @@ describe("useNotification hook", () => {
     const button = getByTitle("test-2-button");
 
     fireEvent.click(button);
+
+    // We expect that the hook has scrolled to the top of the page.
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    // And shows us a message.
     expect(wrapper).toMatchInlineSnapshot(`
       <div
         title="test-2"

--- a/src/tests/unit/notification-message.test.tsx
+++ b/src/tests/unit/notification-message.test.tsx
@@ -1,22 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import React from "react";
-import { fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { useNotificationMessage } from "../../core/utils/useNotificationMessage";
 
-const ComponentWithNotificationMessage = ({
-  wrapperTitle,
-  buttonTitle
-}: {
-  wrapperTitle: string;
-  buttonTitle: string;
-}) => {
+// Define a test component that utilizes the useNotificationMessage hook
+const ComponentWithNotificationMessage = () => {
   const [NotificationMessage, handler] = useNotificationMessage();
 
   return (
-    <div title={wrapperTitle}>
+    <div data-testid="wrapper">
       <NotificationMessage />
       <button
-        title={buttonTitle}
+        data-testid="button"
         type="button"
         onClick={() => handler("Some message")}
       >
@@ -26,22 +21,22 @@ const ComponentWithNotificationMessage = ({
   );
 };
 
-describe("useNotification hook", () => {
-  it("Does not show a message if button is not clicked", async () => {
-    const { getByTitle } = render(
-      <ComponentWithNotificationMessage
-        wrapperTitle="test-1"
-        buttonTitle="test-1-button"
-      />
-    );
-    const wrapper = getByTitle("test-1");
+describe("useNotificationMessage hook", () => {
+  afterEach(() => {
+    cleanup();
+  });
 
+  it("should not display a message before the button is clicked", async () => {
+    const { getByTestId } = render(<ComponentWithNotificationMessage />);
+    const wrapper = getByTestId("wrapper");
+
+    // Assert that the wrapper does not contain the message initially
     expect(wrapper).toMatchInlineSnapshot(`
       <div
-        title="test-1"
+        data-testid="wrapper"
       >
         <button
-          title="test-1-button"
+          data-testid="button"
           type="button"
         >
           Click me
@@ -50,29 +45,26 @@ describe("useNotification hook", () => {
     `);
   });
 
-  it("Does shows a message if button is clicked", async () => {
+  it("should display a message after the button is clicked", async () => {
     vi.spyOn(window, "scrollTo");
     vi.spyOn(window, "setTimeout");
 
-    const { getByTitle } = render(
-      <ComponentWithNotificationMessage
-        wrapperTitle="test-2"
-        buttonTitle="test-2-button"
-      />
-    );
-    const wrapper = getByTitle("test-2");
-    const button = getByTitle("test-2-button");
+    const { getByTestId } = render(<ComponentWithNotificationMessage />);
+    const wrapper = getByTestId("wrapper");
+    const button = getByTestId("button");
 
+    // Simulate button click
     fireEvent.click(button);
 
-    // We expect that the hook has scrolled to the top of the page.
-    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
-    // And the message is gone after 5 seconds.
-    expect(window.setTimeout).toHaveBeenCalledTimes(1);
-    // And shows us a message.
+    // Expectations after the button is clicked
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0); // Expect page to scroll to top
+    expect(window.setTimeout).toHaveBeenCalledTimes(1); // Expect setTimeout to be called once
+    expect(wrapper.textContent).toMatch(/Some message/); // Expect the message to be displayed
+
+    // Assert final state of the wrapper
     expect(wrapper).toMatchInlineSnapshot(`
       <div
-        title="test-2"
+        data-testid="wrapper"
       >
         <section
           class="promo-bar"
@@ -89,7 +81,7 @@ describe("useNotification hook", () => {
           </p>
         </section>
         <button
-          title="test-2-button"
+          data-testid="button"
           type="button"
         >
           Click me


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-84

#### Description

This Pull Request adds the `PromoBar` component and a new custom hook `useNotificationMessage` to the `PatronPage`. 

The `PromoBar` provides visual notifications to users, while the `useNotificationMessage` hook is designed to manage these notifications by handling auto-scrolling and setting removal timeouts.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/a7fe635e-51c6-480e-b680-a1bd2121b735



