### PR TITLE
Activate email notifications for new accounts

### DIFF
--- a/src/apps/create-patron-user-info/UserInfo.tsx
+++ b/src/apps/create-patron-user-info/UserInfo.tsx
@@ -26,7 +26,7 @@ const UserInfo: FC<UserInfoProps> = ({ cpr }) => {
   const { mutate } = useCreateV4();
   const [patron, setPatron] = useState<PatronSettingsV3>({
     preferredPickupBranch: "",
-    receiveEmail: false,
+    receiveEmail: true,
     receivePostalMail: false,
     receiveSms: false,
     phoneNumber: "",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-226

#### Description
Activate email notifications for new accounts

For initial communication, new users are given a welcome email with guidelines and related information. Borrowers have the flexibility to transition to text notifications through their user settings, contingent upon the library's service offerings.
