### PR TITLE
Fix/ereol pickup indication

### DIFF
--- a/src/apps/reservation-list/list/reservation-list.dev.tsx
+++ b/src/apps/reservation-list/list/reservation-list.dev.tsx
@@ -118,6 +118,10 @@ export default {
       defaultValue: "You are at the front of the queue",
       control: { type: "text" }
     },
+    reservationListDigitalPickupText: {
+      defaultValue: "Online access",
+      control: { type: "text" }
+    },
     reservationListInQueueText: {
       defaultValue: "queued",
       control: { type: "text" }

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -33,6 +33,7 @@ export interface ReservationListTextProps {
   etAlText: string;
   reservationListNumberInQueueText: string;
   reservationListFirstInQueueText: string;
+  reservationListDigitalPickupText: string;
   expiresSoonText: string;
   reservationListInQueueText: string;
   reservationPickUpLatestText: string;

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -81,7 +81,10 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
         color={success as string}
         percent={100}
         info={getInfo()}
-        label={[pickupLibrary, pickupNumber || ""]}
+        label={[
+          pickupLibrary,
+          pickupNumber || t("reservationListDigitalPickupText")
+        ]}
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}
         empty={!showStatusCircleIcon}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-213

#### Description
The pickup indication wasn't present for online materials on the user reservations list. A physical address was shown for physical materials, but there was nothing at all for the digital ones. Now we have a generic translatable text for these.
 
#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/c5ae89c7-1a9e-4ca2-bb47-38ac10128a75)


#### Additional comments or questions
n/a