### PR TITLE
Defaults in dpl-react configuration

### DIFF
--- a/src/apps/dashboard/dashboard-fees/dashboard-fees.tsx
+++ b/src/apps/dashboard/dashboard-fees/dashboard-fees.tsx
@@ -8,7 +8,7 @@ import WarningBar from "../../loan-list/materials/utils/warning-bar";
 
 const DashboardFees: FC = () => {
   const t = useText();
-  const { feesUrl, feesPageUrl } = useUrls();
+  const { feesPageUrl } = useUrls();
   const { data: fbsFees } = useGetFeesV2();
   const [feeCount, setFeeCount] = useState<number>();
   const [totalFeeAmount, setTotalFeeAmount] = useState<string>("0");
@@ -29,7 +29,7 @@ const DashboardFees: FC = () => {
               <div className="link-filters__tag-wrapper">
                 <h2 data-cy="dashboard-fees-header">
                   <Link
-                    href={feesUrl}
+                    href={feesPageUrl}
                     className="link-tag link-tag link-filters__tag"
                   >
                     {t("feesText")}

--- a/src/apps/dashboard/dashboard.dev.tsx
+++ b/src/apps/dashboard/dashboard.dev.tsx
@@ -28,10 +28,6 @@ export default {
       defaultValue: "/user/me/loans",
       control: { type: "text" }
     },
-    feesUrl: {
-      defaultValue: "/user/me/fees",
-      control: { type: "text" }
-    },
     reservationsUrl: {
       defaultValue: "/user/me/reservations",
       control: { type: "text" }

--- a/src/apps/dashboard/dashboard.entry.tsx
+++ b/src/apps/dashboard/dashboard.entry.tsx
@@ -17,7 +17,7 @@ export interface DashBoardProps {
   // Url
   loansOverdueUrl: string;
   physicalLoansUrl: string;
-  feesUrl: string;
+  feesPageUrl: string;
   reservationsUrl: string;
   // Config
   blacklistedPickupBranchesConfig: string;

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
@@ -11,7 +11,6 @@ import { useText } from "../../../../core/utils/text";
 import fetchDigitalMaterial from "../../../loan-list/materials/utils/digital-material-fetch-hoc";
 import PhysicalListDetails from "./physical-list-details";
 import { useConfig } from "../../../../core/utils/config";
-import { isConfigValueOne } from "../../../../components/reservation/helper";
 
 export interface ReservationDetailsProps {
   reservation: ReservationType;
@@ -28,14 +27,15 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
   const { state, identifier, numberInQueue } = reservation;
   const { authors, pid, year, title, description, materialType } =
     material || {};
-  const allowRemoveReadyReservation = config(
-    "reservationDetailAllowRemoveReadyReservationsConfig"
-  );
+  const { allowRemoveReadyReservations } = config<{
+    allowRemoveReadyReservations: boolean;
+  }>("reservationDetailsConfig", {
+    transformer: "jsonParse"
+  });
   const isDigital = !!reservation.identifier;
   const readyForPickupState = "readyForPickup";
   const allowUserRemoveReadyReservations =
-    (state === readyForPickupState &&
-      isConfigValueOne(allowRemoveReadyReservation)) ||
+    (state === readyForPickupState && allowRemoveReadyReservations) ||
     state !== readyForPickupState;
 
   return (

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -226,7 +226,7 @@ export const ReservationModalBody = ({
   const instantLoanBranchHoldings = getInstantLoanBranchHoldings(
     holdingsData[0].holdings,
     whitelistBranches,
-    instantLoanMatchStrings
+    instantLoanMatchStrings ?? []
   );
 
   const instantLoanBranchHoldingsAboveThreshold =

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -216,7 +216,7 @@ export const consolidatedHoldings = (branchHoldings: HoldingsV3[]) => {
 export const getInstantLoanBranchHoldings = (
   branchHoldings: HoldingsV3[],
   whitelist: AgencyBranch[],
-  instantLoanStrings: string[] | null
+  instantLoanStrings: string[]
 ) => {
   const whitelistBranchIds = whitelist.map(({ branchId }) => branchId);
   // 1. Filter holdings by branch on whitelist
@@ -230,7 +230,7 @@ export const getInstantLoanBranchHoldings = (
         // if a material group description contains any of the instant loan strings
         // and is available, it is an instant loan.
         return (
-          (instantLoanStrings ?? []).some((instantLoanString) => {
+          instantLoanStrings.some((instantLoanString) => {
             return materialGroup.description?.includes(instantLoanString);
           }) && available
         );

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -216,7 +216,7 @@ export const consolidatedHoldings = (branchHoldings: HoldingsV3[]) => {
 export const getInstantLoanBranchHoldings = (
   branchHoldings: HoldingsV3[],
   whitelist: AgencyBranch[],
-  instantLoanStrings: string[]
+  instantLoanStrings: string[] | null
 ) => {
   const whitelistBranchIds = whitelist.map(({ branchId }) => branchId);
   // 1. Filter holdings by branch on whitelist
@@ -230,7 +230,7 @@ export const getInstantLoanBranchHoldings = (
         // if a material group description contains any of the instant loan strings
         // and is available, it is an instant loan.
         return (
-          instantLoanStrings.some((instantLoanString) => {
+          (instantLoanStrings ?? []).some((instantLoanString) => {
             return materialGroup.description?.includes(instantLoanString);
           }) && available
         );
@@ -246,10 +246,11 @@ export const getInstantLoanBranchHoldings = (
 
 export const getInstantLoanBranchHoldingsAboveThreshold = (
   instantLoanBranchHoldings: HoldingsV3[],
-  instantLoanThresholdConfig: string
+  instantLoanThresholdConfig: string | null
 ) =>
   instantLoanBranchHoldings.filter(
-    ({ materials }) => materials.length >= Number(instantLoanThresholdConfig)
+    ({ materials }) =>
+      materials.length >= Number(instantLoanThresholdConfig ?? 0)
   );
 
 export const removePrefixFromBranchId = (branchId: string) => {

--- a/src/core/storybook/reservationMaterialDetailsArgs.ts
+++ b/src/core/storybook/reservationMaterialDetailsArgs.ts
@@ -10,8 +10,8 @@ export default {
       '[\n   {\n      "branchId":"DK-775120",\n      "title":"Højbjerg"\n   },\n   {\n      "branchId":"DK-775122",\n      "title":"Beder-Malling"\n   },\n   {\n      "branchId":"DK-775144",\n      "title":"Gellerup"\n   },\n   {\n      "branchId":"DK-775167",\n      "title":"Lystrup"\n   },\n   {\n      "branchId":"DK-775146",\n      "title":"Harlev"\n   },\n   {\n      "branchId":"DK-775168",\n      "title":"Skødstrup"\n   },\n   {\n      "branchId":"FBS-751010",\n      "title":"Arresten"\n   },\n   {\n      "branchId":"DK-775147",\n      "title":"Hasle"\n   },\n   {\n      "branchId":"FBS-751032",\n      "title":"Må ikke benyttes"\n   },\n   {\n      "branchId":"FBS-751031",\n      "title":"Fjernlager 1"\n   },\n   {\n      "branchId":"DK-775126",\n      "title":"Solbjerg"\n   },\n   {\n      "branchId":"FBS-751030",\n      "title":"ITK"\n   },\n   {\n      "branchId":"DK-775149",\n      "title":"Sabro"\n   },\n   {\n      "branchId":"DK-775127",\n      "title":"Tranbjerg"\n   },\n   {\n      "branchId":"DK-775160",\n      "title":"Risskov"\n   },\n   {\n      "branchId":"DK-775162",\n      "title":"Hjortshøj"\n   },\n   {\n      "branchId":"DK-775140",\n      "title":"Åby"\n   },\n   {\n      "branchId":"FBS-751009",\n      "title":"Fjernlager 2"\n   },\n   {\n      "branchId":"FBS-751029",\n      "title":"Stadsarkivet"\n   },\n   {\n      "branchId":"FBS-751027",\n      "title":"Intern"\n   },\n   {\n      "branchId":"FBS-751026",\n      "title":"Fælles undervejs"\n   },\n   {\n      "branchId":"FBS-751025",\n      "title":"Fællessekretariatet"\n   },\n   {\n      "branchId":"DK-775133",\n      "title":"Bavnehøj"\n   },\n   {\n      "branchId":"FBS-751024",\n      "title":"Fjernlånte materialer"\n   },\n   {\n      "branchId":"DK-775100",\n      "title":"Hovedbiblioteket"\n   },\n   {\n      "branchId":"DK-775170",\n      "title":"Trige"\n   },\n   {\n      "branchId":"DK-775150",\n      "title":"Tilst"\n   },\n   {\n      "branchId":"DK-775130",\n      "title":"Viby"\n   },\n   {\n      "branchId":"DK-775164",\n      "title":"Egå"\n   }\n]',
     control: { type: "text" }
   },
-  reservationDetailAllowRemoveReadyReservationsConfig: {
-    defaultValue: "1",
+  reservationDetailsConfig: {
+    defaultValue: '{"allowRemoveReadyReservations": true}',
     control: { type: "text" }
   },
   interestPeriodsConfig: {
@@ -150,7 +150,7 @@ export interface ReservationMaterialDetailsProps {
   reservationDetailsReadyForLoanText: string;
   reservationDetailsPickupDeadlineTitleText: string;
   interestPeriodsConfig: string;
-  reservationDetailAllowRemoveReadyReservationsConfig: string;
+  reservationDetailsConfig: string;
   branchesConfig: string;
   blacklistedPickupBranchesConfig: string;
   shiftText: string;

--- a/src/tests/unit/config.test.tsx
+++ b/src/tests/unit/config.test.tsx
@@ -1,0 +1,72 @@
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import React, { ReactNode } from "react";
+import { Provider } from "react-redux";
+import { expect, test } from "vitest";
+import { renderHook, act } from "@testing-library/react-hooks";
+import configReducer from "../../core/config.slice";
+import { useConfig } from "../../core/utils/config";
+
+const store = configureStore({
+  reducer: combineReducers({
+    config: configReducer
+  }),
+  preloadedState: {
+    config: {
+      data: {
+        someStringArrayConfig: "a,b,c",
+        someJsonArrayConfig:
+          '[{"animal": "Blue macaw parrot", "isBlue": true},{"animal": "Bee", "isBlue": false}]',
+        someJsonObjectConfig: `{"title": "Think Again", "author": "Adam Grant"}`
+      }
+    }
+  }
+});
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}> {children} </Provider>
+);
+
+test("Should handle config with string arrays", () => {
+  const { result } = renderHook(() => useConfig(), { wrapper: Wrapper });
+  const config = result.current;
+
+  act(() => {
+    const output = config("someStringArrayConfig", {
+      transformer: "stringToArray"
+    });
+
+    expect(output).toStrictEqual(["a", "b", "c"]);
+  });
+});
+
+test("Should handle config with array with objects", () => {
+  const { result } = renderHook(() => useConfig(), { wrapper: Wrapper });
+  const config = result.current;
+
+  act(() => {
+    const output = config("someJsonArrayConfig", {
+      transformer: "jsonParse"
+    });
+
+    expect(output).toStrictEqual([
+      { animal: "Blue macaw parrot", isBlue: true },
+      { animal: "Bee", isBlue: false }
+    ]);
+  });
+});
+
+test("Should handle config with an object", () => {
+  const { result } = renderHook(() => useConfig(), { wrapper: Wrapper });
+  const config = result.current;
+
+  act(() => {
+    const output = config("someJsonObjectConfig", {
+      transformer: "jsonParse"
+    });
+
+    expect(output).toStrictEqual({
+      title: "Think Again",
+      author: "Adam Grant"
+    });
+  });
+});

--- a/src/tests/unit/text.test.tsx
+++ b/src/tests/unit/text.test.tsx
@@ -25,7 +25,7 @@ const Wrapper = ({ children }: { children: ReactNode }) => (
   <Provider store={store}> {children} </Provider>
 );
 
-test("Should strings with placeholders", () => {
+test("Should handle strings with placeholders", () => {
   const { result } = renderHook(() => useText(), { wrapper: Wrapper });
   // We name it t, because that is how we normally use it in the code.
   const t = result.current;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-246

#### Description

This PR is created as a port of the work being done on this [PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/436) in dpl-cms.
Initiatives in this project:
* Changed allowRemoveReadyReservations to be boolean property. I think we should handle booleans as a part of a json structure config. In that way it is "natively boolean" and we do not have to juggle around with tranforming "1" and "0" or "true" and "false".
* Instant loan config. The place it is used there was no checks if the various config properties were set. I tried to accomodate the situation by let the handling functions accept null parameters where they were used. Not optional though would like to handle it earlier.
* In the work with the allowRemoveReadyReservations boolean I wanted to be sure of how the config handler works with the different input. So I wrote a pair of unit tests to document it.

#### Additional comments or questions

This PR has precedence over https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/436. 