### PR TITLE
Set the patron `preferredPickupBranch` instead of the empty string in `openOrder`

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -7,8 +7,7 @@ import {
   getMaterialTypes,
   getManifestationType,
   materialIsFiction,
-  getReservablePidsFromAnotherLibrary,
-  getPatronAddress
+  getReservablePidsFromAnotherLibrary
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { Button } from "../Buttons/Button";
@@ -155,7 +154,7 @@ export const ReservationModalBody = ({
     }
 
     if (pidsFromAnotherLibrary.length > 0 && patron) {
-      const { patronId, address, name, emailAddress } = patron;
+      const { patronId, name, emailAddress, preferredPickupBranch } = patron;
 
       mutateOpenOrder(
         {
@@ -163,13 +162,12 @@ export const ReservationModalBody = ({
             pids: [...pidsFromAnotherLibrary],
             pickUpBranch: selectedBranch
               ? removePrefixFromBranchId(selectedBranch)
-              : "",
+              : removePrefixFromBranchId(preferredPickupBranch),
             expires:
               selectedInterest?.toString() ||
               defaultInterestDaysForOpenOrder.toString(),
             userParameters: {
               userId: patronId.toString(),
-              userAddress: address ? getPatronAddress(address) : "",
               userName: name,
               userMail: emailAddress
             }

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -20,7 +20,6 @@ import { dashboardReservedApiValueText } from "../../configuration/api-strings.j
 import { ReservationType } from "../types/reservation-type";
 import { ManifestationMaterialType } from "../types/material-type";
 import { store } from "../../store";
-import { AddressV2 } from "../../fbs/model";
 
 export const getManifestationPublicationYear = (
   manifestation: Manifestation
@@ -572,9 +571,6 @@ export const getReservablePidsFromAnotherLibrary = (
 
   return matchingManifestations.map(({ pid }) => pid);
 };
-
-export const getPatronAddress = (address: AddressV2) =>
-  `${address.street}, ${address.postalCode} ${address.city}`;
 
 export default {};
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-528

#### Description

The previous implementation set an empty string for the `pickUpBranch` field in `openOrder` if `selectedBranch` was not provided. However, an empty string is still considered a valid value when sent to the API, which triggered a `UNKNOWN_USER` error due to the user not being found.

Additionally, the `getPatronAddress` function has been removed as it's no longer necessary to send the address. There was a concern regarding potential mismatches in address formatting, which could result in errors since `openOrder` requires exact matches for input values.