### PR TITLE
Add aria label to link

### DIFF
--- a/src/apps/menu/menu-navigation-list/MenuNavigationItem.tsx
+++ b/src/apps/menu/menu-navigation-list/MenuNavigationItem.tsx
@@ -37,7 +37,11 @@ const MenuNavigationItem: FC<MenuNavigationItemProps> = ({
   return (
     <li className="link-filters mb-16">
       <div className="link-filters__tag-wrapper">
-        <a href={link} className="link-tag link-tag link-filters__tag">
+        <a
+          href={link}
+          className="link-tag link-tag link-filters__tag"
+          aria-label={`${name} ${dataMap[dataId] || ""}`}
+        >
           {name}
         </a>
         {dataMap[dataId] !== 0 && (

--- a/src/apps/menu/menu-navigation-list/MenuNavigationItem.tsx
+++ b/src/apps/menu/menu-navigation-list/MenuNavigationItem.tsx
@@ -45,7 +45,9 @@ const MenuNavigationItem: FC<MenuNavigationItemProps> = ({
           {name}
         </a>
         {dataMap[dataId] !== 0 && (
-          <span className="link-filters__counter">{dataMap[dataId]}</span>
+          <span className="link-filters__counter" aria-hidden="true">
+            {dataMap[dataId]}
+          </span>
         )}
       </div>
     </li>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-180

#### Description
We want screen readers to read the number of reserved items. Because the number is not a semantic part of the a tag, the screen reader will ignore it.
An aria-label can solve this, but a more correct solution would be to move the span inside the a tag - which would require changes in design system aswell. 
