### PR TITLE
Close reservations modal when deleting reservation

### DIFF
--- a/src/apps/reservation-list/modal/delete-reservation/delete-reservation-modal.tsx
+++ b/src/apps/reservation-list/modal/delete-reservation/delete-reservation-modal.tsx
@@ -12,7 +12,6 @@ import {
   useDeleteV1UserReservationsIdentifier
 } from "../../../../core/publizon/publizon";
 import { isFaust, isIdentifier } from "../../../dashboard/util/helpers";
-import { getModalIds } from "../../../../core/utils/helpers/general";
 
 interface DeleteReservationModalProps {
   modalId: string;
@@ -28,8 +27,7 @@ const DeleteReservationModal: FC<DeleteReservationModalProps> = ({
   const { mutate: deletePhysicalReservation } = useDeleteReservations();
   const { mutate: deleteDigitalReservation } =
     useDeleteV1UserReservationsIdentifier();
-  const { close } = useModalButtonHandler();
-  const { reservationsQueued } = getModalIds();
+  const { closeAll: closeAllModals } = useModalButtonHandler();
 
   const removeSelectedReservations = () => {
     if (reservations.length > 0) {
@@ -67,8 +65,7 @@ const DeleteReservationModal: FC<DeleteReservationModalProps> = ({
         )
       );
 
-      close(reservationsQueued as string);
-      close(modalId as string);
+      closeAllModals();
     }
   };
 

--- a/src/apps/reservation-list/modal/delete-reservation/delete-reservation-modal.tsx
+++ b/src/apps/reservation-list/modal/delete-reservation/delete-reservation-modal.tsx
@@ -12,6 +12,7 @@ import {
   useDeleteV1UserReservationsIdentifier
 } from "../../../../core/publizon/publizon";
 import { isFaust, isIdentifier } from "../../../dashboard/util/helpers";
+import { getModalIds } from "../../../../core/utils/helpers/general";
 
 interface DeleteReservationModalProps {
   modalId: string;
@@ -28,6 +29,7 @@ const DeleteReservationModal: FC<DeleteReservationModalProps> = ({
   const { mutate: deleteDigitalReservation } =
     useDeleteV1UserReservationsIdentifier();
   const { close } = useModalButtonHandler();
+  const { reservationsQueued } = getModalIds();
 
   const removeSelectedReservations = () => {
     if (reservations.length > 0) {
@@ -65,6 +67,7 @@ const DeleteReservationModal: FC<DeleteReservationModalProps> = ({
         )
       );
 
+      close(reservationsQueued as string);
       close(modalId as string);
     }
   };

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -229,7 +229,7 @@ describe("Reservation details modal test", () => {
 
     cy.get(".modal").find("[data-cy='delete-reservation-button']").click();
 
-    cy.get(".modal").should("not.be.visible");
+    cy.get(".modal").should("not.exist");
   });
 
   it("It shows digital reservation details modal, material queued", () => {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -183,15 +183,6 @@ describe("Reservation details modal test", () => {
     // ID 43 2.b. Material types including accessibility of material
     // ID 17 2.b.ii "Ready for loan" if the reservation is ready for loan, or else it will not be shown
 
-    // ID 17 2.c. the link "Remove your reservation"
-    cy.get(".modal")
-      .find("button.link-tag")
-      .eq(0)
-      .should("have.text", "Remove your reservation")
-      .click();
-
-    cy.get(".modal").find("[data-cy='delete-reservation-button']").click();
-
     // ID 17 2.d. button: go to ereolen
     cy.get(".modal")
       .find("[data-cy='go-to-ereolen-button']")
@@ -229,6 +220,16 @@ describe("Reservation details modal test", () => {
       .eq(1)
       .find(".text-small-caption")
       .should("have.text", "16-08-2022 12:52");
+
+    cy.get(".modal")
+      .find("button.link-tag")
+      .eq(0)
+      .should("have.text", "Remove your reservation")
+      .click();
+
+    cy.get(".modal").find("[data-cy='delete-reservation-button']").click();
+
+    cy.get(".modal").should("not.be.visible");
   });
 
   it("It shows digital reservation details modal, material queued", () => {
@@ -416,16 +417,6 @@ describe("Reservation details modal test", () => {
       .eq(0)
       .find(".text-body-medium-regular")
       .should("have.text", "Others are queueing for this material");
-
-    // ID 13 button: “Remove you reservation”
-    cy.get(".modal")
-      .find(".modal-details__buttons")
-      .eq(0)
-      .find("button")
-      .should("have.text", "Remove your reservation")
-      .click();
-
-    cy.get(".modal").find("[data-cy='delete-reservation-button']").click();
 
     // ID 13 2.d. header "status"
     cy.getBySel("reservation-form-list-item")

--- a/src/core/modal.slice.ts
+++ b/src/core/modal.slice.ts
@@ -92,10 +92,18 @@ const modalSlice = createSlice({
         removeModalIdFromUrl(state);
         returnFocusElement();
       }
+    },
+    closeAllModals(state: StateProps) {
+      // Enables background scrolling to use when Modal is closed
+      document.body.style.overflow = "";
+      state.modalIds = [];
+      removeModalIdFromUrl(state);
+      returnFocusElement();
     }
   }
 });
 
-export const { openModal, closeModal, closeLastModal } = modalSlice.actions;
+export const { openModal, closeModal, closeLastModal, closeAllModals } =
+  modalSlice.actions;
 
 export default modalSlice.reducer;

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -68,7 +68,7 @@ function Modal({
   return (
     <FocusTrap
       focusTrapOptions={{
-        // set fallbackFocus when running vitest to avoid focus trap errors
+        // Set fallbackFocus when running vitest to avoid focus trap errors.
         fallbackFocus: process.env.VITEST ? "body" : undefined
       }}
     >

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import CloseIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/CloseLarge.svg";
 import clsx from "clsx";
 import FocusTrap from "focus-trap-react";
-import { closeModal, openModal } from "../modal.slice";
+import { closeAllModals, closeModal, openModal } from "../modal.slice";
 import { isAnonymous } from "./helpers/user";
 import {
   currentLocationWithParametersUrl,
@@ -146,6 +146,9 @@ export const useModalButtonHandler = () => {
     },
     close: (modalId: ModalId) => {
       return dispatch(closeModal({ modalId }));
+    },
+    closeAll: () => {
+      return dispatch(closeAllModals());
     },
     openGuarded: ({
       authUrl,

--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -66,7 +66,12 @@ function Modal({
   };
 
   return (
-    <FocusTrap>
+    <FocusTrap
+      focusTrapOptions={{
+        // set fallbackFocus when running vitest to avoid focus trap errors
+        fallbackFocus: process.env.VITEST ? "body" : undefined
+      }}
+    >
       <div>
         {/* The backdrop doesn't have a role or keyboard listener because it barely duplicates
           the close button's functionality which possesses both. */}

--- a/src/tests/unit/modal.test.tsx
+++ b/src/tests/unit/modal.test.tsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import modalReducer from "../../core/modal.slice";
+import Modal, { useModalButtonHandler } from "../../core/utils/modal";
+
+const store = configureStore({
+  reducer: combineReducers({
+    modal: modalReducer
+  })
+});
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <Provider store={store}> {children} </Provider>
+);
+
+const ComponentWithModals = () => {
+  const modalId1 = "modal-1";
+  const modalId2 = "modal-2";
+  const modalId3 = "modal-3";
+  const { closeAll, open, close } = useModalButtonHandler();
+
+  return (
+    <div data-testid="wrapper">
+      <button type="button" onClick={() => open(modalId1)}>
+        Open modal 1
+      </button>
+      <Modal
+        modalId={modalId1}
+        classNames="modal-cta"
+        closeModalAriaLabelText="Close modal 1"
+        screenReaderModalDescriptionText="Modal 1"
+        data-testid="modal-1"
+      >
+        Modal 1
+        <button type="button" onClick={() => open(modalId2)}>
+          Open modal 2
+        </button>
+      </Modal>
+      <Modal
+        modalId={modalId2}
+        classNames="modal-cta"
+        closeModalAriaLabelText="Close modal 2"
+        screenReaderModalDescriptionText="Modal 2"
+        data-testid="modal-2"
+      >
+        Modal 2
+        <button type="button" onClick={() => open(modalId3)}>
+          Open modal 3
+        </button>
+        <button type="button" onClick={() => closeAll()}>
+          Close all
+        </button>
+      </Modal>
+      <Modal
+        modalId={modalId3}
+        classNames="modal-cta"
+        closeModalAriaLabelText="Close modal 3"
+        screenReaderModalDescriptionText="Modal 3"
+        data-testid="modal-3"
+      >
+        Modal 3
+        <button type="button" onClick={() => close(modalId3)}>
+          Close this
+        </button>
+      </Modal>
+    </div>
+  );
+};
+
+describe("modal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should not display a modal before the button is clicked", () => {
+    const { getByTestId } = render(<ComponentWithModals />, {
+      wrapper: Wrapper
+    });
+    const wrapper = getByTestId("wrapper");
+
+    // Expectations before the button is clicked
+    expect(screen.queryByText(/Modal 1/)).toBeNull(); // Expect the modal to not be displayed
+
+    // Assert that the wrapper does not contain the modal initially
+    expect(wrapper).toMatchInlineSnapshot(`
+      <div
+        data-testid="wrapper"
+      >
+        <button
+          type="button"
+        >
+          Open modal 1
+        </button>
+      </div>
+    `);
+  });
+
+  it("should display modal 1 after button activation", () => {
+    const { container } = render(<ComponentWithModals />, {
+      wrapper: Wrapper
+    });
+    const button = screen.getByText("Open modal 1");
+
+    // Click the button
+    fireEvent.click(button);
+
+    // Expect the modal to be displayed
+    expect(container.querySelector("#modal-modal-1-description")).toBeTruthy();
+  });
+
+  it("should display modal 2 after closing modal 3", () => {
+    const { container } = render(<ComponentWithModals />, {
+      wrapper: Wrapper
+    });
+    const button = screen.getByText("Open modal 1");
+
+    // Click the button in page
+    fireEvent.click(button);
+
+    // Expect modal 1 to be displayed
+    expect(container.querySelector("#modal-modal-1-description")).toBeTruthy();
+
+    // Click the button inside modal 1
+    fireEvent.click(screen.getByText("Open modal 2"));
+
+    // Expect modal 2 to be displayed
+    expect(container.querySelector("#modal-modal-2-description")).toBeTruthy();
+
+    // Click the button inside modal 2
+    fireEvent.click(screen.getByText("Open modal 3"));
+
+    // Expect modal 3 to be displayed
+    expect(container.querySelector("#modal-modal-3-description")).toBeTruthy();
+
+    // Click close button in modal 3
+    fireEvent.click(screen.getByText("Close this"));
+
+    // Expect modal 2 to be displayed
+    expect(container.querySelector("#modal-modal-2-description")).toBeTruthy();
+  });
+
+  it("should close all modals after clicking close all button", () => {
+    const { container } = render(<ComponentWithModals />, {
+      wrapper: Wrapper
+    });
+    const button = screen.getByText("Open modal 1");
+
+    // Click the button in page
+    fireEvent.click(button);
+
+    // Expect modal 1 to be displayed
+    expect(container.querySelector("#modal-modal-1-description")).toBeTruthy();
+
+    // Click the button inside modal 1
+    fireEvent.click(screen.getByText("Open modal 2"));
+
+    // Expect modal 2 to be displayed
+    expect(container.querySelector("#modal-modal-2-description")).toBeTruthy();
+
+    // Close all modals
+    fireEvent.click(screen.getByText("Close all"));
+
+    // Expect no modals to be displayed
+    expect(container.querySelector("#modal-modal-1-description")).toBeNull();
+  });
+});


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-102

#### Description
Upon deleting a reserved material, the user can be stuck in an infinite loop, because the underlying reservations modal is not closed after deleting a reservation. This change always closes the reservationsQueued modal when deleting a reserved material.
