### PR TITLE
Add disabled state for delete materials button

### DIFF
--- a/src/apps/dashboard/modal/ReservationsGroupModal.tsx
+++ b/src/apps/dashboard/modal/ReservationsGroupModal.tsx
@@ -148,7 +148,7 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
                   }
                 })}
                 buttonType="none"
-                disabled={false}
+                disabled={!materialsToDelete.length}
                 collapsible={false}
                 size="small"
                 variant="filled"


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-171

#### Description
A user should no be able to trigger the delete materials modal, if no materials have been selected. This adds a simple check for that.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/14014012/b178e86f-46c4-4c1d-93a5-43163b31b123)
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/14014012/286f31a1-ece8-47ec-83e1-a27f1fc5535f)

