### PR TITLE
Introduce and implement `useReservations` and `useLoans` hooks

### DIFF
--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -33,7 +33,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
   columns
 }) => {
   const t = useText();
-  const { allReservations, allReadyToLoanReservations, allQueuedReservations } =
+  const { reservations, reservationsReadyToLoan, reservationsQueued } =
     useReservations();
   const {
     allLoans,
@@ -74,7 +74,10 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
     [open]
   );
 
-  const { reservationsReady, reservationsQueued } = getModalIds();
+  const {
+    reservationsReady: reservationsReadyID,
+    reservationsQueued: reservationsQueueID
+  } = getModalIds();
   const { physicalLoansUrl, reservationsUrl } = useUrls();
 
   const openLoanDetailsModal = useCallback(
@@ -97,7 +100,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
     ({ loanId }) => String(loanId) === modalLoanDetailsId
   );
 
-  const reservationForModal = allReservations.find(
+  const reservationForModal = reservations.find(
     ({ faust, reservationId }) =>
       String(modalReservationDetailsId) === String(faust) ||
       String(modalReservationDetailsId) === String(reservationId)
@@ -197,34 +200,33 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
 
   const dashboardNotificationsReservations = [
     {
-      listLength: allReadyToLoanReservations.length,
+      listLength: reservationsReadyToLoan.length,
       header: t("reservationsReadyText"),
       badge: t("readyForLoanText"),
       dataCy: "reservations-ready",
       showNotificationDot: true,
       color: "info",
       notificationClickEvent: () =>
-        allReadyToLoanReservations.length === 1
+        reservationsReadyToLoan.length === 1
           ? openReservationDetailsModal(
-              String(allReadyToLoanReservations[0].faust)
+              String(reservationsReadyToLoan[0].faust)
             )
-          : openModalHandler(reservationsReady as string)
+          : openModalHandler(reservationsReadyID as string)
     },
     {
-      listLength: allQueuedReservations.length,
+      listLength: reservationsQueued.length,
       header: t("reservationsStillInQueueForText"),
       dataCy: "reservations-queued",
       color: "neutral",
       showNotificationDot: false,
       notificationClickEvent: () =>
-        allQueuedReservations.length === 1
+        reservationsQueued.length === 1
           ? openReservationDetailsModal(
               String(
-                allQueuedReservations[0].identifier ||
-                  allQueuedReservations[0].faust
+                reservationsQueued[0].identifier || reservationsQueued[0].faust
               )
             )
-          : openModalHandler(reservationsQueued as string)
+          : openModalHandler(reservationsQueueID as string)
     }
   ];
   const resetAccepted = () => {
@@ -245,7 +247,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
             />
             <NotificationColumn
               materials={dashboardNotificationsReservations}
-              materialsCount={allReservations.length}
+              materialsCount={reservations.length}
               headerUrl={reservationsUrl}
               header={t("reservationsText")}
               emptyListText={t("noReservationsText")}
@@ -292,7 +294,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           <SimpleModalHeader header={modalHeader} />
         </LoansGroupModal>
       )}
-      {allReservations && (
+      {reservations && (
         <ReservationGroupModal
           openDetailsModal={openReservationDetailsModal}
           modalId={reservationModalId}

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -35,12 +35,8 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
   const t = useText();
   const { reservations, reservationsReadyToLoan, reservationsQueued } =
     useReservations();
-  const {
-    allLoans,
-    allOverdueLoans,
-    allSoonOverdueLoans,
-    allFarFromOverdueLoans
-  } = useLoans();
+  const { loans, loansOverdue, loansSoonOverdue, loansFarFromOverdue } =
+    useLoans();
   const [accepted, setAccepted] = useState<boolean>(false);
   const [modalReservationDetailsId, setModalReservationDetailsId] = useState<
     string | null
@@ -96,7 +92,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
     [open, reservationDetails]
   );
 
-  const modalLoan = allLoans.find(
+  const modalLoan = loans.find(
     ({ loanId }) => String(loanId) === modalLoanDetailsId
   );
 
@@ -127,17 +123,17 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
 
       switch (dueDateInput) {
         case yesterday:
-          setLoansToDisplay(allOverdueLoans);
+          setLoansToDisplay(loansOverdue);
           setModalHeader(t("loansOverdueText"));
           break;
 
         case soon:
-          setLoansToDisplay(allSoonOverdueLoans);
+          setLoansToDisplay(loansSoonOverdue);
           setModalHeader(t("loansSoonOverdueText"));
           break;
 
         case longer:
-          setLoansToDisplay(allFarFromOverdueLoans);
+          setLoansToDisplay(loansFarFromOverdue);
           setModalHeader(t("loansNotOverdueText"));
           break;
 
@@ -146,50 +142,43 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       }
       open(constructModalId(dueDateModal as string, [dueDateInput]));
     },
-    [
-      dueDateModal,
-      open,
-      allFarFromOverdueLoans,
-      allOverdueLoans,
-      allSoonOverdueLoans,
-      t
-    ]
+    [dueDateModal, open, loansFarFromOverdue, loansOverdue, loansSoonOverdue, t]
   );
 
   const dashboardNotificationsLoan = [
     {
-      listLength: allOverdueLoans.length,
+      listLength: loansOverdue.length,
       badge: t("materialDetailsOverdueText"),
       header: t("loansOverdueText"),
       color: "danger",
       dataCy: "physical-loans-overdue",
       showNotificationDot: true,
       notificationClickEvent: () =>
-        allOverdueLoans.length === 1
-          ? openLoanDetailsModal(String(allOverdueLoans[0].loanId))
+        loansOverdue.length === 1
+          ? openLoanDetailsModal(String(loansOverdue[0].loanId))
           : openDueDateModal(yesterday)
     },
     {
-      listLength: allSoonOverdueLoans.length,
+      listLength: loansSoonOverdue.length,
       badge: t("statusBadgeWarningText"),
       header: t("loansSoonOverdueText"),
       color: "warning",
       dataCy: "physical-loans-soon-overdue",
       showNotificationDot: true,
       notificationClickEvent: () =>
-        allSoonOverdueLoans.length === 1
-          ? openLoanDetailsModal(String(allSoonOverdueLoans[0].loanId))
+        loansSoonOverdue.length === 1
+          ? openLoanDetailsModal(String(loansSoonOverdue[0].loanId))
           : openDueDateModal(soon)
     },
     {
-      listLength: allFarFromOverdueLoans.length,
+      listLength: loansFarFromOverdue.length,
       header: t("loansNotOverdueText"),
       dataCy: "loans-not-overdue",
       color: "neutral",
       showNotificationDot: false,
       notificationClickEvent: () =>
-        allFarFromOverdueLoans.length === 1
-          ? openLoanDetailsModal(String(allFarFromOverdueLoans[0].loanId))
+        loansFarFromOverdue.length === 1
+          ? openLoanDetailsModal(String(loansFarFromOverdue[0].loanId))
           : openDueDateModal(longer)
     }
   ];
@@ -240,7 +229,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           <>
             <NotificationColumn
               materials={dashboardNotificationsLoan}
-              materialsCount={allLoans.length}
+              materialsCount={loans.length}
               headerUrl={physicalLoansUrl}
               header={t("physicalLoansText")}
               emptyListText={t("noPhysicalLoansText")}
@@ -281,7 +270,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           )}
         />
       </MaterialDetailsModal>
-      {dueDate && allLoans && loansToDisplay && (
+      {dueDate && loans && loansToDisplay && (
         <LoansGroupModal
           accepted={accepted}
           resetAccepted={() => resetAccepted()}

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -40,8 +40,14 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       queued: reservationsQueued
     }
   } = useReservations();
-  const { loans, loansOverdue, loansSoonOverdue, loansFarFromOverdue } =
-    useLoans();
+  const {
+    all: {
+      loans,
+      overdue: loansOverdue,
+      soonOverdue: loansSoonOverdue,
+      farFromOverdue: loansFarFromOverdue
+    }
+  } = useLoans();
   const [accepted, setAccepted] = useState<boolean>(false);
   const [modalReservationDetailsId, setModalReservationDetailsId] = useState<
     string | null

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -33,8 +33,13 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
   columns
 }) => {
   const t = useText();
-  const { reservations, reservationsReadyToLoan, reservationsQueued } =
-    useReservations();
+  const {
+    all: {
+      reservations,
+      readyToLoan: reservationsReadyToLoan,
+      queued: reservationsQueued
+    }
+  } = useReservations();
   const { loans, loansOverdue, loansSoonOverdue, loansFarFromOverdue } =
     useLoans();
   const [accepted, setAccepted] = useState<boolean>(false);

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -100,7 +100,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
   const reservationForModal = allReservations.find(
     ({ faust, reservationId }) =>
       String(modalReservationDetailsId) === String(faust) ||
-      String(reservationId)
+      String(modalReservationDetailsId) === String(reservationId)
   );
 
   const openReservationDeleteModal = useCallback(() => {

--- a/src/apps/dashboard/dashboard.tsx
+++ b/src/apps/dashboard/dashboard.tsx
@@ -1,17 +1,7 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC } from "react";
 import DashboardFees from "./dashboard-fees/dashboard-fees";
 import DashboardNotificationList from "./dashboard-notification-list/dashboard-notification-list";
 import { useText } from "../../core/utils/text";
-import { sortByDueDate } from "../../core/utils/helpers/general";
-import { LoanType } from "../../core/utils/types/loan-type";
-import { useGetLoansV2, useGetReservationsV2 } from "../../core/fbs/fbs";
-import {
-  mapFBSLoanToLoanType,
-  mapFBSReservationToReservationType
-} from "../../core/utils/helpers/list-mapper";
-import { ThresholdType } from "../../core/utils/types/threshold-type";
-import { useConfig } from "../../core/utils/config";
-import { ReservationType } from "../../core/utils/types/reservation-type";
 
 interface DashboardProps {
   pageSize: number;
@@ -19,37 +9,6 @@ interface DashboardProps {
 
 const DashBoard: FC<DashboardProps> = ({ pageSize }) => {
   const t = useText();
-  const config = useConfig();
-  const {
-    colorThresholds: { warning }
-  } = config<ThresholdType>("thresholdConfig", {
-    transformer: "jsonParse"
-  });
-  const { data: reservationsFbs } = useGetReservationsV2();
-  const [reservations, setReservations] = useState<ReservationType[]>([]);
-
-  const { isSuccess, data } = useGetLoansV2();
-  const [loans, setLoans] = useState<LoanType[] | null>(null);
-
-  useEffect(() => {
-    if (reservationsFbs) {
-      setReservations(mapFBSReservationToReservationType(reservationsFbs));
-    }
-  }, [reservationsFbs]);
-
-  useEffect(() => {
-    if (isSuccess && data) {
-      const mapToLoanType = mapFBSLoanToLoanType(data);
-      setLoans(mapToLoanType);
-
-      // Loans are sorted by loan date
-      const sortedByLoanDate = sortByDueDate(mapToLoanType);
-
-      setLoans(sortedByLoanDate);
-    } else {
-      setLoans([]);
-    }
-  }, [isSuccess, data, warning]);
 
   return (
     <div className="dashboard-page">
@@ -57,12 +16,7 @@ const DashBoard: FC<DashboardProps> = ({ pageSize }) => {
         {t("yourProfileText")}
       </h1>
       <DashboardFees />
-      <DashboardNotificationList
-        columns
-        pageSize={pageSize}
-        reservations={reservations}
-        loans={loans}
-      />
+      <DashboardNotificationList columns pageSize={pageSize} />
     </div>
   );
 };

--- a/src/apps/dashboard/modal/ReservationsGroupModal.tsx
+++ b/src/apps/dashboard/modal/ReservationsGroupModal.tsx
@@ -24,12 +24,7 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
   setReservationsToDelete,
   openDetailsModal
 }) => {
-  const {
-    reservationsReadyToLoanFBS,
-    reservationsReadyToLoanPublizon,
-    reservationsQueuedFBS,
-    reservationsQueuedPublizon
-  } = useReservations();
+  const { fbs, publizon } = useReservations();
   const t = useText();
   const { reservationsReady, reservationsQueued } = getModalIds();
   const [materialsToDelete, setMaterialsToDelete] = useState<string[]>([]);
@@ -38,13 +33,13 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
   let digitalReservations: ReservationType[] = [];
 
   if (modalId === reservationsReady) {
-    physicalReservations = reservationsReadyToLoanFBS;
-    digitalReservations = reservationsReadyToLoanPublizon;
+    physicalReservations = fbs.readyToLoan;
+    digitalReservations = publizon.readyToLoan;
   }
 
   if (modalId === reservationsQueued) {
-    physicalReservations = reservationsQueuedFBS;
-    digitalReservations = reservationsQueuedPublizon;
+    physicalReservations = fbs.queued;
+    digitalReservations = publizon.queued;
   }
 
   useEffect(() => {

--- a/src/apps/dashboard/modal/ReservationsGroupModal.tsx
+++ b/src/apps/dashboard/modal/ReservationsGroupModal.tsx
@@ -25,10 +25,10 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
   openDetailsModal
 }) => {
   const {
-    readyToLoanReservationsFBS,
-    readyToLoanReservationsPublizon,
-    queuedFBSReservations,
-    queuedPublizonReservations
+    reservationsReadyToLoanFBS,
+    reservationsReadyToLoanPublizon,
+    reservationsQueuedFBS,
+    reservationsQueuedPublizon
   } = useReservations();
   const t = useText();
   const { reservationsReady, reservationsQueued } = getModalIds();
@@ -38,13 +38,13 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
   let digitalReservations: ReservationType[] = [];
 
   if (modalId === reservationsReady) {
-    physicalReservations = readyToLoanReservationsFBS;
-    digitalReservations = readyToLoanReservationsPublizon;
+    physicalReservations = reservationsReadyToLoanFBS;
+    digitalReservations = reservationsReadyToLoanPublizon;
   }
 
   if (modalId === reservationsQueued) {
-    physicalReservations = queuedFBSReservations;
-    digitalReservations = queuedPublizonReservations;
+    physicalReservations = reservationsQueuedFBS;
+    digitalReservations = reservationsQueuedPublizon;
   }
 
   useEffect(() => {

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -57,8 +57,8 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const [accepted, setAccepted] = useState<boolean>(false);
   const [modalDetailsId, setModalDetailsId] = useState<string | null>(null);
   const {
-    sortedByLoanDateFbs,
-    sortedByLoanDatePublizon,
+    loansSortedByDateFbs,
+    loansSortedByDatePublizon,
     stackedMaterialsDueDatesFbs
   } = useLoans();
   useEffect(() => {
@@ -67,20 +67,20 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
       return;
     }
     let loanForModal = null;
-    if (sortedByLoanDateFbs && modalDetailsId) {
+    if (loansSortedByDateFbs && modalDetailsId) {
       loanForModal = getFromListByKey(
-        sortedByLoanDateFbs,
+        loansSortedByDateFbs,
         "loanId",
         modalDetailsId
       );
     }
     if (
       loanForModal?.length === 0 &&
-      sortedByLoanDatePublizon &&
+      loansSortedByDatePublizon &&
       modalDetailsId
     ) {
       loanForModal = getFromListByKey(
-        sortedByLoanDatePublizon,
+        loansSortedByDatePublizon,
         "identifier",
         modalDetailsId
       );
@@ -91,8 +91,8 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   }, [
     modalDetailsId,
     modalLoan,
-    sortedByLoanDateFbs,
-    sortedByLoanDatePublizon
+    loansSortedByDateFbs,
+    loansSortedByDatePublizon
   ]);
 
   const openAcceptModal = useCallback(() => {
@@ -142,9 +142,9 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   }, [allLoansId, loanDetails, openDueDateModal]);
 
   const listContainsLoans =
-    (Array.isArray(sortedByLoanDateFbs) && sortedByLoanDateFbs.length > 0) ||
-    (Array.isArray(sortedByLoanDatePublizon) &&
-      sortedByLoanDatePublizon.length > 0);
+    (Array.isArray(loansSortedByDateFbs) && loansSortedByDateFbs.length > 0) ||
+    (Array.isArray(loansSortedByDatePublizon) &&
+      loansSortedByDatePublizon.length > 0);
 
   const resetAccepted = () => {
     setAccepted(false);
@@ -156,11 +156,11 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
         <h1 className="text-header-h1 my-32">{t("loanListTitleText")}</h1>
         {listContainsLoans && (
           <>
-            {sortedByLoanDateFbs && (
+            {loansSortedByDateFbs && (
               <List
                 pageSize={pageSize}
                 emptyListLabel={t("loanListPhysicalLoansEmptyListText")}
-                loans={sortedByLoanDateFbs}
+                loans={loansSortedByDateFbs}
                 dueDates={stackedMaterialsDueDatesFbs}
                 view={view}
                 openLoanDetailsModal={openLoanDetailsModal}
@@ -168,41 +168,41 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
               >
                 <ListHeader
                   header={t("loanListPhysicalLoansTitleText")}
-                  amount={sortedByLoanDateFbs.length}
+                  amount={loansSortedByDateFbs.length}
                 >
                   <ToggleListViewButtons
                     disableRenewLoansButton={
-                      getAmountOfRenewableLoans(sortedByLoanDateFbs) === 0
+                      getAmountOfRenewableLoans(loansSortedByDateFbs) === 0
                     }
                     view={view}
                     setView={setView}
-                    loans={sortedByLoanDateFbs}
+                    loans={loansSortedByDateFbs}
                     pageSize={pageSize}
                     openRenewLoansModal={openRenewLoansModal}
                   />
                 </ListHeader>
               </List>
             )}
-            {sortedByLoanDatePublizon && (
+            {loansSortedByDatePublizon && (
               <List
                 pageSize={pageSize}
                 emptyListLabel={t("loanListDigitalLoansEmptyListText")}
-                loans={sortedByLoanDatePublizon}
+                loans={loansSortedByDatePublizon}
                 view="list"
                 openLoanDetailsModal={openLoanDetailsModal}
                 openDueDateModal={openDueDateModal}
               >
                 <ListHeader
                   header={t("loanListDigitalLoansTitleText")}
-                  amount={sortedByLoanDatePublizon.length}
+                  amount={loansSortedByDatePublizon.length}
                 />
               </List>
             )}
           </>
         )}
 
-        {loansAreEmpty(sortedByLoanDateFbs) &&
-          loansAreEmpty(sortedByLoanDatePublizon) && (
+        {loansAreEmpty(loansSortedByDateFbs) &&
+          loansAreEmpty(loansSortedByDatePublizon) && (
             <EmptyList
               classNames="mt-24"
               emptyListText={t("loanListDigitalPhysicalLoansEmptyListText")}
@@ -223,7 +223,7 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           modalId={constructMaterialDetailsModalId(loanDetails, modalDetailsId)}
         />
       </MaterialDetailsModal>
-      {sortedByLoanDateFbs && (
+      {loansSortedByDateFbs && (
         <LoansGroupModal
           accepted={accepted}
           resetAccepted={() => resetAccepted()}
@@ -233,8 +233,8 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           openAcceptModal={openAcceptModal}
           loansModal={
             dueDate
-              ? removeLoansWithDuplicateDueDate(dueDate, sortedByLoanDateFbs)
-              : sortedByLoanDateFbs
+              ? removeLoansWithDuplicateDueDate(dueDate, loansSortedByDateFbs)
+              : loansSortedByDateFbs
           }
         >
           {dueDate && (

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -58,31 +58,24 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const [modalDetailsId, setModalDetailsId] = useState<string | null>(null);
   const {
     fbs: {
-      sortedByDate: loansSortedByDateFbs,
+      loans: loansPhysical,
       stackedMaterialsDueDates: stackedMaterialsDueDatesFbs
     },
-    publizon: { sortedByDate: loansSortedByDatePublizon }
+    publizon: { loans: loansDigital }
   } = useLoans();
+
   useEffect(() => {
     // If modalLoan is already set it should not be set again, because it will cause an infinite loop
     if (modalLoan) {
       return;
     }
     let loanForModal = null;
-    if (loansSortedByDateFbs && modalDetailsId) {
-      loanForModal = getFromListByKey(
-        loansSortedByDateFbs,
-        "loanId",
-        modalDetailsId
-      );
+    if (loansPhysical && modalDetailsId) {
+      loanForModal = getFromListByKey(loansPhysical, "loanId", modalDetailsId);
     }
-    if (
-      loanForModal?.length === 0 &&
-      loansSortedByDatePublizon &&
-      modalDetailsId
-    ) {
+    if (loanForModal?.length === 0 && loansDigital && modalDetailsId) {
       loanForModal = getFromListByKey(
-        loansSortedByDatePublizon,
+        loansDigital,
         "identifier",
         modalDetailsId
       );
@@ -90,12 +83,7 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
     if (loanForModal && loanForModal.length > 0) {
       setModalLoan(loanForModal[0]);
     }
-  }, [
-    modalDetailsId,
-    modalLoan,
-    loansSortedByDateFbs,
-    loansSortedByDatePublizon
-  ]);
+  }, [modalDetailsId, modalLoan, loansPhysical, loansDigital]);
 
   const openAcceptModal = useCallback(() => {
     open(`${acceptModal}`);
@@ -144,9 +132,8 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   }, [allLoansId, loanDetails, openDueDateModal]);
 
   const listContainsLoans =
-    (Array.isArray(loansSortedByDateFbs) && loansSortedByDateFbs.length > 0) ||
-    (Array.isArray(loansSortedByDatePublizon) &&
-      loansSortedByDatePublizon.length > 0);
+    (Array.isArray(loansPhysical) && loansPhysical.length > 0) ||
+    (Array.isArray(loansDigital) && loansDigital.length > 0);
 
   const resetAccepted = () => {
     setAccepted(false);
@@ -158,11 +145,11 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
         <h1 className="text-header-h1 my-32">{t("loanListTitleText")}</h1>
         {listContainsLoans && (
           <>
-            {loansSortedByDateFbs && (
+            {loansPhysical && (
               <List
                 pageSize={pageSize}
                 emptyListLabel={t("loanListPhysicalLoansEmptyListText")}
-                loans={loansSortedByDateFbs}
+                loans={loansPhysical}
                 dueDates={stackedMaterialsDueDatesFbs}
                 view={view}
                 openLoanDetailsModal={openLoanDetailsModal}
@@ -170,43 +157,43 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
               >
                 <ListHeader
                   header={t("loanListPhysicalLoansTitleText")}
-                  amount={loansSortedByDateFbs.length}
+                  amount={loansPhysical.length}
                 >
                   <ToggleListViewButtons
                     disableRenewLoansButton={
-                      getAmountOfRenewableLoans(loansSortedByDateFbs) === 0
+                      getAmountOfRenewableLoans(loansPhysical) === 0
                     }
                     view={view}
                     setView={setView}
-                    loans={loansSortedByDateFbs}
+                    loans={loansPhysical}
                     pageSize={pageSize}
                     openRenewLoansModal={openRenewLoansModal}
                   />
                 </ListHeader>
               </List>
             )}
-            {loansSortedByDatePublizon && (
+            {loansDigital && (
               <List
                 pageSize={pageSize}
                 emptyListLabel={t("loanListDigitalLoansEmptyListText")}
-                loans={loansSortedByDatePublizon}
+                loans={loansDigital}
                 view="list"
                 openLoanDetailsModal={openLoanDetailsModal}
                 openDueDateModal={openDueDateModal}
               >
                 <ListHeader
                   header={t("loanListDigitalLoansTitleText")}
-                  amount={loansSortedByDatePublizon.length}
+                  amount={loansDigital.length}
                 />
               </List>
             )}
           </>
         )}
 
-        {loansSortedByDateFbs &&
-          loansSortedByDatePublizon &&
-          loansAreEmpty(loansSortedByDateFbs) &&
-          loansAreEmpty(loansSortedByDatePublizon) && (
+        {loansPhysical &&
+          loansDigital &&
+          loansAreEmpty(loansPhysical) &&
+          loansAreEmpty(loansDigital) && (
             <EmptyList
               classNames="mt-24"
               emptyListText={t("loanListDigitalPhysicalLoansEmptyListText")}
@@ -227,7 +214,7 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           modalId={constructMaterialDetailsModalId(loanDetails, modalDetailsId)}
         />
       </MaterialDetailsModal>
-      {loansSortedByDateFbs && (
+      {loansPhysical && (
         <LoansGroupModal
           accepted={accepted}
           resetAccepted={() => resetAccepted()}
@@ -237,8 +224,8 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           openAcceptModal={openAcceptModal}
           loansModal={
             dueDate
-              ? removeLoansWithDuplicateDueDate(dueDate, loansSortedByDateFbs)
-              : loansSortedByDateFbs
+              ? removeLoansWithDuplicateDueDate(dueDate, loansPhysical)
+              : loansPhysical
           }
         >
           {dueDate && (

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -1,12 +1,9 @@
 import React, { useEffect, useState, FC, useCallback } from "react";
 import { useSelector } from "react-redux";
 import dayjs from "dayjs";
-import { useGetLoansV2 } from "../../../core/fbs/fbs";
 import {
   getAmountOfRenewableLoans,
-  getDueDatesLoan,
   getModalIds,
-  sortByDueDate,
   getScrollClass,
   constructModalId
 } from "../../../core/utils/helpers/general";
@@ -17,14 +14,9 @@ import {
   ModalIdsProps
 } from "../../../core/utils/modal";
 import List from "./list";
-import { useGetV1UserLoans } from "../../../core/publizon/publizon";
 import { LoanType } from "../../../core/utils/types/loan-type";
 import { ListView } from "../../../core/utils/types/list-view";
 import EmptyList from "../../../components/empty-list/empty-list";
-import {
-  mapPublizonLoanToLoanType,
-  mapFBSLoanToLoanType
-} from "../../../core/utils/helpers/list-mapper";
 import ToggleListViewButtons from "./ToggleListViewButtons";
 import ListHeader from "./ListHeader";
 import {
@@ -48,6 +40,7 @@ import StatusCircleModalHeader from "../../../components/GroupModal/StatusCircle
 import StatusCircle from "../materials/utils/status-circle";
 import AcceptModal from "../../../components/accept-fees-modal/AcceptFeesModal";
 import { formatDate } from "../../../core/utils/helpers/date";
+import useLoans from "../../../core/utils/useLoans";
 
 interface LoanListProps {
   pageSize: number;
@@ -63,21 +56,31 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const [dueDate, setDueDate] = useState<string | null>(null);
   const [accepted, setAccepted] = useState<boolean>(false);
   const [modalDetailsId, setModalDetailsId] = useState<string | null>(null);
-  const [physicalLoans, setPhysicalLoans] = useState<LoanType[] | null>(null);
-  const [digitalLoans, setDigitalLoans] = useState<LoanType[] | null>(null);
-  const [physicalLoansDueDates, setPhysicalLoansDueDates] = useState<string[]>(
-    []
-  );
-  const { isSuccess, data } = useGetLoansV2();
-  const { data: publizonData } = useGetV1UserLoans();
+  const {
+    sortedByLoanDateFbs,
+    sortedByLoanDatePublizon,
+    stackedMaterialsDueDatesFbs
+  } = useLoans();
   useEffect(() => {
-    let loanForModal = null;
-    if (physicalLoans && modalDetailsId) {
-      loanForModal = getFromListByKey(physicalLoans, "loanId", modalDetailsId);
+    // If modalLoan is already set it should not be set again, because it will cause an infinite loop
+    if (modalLoan) {
+      return;
     }
-    if (loanForModal?.length === 0 && digitalLoans && modalDetailsId) {
+    let loanForModal = null;
+    if (sortedByLoanDateFbs && modalDetailsId) {
       loanForModal = getFromListByKey(
-        digitalLoans,
+        sortedByLoanDateFbs,
+        "loanId",
+        modalDetailsId
+      );
+    }
+    if (
+      loanForModal?.length === 0 &&
+      sortedByLoanDatePublizon &&
+      modalDetailsId
+    ) {
+      loanForModal = getFromListByKey(
+        sortedByLoanDatePublizon,
         "identifier",
         modalDetailsId
       );
@@ -85,37 +88,12 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
     if (loanForModal && loanForModal.length > 0) {
       setModalLoan(loanForModal[0]);
     }
-  }, [digitalLoans, modalDetailsId, physicalLoans]);
-
-  useEffect(() => {
-    if (isSuccess && data) {
-      const mapToLoanType = mapFBSLoanToLoanType(data);
-
-      // The due dates are used for the stacked materials
-      // The stacked materials view shows materials stacked by
-      // due date, and for this we need a unique list of due dates
-      setPhysicalLoansDueDates(getDueDatesLoan(mapToLoanType));
-
-      // Loans are sorted by loan date
-      const sortedByLoanDate = sortByDueDate(mapToLoanType);
-
-      setPhysicalLoans(sortedByLoanDate);
-    } else {
-      setPhysicalLoans([]);
-    }
-  }, [isSuccess, data]);
-
-  useEffect(() => {
-    if (publizonData?.loans) {
-      const mapToLoanType = mapPublizonLoanToLoanType(publizonData.loans);
-
-      // Loans are sorted by loan date
-      const sortedByLoanDate = sortByDueDate(mapToLoanType);
-      setDigitalLoans(sortedByLoanDate);
-    } else {
-      setDigitalLoans([]);
-    }
-  }, [publizonData]);
+  }, [
+    modalDetailsId,
+    modalLoan,
+    sortedByLoanDateFbs,
+    sortedByLoanDatePublizon
+  ]);
 
   const openAcceptModal = useCallback(() => {
     open(`${acceptModal}`);
@@ -164,8 +142,9 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   }, [allLoansId, loanDetails, openDueDateModal]);
 
   const listContainsLoans =
-    (Array.isArray(physicalLoans) && physicalLoans.length > 0) ||
-    (Array.isArray(digitalLoans) && digitalLoans.length > 0);
+    (Array.isArray(sortedByLoanDateFbs) && sortedByLoanDateFbs.length > 0) ||
+    (Array.isArray(sortedByLoanDatePublizon) &&
+      sortedByLoanDatePublizon.length > 0);
 
   const resetAccepted = () => {
     setAccepted(false);
@@ -177,57 +156,58 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
         <h1 className="text-header-h1 my-32">{t("loanListTitleText")}</h1>
         {listContainsLoans && (
           <>
-            {physicalLoans && (
+            {sortedByLoanDateFbs && (
               <List
                 pageSize={pageSize}
                 emptyListLabel={t("loanListPhysicalLoansEmptyListText")}
-                loans={physicalLoans}
-                dueDates={physicalLoansDueDates}
+                loans={sortedByLoanDateFbs}
+                dueDates={stackedMaterialsDueDatesFbs}
                 view={view}
                 openLoanDetailsModal={openLoanDetailsModal}
                 openDueDateModal={openDueDateModal}
               >
                 <ListHeader
                   header={t("loanListPhysicalLoansTitleText")}
-                  amount={physicalLoans.length}
+                  amount={sortedByLoanDateFbs.length}
                 >
                   <ToggleListViewButtons
                     disableRenewLoansButton={
-                      getAmountOfRenewableLoans(physicalLoans) === 0
+                      getAmountOfRenewableLoans(sortedByLoanDateFbs) === 0
                     }
                     view={view}
                     setView={setView}
-                    loans={physicalLoans}
+                    loans={sortedByLoanDateFbs}
                     pageSize={pageSize}
                     openRenewLoansModal={openRenewLoansModal}
                   />
                 </ListHeader>
               </List>
             )}
-            {digitalLoans && (
+            {sortedByLoanDatePublizon && (
               <List
                 pageSize={pageSize}
                 emptyListLabel={t("loanListDigitalLoansEmptyListText")}
-                loans={digitalLoans}
+                loans={sortedByLoanDatePublizon}
                 view="list"
                 openLoanDetailsModal={openLoanDetailsModal}
                 openDueDateModal={openDueDateModal}
               >
                 <ListHeader
                   header={t("loanListDigitalLoansTitleText")}
-                  amount={digitalLoans.length}
+                  amount={sortedByLoanDatePublizon.length}
                 />
               </List>
             )}
           </>
         )}
 
-        {loansAreEmpty(physicalLoans) && loansAreEmpty(digitalLoans) && (
-          <EmptyList
-            classNames="mt-24"
-            emptyListText={t("loanListDigitalPhysicalLoansEmptyListText")}
-          />
-        )}
+        {loansAreEmpty(sortedByLoanDateFbs) &&
+          loansAreEmpty(sortedByLoanDatePublizon) && (
+            <EmptyList
+              classNames="mt-24"
+              emptyListText={t("loanListDigitalPhysicalLoansEmptyListText")}
+            />
+          )}
       </div>
       {/* modals below, the reason they are located here is that if they are nested
       within the components, it is not possible to hide the loan list when a modal is present
@@ -243,7 +223,7 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           modalId={constructMaterialDetailsModalId(loanDetails, modalDetailsId)}
         />
       </MaterialDetailsModal>
-      {physicalLoans && (
+      {sortedByLoanDateFbs && (
         <LoansGroupModal
           accepted={accepted}
           resetAccepted={() => resetAccepted()}
@@ -253,8 +233,8 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           openAcceptModal={openAcceptModal}
           loansModal={
             dueDate
-              ? removeLoansWithDuplicateDueDate(dueDate, physicalLoans)
-              : physicalLoans
+              ? removeLoansWithDuplicateDueDate(dueDate, sortedByLoanDateFbs)
+              : sortedByLoanDateFbs
           }
         >
           {dueDate && (

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -57,9 +57,11 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const [accepted, setAccepted] = useState<boolean>(false);
   const [modalDetailsId, setModalDetailsId] = useState<string | null>(null);
   const {
-    loansSortedByDateFbs,
-    loansSortedByDatePublizon,
-    stackedMaterialsDueDatesFbs
+    fbs: {
+      sortedByDate: loansSortedByDateFbs,
+      stackedMaterialsDueDates: stackedMaterialsDueDatesFbs
+    },
+    publizon: { sortedByDate: loansSortedByDatePublizon }
   } = useLoans();
   useEffect(() => {
     // If modalLoan is already set it should not be set again, because it will cause an infinite loop
@@ -201,7 +203,9 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           </>
         )}
 
-        {loansAreEmpty(loansSortedByDateFbs) &&
+        {loansSortedByDateFbs &&
+          loansSortedByDatePublizon &&
+          loansAreEmpty(loansSortedByDateFbs) &&
           loansAreEmpty(loansSortedByDatePublizon) && (
             <EmptyList
               classNames="mt-24"

--- a/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
+++ b/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
@@ -22,7 +22,9 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   const {
     all: { reservations }
   } = useReservations();
-  const { loans, loansOverdue, loansSoonOverdue } = useLoans();
+  const {
+    all: { loans, overdue: loansOverdue, soonOverdue: loansSoonOverdue }
+  } = useLoans();
   const { data: patronData } = usePatronData();
   const { data: fbsFees } = useGetFeesV2();
   const t = useText();

--- a/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
+++ b/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
@@ -6,44 +6,25 @@ import MenuNavigationItem, {
 } from "../menu-navigation-list/MenuNavigationItem";
 import { AuthenticatedPatronV6 } from "../../../core/fbs/model";
 import { useUrls } from "../../../core/utils/url";
-import {
-  useGetLoansV2,
-  useGetReservationsV2,
-  useGetFeesV2
-} from "../../../core/fbs/fbs";
-import {
-  mapFBSLoanToLoanType,
-  mapFBSReservationToReservationType
-} from "../../../core/utils/helpers/list-mapper";
-import { LoanType } from "../../../core/utils/types/loan-type";
-import {
-  filterLoansOverdue,
-  filterLoansSoonOverdue
-} from "../../../core/utils/helpers/general";
+import { useGetFeesV2 } from "../../../core/fbs/fbs";
 import { useConfig } from "../../../core/utils/config";
-import { ThresholdType } from "../../../core/utils/types/threshold-type";
 import { useText } from "../../../core/utils/text";
-import { getReadyForPickup } from "../../reservation-list/utils/helpers";
-import { ReservationType } from "../../../core/utils/types/reservation-type";
-import DashboardNotificationList from "../../dashboard/dashboard-notification-list/dashboard-notification-list";
 import { usePatronData } from "../../../core/utils/helpers/user";
+import DashboardNotificationList from "../../dashboard/dashboard-notification-list/dashboard-notification-list";
+import useReservations from "../../../core/utils/useReservations";
+import useLoans from "../../../core/utils/useLoans";
 
 interface MenuLoggedInContentProps {
   pageSize: number;
 }
 
 const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
+  const { allReservations } = useReservations();
+  const { allLoans, allOverdueLoans, allSoonOverdueLoans } = useLoans();
   const { data: patronData } = usePatronData();
-  const { data: patronReservations } = useGetReservationsV2();
-  const { data: fbsData } = useGetLoansV2();
   const { data: fbsFees } = useGetFeesV2();
   const t = useText();
   const config = useConfig();
-  const {
-    colorThresholds: { warning }
-  } = config<ThresholdType>("thresholdConfig", {
-    transformer: "jsonParse"
-  });
 
   // Get menu navigation data from config.
   const menuNavigationData = config<MenuNavigationDataType[]>(
@@ -55,59 +36,13 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   const [userData, setUserData] = useState<
     AuthenticatedPatronV6 | null | undefined
   >();
-  const [loans, setLoans] = useState<LoanType[]>([]);
-  const [reservations, setReservations] = useState<ReservationType[]>([]);
-  const [loansCount, setLoansCount] = useState<number>(0);
-  const [reservationCount, setReservationCount] = useState<number>(0);
   const [feeCount, setFeeCount] = useState<number>(0);
-  const [loansOverdue, setLoansOverdue] = useState<number>(0);
-  const [loansSoonOverdue, setLoansSoonOverdue] = useState<number>(0);
-  const [reservationsReadyForPickup, setReservationsReadyForPickup] =
-    useState<number>(0);
   const { menuViewYourProfileTextUrl, logoutUrl } = useUrls();
 
   // Set user data
   useEffect(() => {
     setUserData(patronData);
   }, [patronData]);
-
-  // Merge digital and physical loans, for easier filtration down the line.
-  useEffect(() => {
-    if (fbsData) {
-      const mappedFbsLoans = mapFBSLoanToLoanType(fbsData);
-      setLoans(mappedFbsLoans);
-    }
-  }, [fbsData]);
-
-  // Set count of loans overdue.
-  useEffect(() => {
-    setLoansOverdue(filterLoansOverdue(loans).length);
-  }, [loans]);
-
-  // Set count of loans soon to be overdue.
-  useEffect(() => {
-    if (warning) {
-      setLoansSoonOverdue(filterLoansSoonOverdue(loans, warning).length);
-    }
-  }, [loans, warning]);
-
-  // Set count of reservations- and ready-for-pickup.
-  useEffect(() => {
-    if (patronReservations) {
-      const mappedReservations =
-        mapFBSReservationToReservationType(patronReservations);
-      setReservations(mappedReservations);
-      setReservationsReadyForPickup(
-        getReadyForPickup(mappedReservations).length
-      );
-      setReservationCount(mappedReservations.length);
-    }
-  }, [patronReservations]);
-
-  // Set count of loans.
-  useEffect(() => {
-    setLoansCount(loans.length);
-  }, [loans]);
 
   // Set count of fees.
   useEffect(() => {
@@ -117,9 +52,9 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   }, [fbsFees]);
 
   const showNotifications =
-    loansOverdue !== 0 ||
-    loansSoonOverdue !== 0 ||
-    reservationsReadyForPickup !== 0;
+    allOverdueLoans.length !== 0 ||
+    allSoonOverdueLoans.length !== 0 ||
+    allReservations.length !== 0;
 
   return (
     <div className="modal-login modal-login--authenticated">
@@ -145,12 +80,7 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
         </div>
         {showNotifications && (
           <div className="modal-profile__container">
-            <DashboardNotificationList
-              reservations={reservations}
-              loans={loans}
-              pageSize={pageSize}
-              columns={false}
-            />
+            <DashboardNotificationList pageSize={pageSize} columns={false} />
           </div>
         )}
         <nav
@@ -161,8 +91,8 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
             {menuNavigationData.map((menuNavigationItem) => (
               <MenuNavigationItem
                 menuNavigationItem={menuNavigationItem}
-                loansCount={loansCount}
-                reservationCount={reservationCount}
+                loansCount={allLoans.length}
+                reservationCount={allReservations.length}
                 feeCount={feeCount}
               />
             ))}

--- a/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
+++ b/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
@@ -19,7 +19,7 @@ interface MenuLoggedInContentProps {
 }
 
 const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
-  const { allReservations } = useReservations();
+  const { reservations } = useReservations();
   const { allLoans, allOverdueLoans, allSoonOverdueLoans } = useLoans();
   const { data: patronData } = usePatronData();
   const { data: fbsFees } = useGetFeesV2();
@@ -54,7 +54,7 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   const showNotifications =
     allOverdueLoans.length !== 0 ||
     allSoonOverdueLoans.length !== 0 ||
-    allReservations.length !== 0;
+    reservations.length !== 0;
 
   return (
     <div className="modal-login modal-login--authenticated">
@@ -92,7 +92,7 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
               <MenuNavigationItem
                 menuNavigationItem={menuNavigationItem}
                 loansCount={allLoans.length}
-                reservationCount={allReservations.length}
+                reservationCount={reservations.length}
                 feeCount={feeCount}
               />
             ))}

--- a/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
+++ b/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
@@ -20,7 +20,7 @@ interface MenuLoggedInContentProps {
 
 const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   const { reservations } = useReservations();
-  const { allLoans, allOverdueLoans, allSoonOverdueLoans } = useLoans();
+  const { loans, loansOverdue, loansSoonOverdue } = useLoans();
   const { data: patronData } = usePatronData();
   const { data: fbsFees } = useGetFeesV2();
   const t = useText();
@@ -52,8 +52,8 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
   }, [fbsFees]);
 
   const showNotifications =
-    allOverdueLoans.length !== 0 ||
-    allSoonOverdueLoans.length !== 0 ||
+    loansOverdue.length !== 0 ||
+    loansSoonOverdue.length !== 0 ||
     reservations.length !== 0;
 
   return (
@@ -91,7 +91,7 @@ const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
             {menuNavigationData.map((menuNavigationItem) => (
               <MenuNavigationItem
                 menuNavigationItem={menuNavigationItem}
-                loansCount={allLoans.length}
+                loansCount={loans.length}
                 reservationCount={reservations.length}
                 feeCount={feeCount}
               />

--- a/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
+++ b/src/apps/menu/menu-logged-in/MenuLoggedInContent.tsx
@@ -19,7 +19,9 @@ interface MenuLoggedInContentProps {
 }
 
 const MenuLoggedInContent: FC<MenuLoggedInContentProps> = ({ pageSize }) => {
-  const { reservations } = useReservations();
+  const {
+    all: { reservations }
+  } = useReservations();
   const { loans, loansOverdue, loansSoonOverdue } = useLoans();
   const { data: patronData } = usePatronData();
   const { data: fbsFees } = useGetFeesV2();

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -325,7 +325,7 @@ export const pageSizeGlobal = (
 export const materialIsOverdue = (date: string | undefined | null) =>
   dayjs().isAfter(dayjs(date), "day");
 
-export const getPhysicalQueuedReservations = (list: ReservationType[]) => {
+export const getQueuedReservations = (list: ReservationType[]) => {
   return [...list].filter(
     ({ state }) => state === dashboardReservedApiValueText
   );

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -16,7 +16,6 @@ import { LoanType } from "../types/loan-type";
 import { ListType } from "../types/list-type";
 import { ManifestationReviewFieldsFragment } from "../../dbc-gateway/generated/graphql";
 import { FeeV2 } from "../../fbs/model/feeV2";
-import { dashboardReservedApiValueText } from "../../configuration/api-strings.json";
 import { ReservationType } from "../types/reservation-type";
 import { ManifestationMaterialType } from "../types/material-type";
 import { store } from "../../store";
@@ -303,12 +302,6 @@ export const pageSizeGlobal = (
 
 export const materialIsOverdue = (date: string | undefined | null) =>
   dayjs().isAfter(dayjs(date), "day");
-
-export const getQueuedReservations = (list: ReservationType[]) => {
-  return [...list].filter(
-    ({ state }) => state === dashboardReservedApiValueText
-  );
-};
 
 export const loansOverdue = (loans: LoanType[]): boolean => {
   return loans.every((loan) => materialIsOverdue(loan.dueDate));

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -178,16 +178,6 @@ export const getParams = (props: Record<string, string | undefined>) =>
     {}
   );
 
-export const sortByDueDate = (list: LoanType[]) => {
-  // Todo figure out what to do if loan does not have loan date
-  // For now, its at the bottom of the list
-  return list.sort(
-    (a, b) =>
-      new Date(a.dueDate || new Date()).getTime() -
-      new Date(b.dueDate || new Date()).getTime()
-  );
-};
-
 export const sortByLoanDate = (list: LoanType[]) => {
   // Todo figure out what to do if loan does not have loan date
   // For now, its at the bottom of the list
@@ -204,17 +194,6 @@ export const sortByReservationDate = (list: ReservationType[]) => {
       new Date(objA.dateOfReservation || new Date()).getTime() -
       new Date(objB.dateOfReservation || new Date()).getTime()
   );
-};
-
-export const getDueDatesLoan = (list: LoanType[]) => {
-  return Array.from(
-    new Set(
-      list
-        .filter(({ dueDate }) => dueDate !== (undefined || null))
-        .map(({ dueDate }) => dueDate)
-        .sort()
-    )
-  ) as string[];
 };
 
 export const getDueDatesForModal = (list: LoanType[], date: string) => {
@@ -345,24 +324,6 @@ export const tallyUpFees = (fees: FeeV2[]) => {
     .toLocaleString("da-DA");
 };
 
-// Loans overdue
-export const filterLoansOverdue = (loans: LoanType[]) => {
-  return loans.filter(({ dueDate }) => {
-    return materialIsOverdue(dueDate);
-  });
-};
-
-export const filterLoansSoonOverdue = (loans: LoanType[], warning: number) => {
-  return loans.filter(({ dueDate }) => {
-    const due: string = dueDate || "";
-    const daysUntilExpiration = daysBetweenTodayAndDate(due);
-    return (
-      daysUntilExpiration - warning <= 0 &&
-      daysUntilExpiration - warning >= -warning
-    );
-  });
-};
-
 export const getMaterialTypes = (
   manifestations: Manifestation[],
   onlyFirstType = true
@@ -404,14 +365,6 @@ export const getAllFaustIds = (manifestations: Manifestation[]) => {
 
 export const getScrollClass = (modalIds: string[]) => {
   return modalIds.length > 0 ? "scroll-lock-background" : "";
-};
-// Loans with more than warning-threshold days until due
-export const filterLoansNotOverdue = (loans: LoanType[], warning: number) => {
-  return loans.filter(({ dueDate }) => {
-    const due: string = dueDate || "";
-    const daysUntilExpiration = daysBetweenTodayAndDate(due);
-    return daysUntilExpiration - warning > 0;
-  });
 };
 
 function getDateFromCpr(cprInput: string) {

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -16,13 +16,24 @@ import { ThresholdType } from "./types/threshold-type";
 
 const useLoans = () => {
   const config = useConfig();
-  const { data: loansFbs } = useGetLoansV2();
-  const { data: loansPublizon } = useGetV1UserLoans();
+  const {
+    data: loansFbs,
+    isLoading: isLoadingFbs,
+    isError: isErrorFbs
+  } = useGetLoansV2();
+  const {
+    data: loansPublizon,
+    isLoading: isLoadingPublizon,
+    isError: isErrorPublizon
+  } = useGetV1UserLoans();
   const {
     colorThresholds: { warning }
   } = config<ThresholdType>("thresholdConfig", {
     transformer: "jsonParse"
   });
+
+  const loansIsLoading = isLoadingFbs || isLoadingPublizon;
+  const loansIsError = isErrorFbs || isErrorPublizon;
 
   // map loans to same type
   const mappedLoansFbs = loansFbs ? mapFBSLoanToLoanType(loansFbs) : [];
@@ -81,7 +92,9 @@ const useLoans = () => {
     loansOverdue,
     loansSoonOverdue,
     loansFarFromOverdue,
-    stackedMaterialsDueDatesFbs
+    stackedMaterialsDueDatesFbs,
+    loansIsLoading,
+    loansIsError
   };
 };
 

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -34,53 +34,53 @@ const useLoans = () => {
     : [];
 
   // Combine all loans from both FBS and Publizon
-  const allLoans = sortByDueDate([...mappedLoansFbs, ...mappedLoansPublizon]);
+  const loans = sortByDueDate([...mappedLoansFbs, ...mappedLoansPublizon]);
 
   // Combine "overdue loans" from both FBS and Publizon
-  const overdueLoansFBS = filterLoansOverdue(mappedLoansFbs);
-  const overdueLoansPublizon = filterLoansOverdue(mappedLoansPublizon);
-  const allOverdueLoans = sortByDueDate([
-    ...overdueLoansFBS,
-    ...overdueLoansPublizon
+  const loansOverdueFBS = filterLoansOverdue(mappedLoansFbs);
+  const LoansOverduePublizon = filterLoansOverdue(mappedLoansPublizon);
+  const loansOverdue = sortByDueDate([
+    ...loansOverdueFBS,
+    ...LoansOverduePublizon
   ]);
 
   // combine "soon overdue" loans from both FBS and Publizon
-  const soonOverdueLoansFBS = filterLoansSoonOverdue(mappedLoansFbs, warning);
-  const soonOverdueLoansPublizon = filterLoansSoonOverdue(
+  const loansSoonOverdueFBS = filterLoansSoonOverdue(mappedLoansFbs, warning);
+  const loansSoonOverduePublizon = filterLoansSoonOverdue(
     mappedLoansPublizon,
     warning
   );
-  const allSoonOverdueLoans = sortByDueDate([
-    ...soonOverdueLoansFBS,
-    ...soonOverdueLoansPublizon
+  const loansSoonOverdue = sortByDueDate([
+    ...loansSoonOverdueFBS,
+    ...loansSoonOverduePublizon
   ]);
 
   // combine "far from overdue" loans from both FBS and Publizon
-  const farFromOverdueFBS = filterLoansNotOverdue(mappedLoansFbs, warning);
-  const farFromOverduePublizon = filterLoansNotOverdue(
+  const loansFarFromOverdueFBS = filterLoansNotOverdue(mappedLoansFbs, warning);
+  const loansFarFromOverduePublizon = filterLoansNotOverdue(
     mappedLoansPublizon,
     warning
   );
-  const allFarFromOverdueLoans = sortByDueDate([
-    ...farFromOverdueFBS,
-    ...farFromOverduePublizon
+  const loansFarFromOverdue = sortByDueDate([
+    ...loansFarFromOverdueFBS,
+    ...loansFarFromOverduePublizon
   ]);
 
   // The due dates are used for the stacked materials
   // The stacked materials view shows materials stacked by
   // due date, and for this we need a unique list of due dates
-  const sortedByLoanDateFbs = sortByDueDate(mappedLoansFbs);
-  const sortedByLoanDatePublizon = sortByDueDate(mappedLoansPublizon);
+  const loansSortedByDateFbs = sortByDueDate(mappedLoansFbs);
+  const loansSortedByDatePublizon = sortByDueDate(mappedLoansPublizon);
 
   // list of all due dates used for the stacked materials
   const stackedMaterialsDueDatesFbs = getDueDatesLoan(mappedLoansFbs);
   return {
-    allLoans,
-    sortedByLoanDateFbs,
-    sortedByLoanDatePublizon,
-    allOverdueLoans,
-    allSoonOverdueLoans,
-    allFarFromOverdueLoans,
+    loans,
+    loansSortedByDateFbs,
+    loansSortedByDatePublizon,
+    loansOverdue,
+    loansSoonOverdue,
+    loansFarFromOverdue,
     stackedMaterialsDueDatesFbs
   };
 };

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -57,19 +57,17 @@ const sortByDueDate = (list: LoanType[]) => {
 };
 
 type Loans = {
+  loans: LoanType[];
   overdue: LoanType[];
   soonOverdue: LoanType[];
   farFromOverdue: LoanType[];
   isLoading: boolean;
   isError: boolean;
-  sortedByDate?: LoanType[];
   stackedMaterialsDueDates?: string[];
 };
 
 type UseLoansType = {
-  all: Loans & {
-    loans: LoanType[];
-  };
+  all: Loans;
   fbs: Loans;
   publizon: Loans;
 };
@@ -157,19 +155,19 @@ const useLoans: UseLoans = () => {
       isError: loansIsError
     },
     fbs: {
+      loans: loansSortedByDateFbs,
       overdue: loansOverdueFBS,
       soonOverdue: loansSoonOverdueFBS,
       farFromOverdue: loansFarFromOverdueFBS,
-      sortedByDate: loansSortedByDateFbs,
       stackedMaterialsDueDates: stackedMaterialsDueDatesFbs,
       isLoading: isLoadingFbs,
       isError: isErrorFbs
     },
     publizon: {
+      loans: loansSortedByDatePublizon,
       overdue: LoansOverduePublizon,
       soonOverdue: loansSoonOverduePublizon,
       farFromOverdue: loansFarFromOverduePublizon,
-      sortedByDate: loansSortedByDatePublizon,
       isLoading: isLoadingPublizon,
       isError: isErrorPublizon
     }

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -1,0 +1,88 @@
+import { useGetLoansV2 } from "../fbs/fbs";
+import { useGetV1UserLoans } from "../publizon/publizon";
+import { useConfig } from "./config";
+import {
+  filterLoansNotOverdue,
+  filterLoansOverdue,
+  filterLoansSoonOverdue,
+  getDueDatesLoan,
+  sortByDueDate
+} from "./helpers/general";
+import {
+  mapFBSLoanToLoanType,
+  mapPublizonLoanToLoanType
+} from "./helpers/list-mapper";
+import { ThresholdType } from "./types/threshold-type";
+
+const useLoans = () => {
+  const config = useConfig();
+  const { data: loansFbs } = useGetLoansV2();
+  const { data: loansPublizon } = useGetV1UserLoans();
+  const {
+    colorThresholds: { warning }
+  } = config<ThresholdType>("thresholdConfig", {
+    transformer: "jsonParse"
+  });
+
+  // map loans to same type
+  const mappedLoansFbs = loansFbs ? mapFBSLoanToLoanType(loansFbs) : [];
+  const mappedLoansPublizon = loansPublizon?.loans
+    ? mapPublizonLoanToLoanType(loansPublizon.loans)
+        // TODO: is it necessary to filter out loans without dueDate?
+        // there are loans without dueDate in the publizon MOCK data
+        .filter((item) => item.dueDate)
+    : [];
+
+  // Combine all loans from both FBS and Publizon
+  const allLoans = sortByDueDate([...mappedLoansFbs, ...mappedLoansPublizon]);
+
+  // Combine "overdue loans" from both FBS and Publizon
+  const overdueLoansFBS = filterLoansOverdue(mappedLoansFbs);
+  const overdueLoansPublizon = filterLoansOverdue(mappedLoansPublizon);
+  const allOverdueLoans = sortByDueDate([
+    ...overdueLoansFBS,
+    ...overdueLoansPublizon
+  ]);
+
+  // combine "soon overdue" loans from both FBS and Publizon
+  const soonOverdueLoansFBS = filterLoansSoonOverdue(mappedLoansFbs, warning);
+  const soonOverdueLoansPublizon = filterLoansSoonOverdue(
+    mappedLoansPublizon,
+    warning
+  );
+  const allSoonOverdueLoans = sortByDueDate([
+    ...soonOverdueLoansFBS,
+    ...soonOverdueLoansPublizon
+  ]);
+
+  // combine "far from overdue" loans from both FBS and Publizon
+  const farFromOverdueFBS = filterLoansNotOverdue(mappedLoansFbs, warning);
+  const farFromOverduePublizon = filterLoansNotOverdue(
+    mappedLoansPublizon,
+    warning
+  );
+  const allFarFromOverdueLoans = sortByDueDate([
+    ...farFromOverdueFBS,
+    ...farFromOverduePublizon
+  ]);
+
+  // The due dates are used for the stacked materials
+  // The stacked materials view shows materials stacked by
+  // due date, and for this we need a unique list of due dates
+  const sortedByLoanDateFbs = sortByDueDate(mappedLoansFbs);
+  const sortedByLoanDatePublizon = sortByDueDate(mappedLoansPublizon);
+
+  // list of all due dates used for the stacked materials
+  const stackedMaterialsDueDatesFbs = getDueDatesLoan(mappedLoansFbs);
+  return {
+    allLoans,
+    sortedByLoanDateFbs,
+    sortedByLoanDatePublizon,
+    allOverdueLoans,
+    allSoonOverdueLoans,
+    allFarFromOverdueLoans,
+    stackedMaterialsDueDatesFbs
+  };
+};
+
+export default useLoans;

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -12,9 +12,30 @@ import {
   mapFBSLoanToLoanType,
   mapPublizonLoanToLoanType
 } from "./helpers/list-mapper";
+import { LoanType } from "./types/loan-type";
 import { ThresholdType } from "./types/threshold-type";
 
-const useLoans = () => {
+type Loans = {
+  overdue: LoanType[];
+  soonOverdue: LoanType[];
+  farFromOverdue: LoanType[];
+  isLoading: boolean;
+  isError: boolean;
+  sortedByDate?: LoanType[];
+  stackedMaterialsDueDates?: string[];
+};
+
+type UseLoansType = {
+  all: Loans & {
+    loans: LoanType[];
+  };
+  fbs: Loans;
+  publizon: Loans;
+};
+
+type UseLoans = () => UseLoansType;
+
+const useLoans: UseLoans = () => {
   const config = useConfig();
   const {
     data: loansFbs,
@@ -86,15 +107,31 @@ const useLoans = () => {
   // list of all due dates used for the stacked materials
   const stackedMaterialsDueDatesFbs = getDueDatesLoan(mappedLoansFbs);
   return {
-    loans,
-    loansSortedByDateFbs,
-    loansSortedByDatePublizon,
-    loansOverdue,
-    loansSoonOverdue,
-    loansFarFromOverdue,
-    stackedMaterialsDueDatesFbs,
-    loansIsLoading,
-    loansIsError
+    all: {
+      loans,
+      overdue: loansOverdue,
+      soonOverdue: loansSoonOverdue,
+      farFromOverdue: loansFarFromOverdue,
+      isLoading: loansIsLoading,
+      isError: loansIsError
+    },
+    fbs: {
+      overdue: loansOverdueFBS,
+      soonOverdue: loansSoonOverdueFBS,
+      farFromOverdue: loansFarFromOverdueFBS,
+      sortedByDate: loansSortedByDateFbs,
+      stackedMaterialsDueDates: stackedMaterialsDueDatesFbs,
+      isLoading: isLoadingFbs,
+      isError: isErrorFbs
+    },
+    publizon: {
+      overdue: LoansOverduePublizon,
+      soonOverdue: loansSoonOverduePublizon,
+      farFromOverdue: loansFarFromOverduePublizon,
+      sortedByDate: loansSortedByDatePublizon,
+      isLoading: isLoadingPublizon,
+      isError: isErrorPublizon
+    }
   };
 };
 

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -1,0 +1,61 @@
+import { useGetReservationsV2 } from "../fbs/fbs";
+import { useGetV1UserReservations } from "../publizon/publizon";
+import { getPhysicalQueuedReservations } from "./helpers/general";
+import {
+  mapFBSReservationToReservationType,
+  mapPublizonReservationToReservationType
+} from "./helpers/list-mapper";
+import { getReadyForPickup } from "../../apps/reservation-list/utils/helpers";
+
+const useReservations = () => {
+  const { data: reservationsFbs } = useGetReservationsV2();
+  const { data: reservationsPublizon } = useGetV1UserReservations();
+
+  // map reservations to same type
+  const mappedReservationsFbs = reservationsFbs
+    ? mapFBSReservationToReservationType(reservationsFbs)
+    : [];
+  const mappedReservationsPublizon = reservationsPublizon?.reservations
+    ? mapPublizonReservationToReservationType(reservationsPublizon.reservations)
+    : [];
+
+  // Combine all reservations from both FBS and Publizon
+  const allReservations = [
+    ...mappedReservationsFbs,
+    ...mappedReservationsPublizon
+  ];
+
+  // Combine "ready to loan" reservations from both FBS and Publizon
+  const readyToLoanReservationsFBS = getReadyForPickup(mappedReservationsFbs);
+  const readyToLoanReservationsPublizon = getReadyForPickup(
+    mappedReservationsPublizon
+  );
+  const allReadyToLoanReservations = [
+    ...readyToLoanReservationsFBS,
+    ...readyToLoanReservationsPublizon
+  ];
+
+  // Combine "still in queue" reservations from both FBS and Publizon
+  const queuedFBSReservations = getPhysicalQueuedReservations(
+    mappedReservationsFbs
+  );
+  const queuedPublizonReservations = getPhysicalQueuedReservations(
+    mappedReservationsPublizon
+  );
+  const allQueuedReservations = [
+    ...queuedFBSReservations,
+    ...queuedPublizonReservations
+  ];
+
+  return {
+    allReservations,
+    readyToLoanReservationsFBS,
+    readyToLoanReservationsPublizon,
+    allReadyToLoanReservations,
+    allQueuedReservations,
+    queuedFBSReservations,
+    queuedPublizonReservations
+  };
+};
+
+export default useReservations;

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -20,39 +20,39 @@ const useReservations = () => {
     : [];
 
   // Combine all reservations from both FBS and Publizon
-  const allReservations = [
+  const reservations = [
     ...mappedReservationsFbs,
     ...mappedReservationsPublizon
   ];
 
   // Combine "ready to loan" reservations from both FBS and Publizon
-  const readyToLoanReservationsFBS = getReadyForPickup(mappedReservationsFbs);
-  const readyToLoanReservationsPublizon = getReadyForPickup(
+  const reservationsReadyToLoanFBS = getReadyForPickup(mappedReservationsFbs);
+  const reservationsReadyToLoanPublizon = getReadyForPickup(
     mappedReservationsPublizon
   );
-  const allReadyToLoanReservations = [
-    ...readyToLoanReservationsFBS,
-    ...readyToLoanReservationsPublizon
+  const reservationsReadyToLoan = [
+    ...reservationsReadyToLoanFBS,
+    ...reservationsReadyToLoanPublizon
   ];
 
   // Combine "still in queue" reservations from both FBS and Publizon
-  const queuedFBSReservations = getQueuedReservations(mappedReservationsFbs);
-  const queuedPublizonReservations = getQueuedReservations(
+  const reservationsQueuedFBS = getQueuedReservations(mappedReservationsFbs);
+  const reservationsQueuedPublizon = getQueuedReservations(
     mappedReservationsPublizon
   );
-  const allQueuedReservations = [
-    ...queuedFBSReservations,
-    ...queuedPublizonReservations
+  const reservationsQueued = [
+    ...reservationsQueuedFBS,
+    ...reservationsQueuedPublizon
   ];
 
   return {
-    allReservations,
-    readyToLoanReservationsFBS,
-    readyToLoanReservationsPublizon,
-    allReadyToLoanReservations,
-    allQueuedReservations,
-    queuedFBSReservations,
-    queuedPublizonReservations
+    reservations,
+    reservationsReadyToLoanFBS,
+    reservationsReadyToLoanPublizon,
+    reservationsReadyToLoan,
+    reservationsQueued,
+    reservationsQueuedFBS,
+    reservationsQueuedPublizon
   };
 };
 

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -15,6 +15,7 @@ const getQueuedReservations = (list: ReservationType[]) => {
 };
 
 type Reservations = {
+  reservations: ReservationType[];
   readyToLoan: ReservationType[];
   queued: ReservationType[];
   isLoading: boolean;
@@ -22,9 +23,7 @@ type Reservations = {
 };
 
 type UseReservationsType = {
-  all: Reservations & {
-    reservations: ReservationType[];
-  };
+  all: Reservations;
   fbs: Reservations;
   publizon: Reservations;
 };
@@ -89,12 +88,14 @@ const useReservations: UseReservations = () => {
       isError: reservationsIsError
     },
     fbs: {
+      reservations: mappedReservationsFbs,
       readyToLoan: reservationsReadyToLoanFBS,
       queued: reservationsQueuedFBS,
       isLoading: isLoadingFbs,
       isError: isErrorFbs
     },
     publizon: {
+      reservations: mappedReservationsPublizon,
       readyToLoan: reservationsReadyToLoanPublizon,
       queued: reservationsQueuedPublizon,
       isLoading: isLoadingPublizon,

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -6,8 +6,26 @@ import {
   mapPublizonReservationToReservationType
 } from "./helpers/list-mapper";
 import { getReadyForPickup } from "../../apps/reservation-list/utils/helpers";
+import { ReservationType } from "./types/reservation-type";
 
-const useReservations = () => {
+type Reservations = {
+  readyToLoan: ReservationType[];
+  queued: ReservationType[];
+  isLoading: boolean;
+  isError: boolean;
+};
+
+type UseReservationsType = {
+  all: Reservations & {
+    reservations: ReservationType[];
+  };
+  fbs: Reservations;
+  publizon: Reservations;
+};
+
+type UseReservations = () => UseReservationsType;
+
+const useReservations: UseReservations = () => {
   const {
     data: reservationsFbs,
     isLoading: isLoadingFbs,
@@ -57,15 +75,25 @@ const useReservations = () => {
   ];
 
   return {
-    reservations,
-    reservationsReadyToLoanFBS,
-    reservationsReadyToLoanPublizon,
-    reservationsReadyToLoan,
-    reservationsQueued,
-    reservationsQueuedFBS,
-    reservationsQueuedPublizon,
-    reservationsIsLoading,
-    reservationsIsError
+    all: {
+      reservations,
+      readyToLoan: reservationsReadyToLoan,
+      queued: reservationsQueued,
+      isLoading: reservationsIsLoading,
+      isError: reservationsIsError
+    },
+    fbs: {
+      readyToLoan: reservationsReadyToLoanFBS,
+      queued: reservationsQueuedFBS,
+      isLoading: isLoadingFbs,
+      isError: isErrorFbs
+    },
+    publizon: {
+      readyToLoan: reservationsReadyToLoanPublizon,
+      queued: reservationsQueuedPublizon,
+      isLoading: isLoadingPublizon,
+      isError: isErrorPublizon
+    }
   };
 };
 

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -8,8 +8,19 @@ import {
 import { getReadyForPickup } from "../../apps/reservation-list/utils/helpers";
 
 const useReservations = () => {
-  const { data: reservationsFbs } = useGetReservationsV2();
-  const { data: reservationsPublizon } = useGetV1UserReservations();
+  const {
+    data: reservationsFbs,
+    isLoading: isLoadingFbs,
+    isError: isErrorFbs
+  } = useGetReservationsV2();
+  const {
+    data: reservationsPublizon,
+    isLoading: isLoadingPublizon,
+    isError: isErrorPublizon
+  } = useGetV1UserReservations();
+
+  const reservationsIsLoading = isLoadingFbs || isLoadingPublizon;
+  const reservationsIsError = isErrorFbs || isErrorPublizon;
 
   // map reservations to same type
   const mappedReservationsFbs = reservationsFbs
@@ -52,7 +63,9 @@ const useReservations = () => {
     reservationsReadyToLoan,
     reservationsQueued,
     reservationsQueuedFBS,
-    reservationsQueuedPublizon
+    reservationsQueuedPublizon,
+    reservationsIsLoading,
+    reservationsIsError
   };
 };
 

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -1,6 +1,6 @@
 import { useGetReservationsV2 } from "../fbs/fbs";
 import { useGetV1UserReservations } from "../publizon/publizon";
-import { getPhysicalQueuedReservations } from "./helpers/general";
+import { getQueuedReservations } from "./helpers/general";
 import {
   mapFBSReservationToReservationType,
   mapPublizonReservationToReservationType
@@ -36,10 +36,8 @@ const useReservations = () => {
   ];
 
   // Combine "still in queue" reservations from both FBS and Publizon
-  const queuedFBSReservations = getPhysicalQueuedReservations(
-    mappedReservationsFbs
-  );
-  const queuedPublizonReservations = getPhysicalQueuedReservations(
+  const queuedFBSReservations = getQueuedReservations(mappedReservationsFbs);
+  const queuedPublizonReservations = getQueuedReservations(
     mappedReservationsPublizon
   );
   const allQueuedReservations = [

--- a/src/core/utils/useReservations.tsx
+++ b/src/core/utils/useReservations.tsx
@@ -1,12 +1,18 @@
 import { useGetReservationsV2 } from "../fbs/fbs";
 import { useGetV1UserReservations } from "../publizon/publizon";
-import { getQueuedReservations } from "./helpers/general";
 import {
   mapFBSReservationToReservationType,
   mapPublizonReservationToReservationType
 } from "./helpers/list-mapper";
 import { getReadyForPickup } from "../../apps/reservation-list/utils/helpers";
 import { ReservationType } from "./types/reservation-type";
+import { dashboardReservedApiValueText } from "../configuration/api-strings.json";
+
+const getQueuedReservations = (list: ReservationType[]) => {
+  return [...list].filter(
+    ({ state }) => state === dashboardReservedApiValueText
+  );
+};
 
 type Reservations = {
   readyToLoan: ReservationType[];


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-197
https://reload.atlassian.net/browse/DDFLSBP-198
https://reload.atlassian.net/browse/DDFLSBP-233
https://reload.atlassian.net/browse/DDFLSBP-157

#### Description

This Pull Request addresses issues pertaining to the display of reservations and loans from both FBS and Publizon systems. It introduces two new hooks: `useReservations` and `useLoans` and the implement of them

These new hooks simplify interactions with both FBS and Publizon systems by consolidating reservations and loans from each provider, respectively. Additionally, they return other specific lists of loans and reservations as required for the UI.

The changes have been integrated in sections relevant to loans and reservations.

All changes have been consolidated into a single commit to mitigate potential merge conflicts, especially with Kasper Garnes who has been working on the same files.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/a86c5aac-da47-415e-ba2f-a4952f7bc051

<img width="959" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/c87fdffd-77cd-46a1-a999-f6a3e281d18b">

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/cc2db61c-8ddd-4534-8fe8-e16b5b19156b