### PR TITLE
Scroll advanced search results into view on click of "search" button

### DIFF
--- a/src/apps/advanced-search/AdvancedSearchHeader.tsx
+++ b/src/apps/advanced-search/AdvancedSearchHeader.tsx
@@ -80,24 +80,39 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
     setSearchObject(structuredClone(initialAdvancedSearchQuery));
   };
 
-  useEffect(() => {
-    if (searchQuery && !searchObject) {
-      setIsFormMode(false);
+  const scrollToResults = () => {
+    const element = document.getElementById("advanced-search-result");
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" });
     }
-  }, [searchObject, searchQuery]);
+  };
 
   const handleSearchButtonClick = () => {
     if (rawCql.trim() !== "" && !isFormMode) {
       setSearchQuery(rawCql);
+      // Half a second makes sure search result is rendered before scrolling to it.
+      setTimeout(() => {
+        scrollToResults();
+      }, 500);
       return;
     }
     setSearchObject(internalSearchObject);
+    // Half a second makes sure search result is rendered before scrolling to it.
+    setTimeout(() => {
+      scrollToResults();
+    }, 500);
   };
 
   const [isSearchButtonDisabled, setIsSearchButtonDisabled] =
     useState<boolean>(true);
 
   const translatedCql = previewCql || searchQuery || "";
+
+  useEffect(() => {
+    if (searchQuery && !searchObject) {
+      setIsFormMode(false);
+    }
+  }, [searchObject, searchQuery]);
 
   useEffect(() => {
     setIsSearchButtonDisabled(

--- a/src/apps/advanced-search/AdvancedSearchResults.tsx
+++ b/src/apps/advanced-search/AdvancedSearchResults.tsx
@@ -103,7 +103,11 @@ const AdvancedSearchResult: React.FC<AdvancedSearchResultProps> = ({
   return (
     <>
       {!showContentOnly && <div className="advanced-search__divider" />}
-      <h2 className="text-header-h2 advanced-search__title capitalize-first">
+      <h2
+        className="text-header-h2 advanced-search__title capitalize-first"
+        /* ID is used to scroll to the results upon hitting the search button. */
+        id="advanced-search-result"
+      >
         {isLoading && t("loadingResultsText")}
         {shouldShowResultHeadline &&
           t("showingMaterialsText", {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-76

#### Description
This PR introduces a scoll into view feature for the advanced search results upon clicking the search button.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/2abf4fab-43d2-4741-9646-f27bd0f50d7c

#### Additional comments or questions
n/a