### PR TITLE
Refactoring thresholdConfig => expirationWarningDaysBeforeConfig

### DIFF
--- a/src/apps/dashboard/dashboard.dev.tsx
+++ b/src/apps/dashboard/dashboard.dev.tsx
@@ -156,10 +156,8 @@ export default {
       defaultValue: "Borrow before @date",
       control: { type: "text" }
     },
-    // Config
-    thresholdConfig: {
-      defaultValue:
-        '{\n      "colorThresholds":{\n      "danger":"0",\n      "warning":"6"\n   }\n   }',
+    expirationWarningDaysBeforeConfig: {
+      defaultValue: "6",
       control: { type: "text" }
     }
   },

--- a/src/apps/dashboard/dashboard.entry.tsx
+++ b/src/apps/dashboard/dashboard.entry.tsx
@@ -22,7 +22,7 @@ export interface DashBoardProps {
   // Config
   blacklistedPickupBranchesConfig: string;
   branchesConfig: string;
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
   // Texts
   yourProfileText: string;
   feesText: string;

--- a/src/apps/fee-list/FeeList.dev.tsx
+++ b/src/apps/fee-list/FeeList.dev.tsx
@@ -67,9 +67,8 @@ export default {
       defaultValue: "@amount,-",
       control: { type: "text" }
     },
-    thresholdConfig: {
-      defaultValue:
-        '{\n      "colorThresholds":{\n      "danger":"0",\n      "warning":"6"\n   }\n   }',
+    expirationWarningDaysBeforeConfig: {
+      defaultValue: "6",
       control: { type: "text" }
     },
     iAcceptText: {

--- a/src/apps/fee-list/FeeList.entry.tsx
+++ b/src/apps/fee-list/FeeList.entry.tsx
@@ -8,7 +8,7 @@ import GlobalUrlEntryPropsInterface from "../../core/utils/types/global-url-prop
 import { withConfig } from "../../core/utils/config";
 
 export interface IntermedateListEntryConfigProps {
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
 }
 
 export interface FeeListProps {

--- a/src/apps/loan-list/list/loan-list.dev.tsx
+++ b/src/apps/loan-list/list/loan-list.dev.tsx
@@ -36,9 +36,8 @@ export default {
       control: { type: "number" }
     },
     // Config
-    thresholdConfig: {
-      defaultValue:
-        '{\n      "colorThresholds":{\n      "danger":"0",\n      "warning":"6"\n   }\n   }',
+    expirationWarningDaysBeforeConfig: {
+      defaultValue: "6",
       control: { type: "text" }
     },
     // Texts

--- a/src/apps/loan-list/list/loan-list.entry.tsx
+++ b/src/apps/loan-list/list/loan-list.entry.tsx
@@ -14,11 +14,11 @@ import { MaterialDetailsModalProps } from "../../../core/storybook/materialDetai
 import { AcceptFeesModalEntryTextProps } from "../../../core/storybook/acceptFeesModalArgs";
 
 export interface LoanListEntryConfigProps {
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
 }
 export interface LoanListEntryUrlProps {
   materialOverdueUrl: string;
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
 }
 
 interface LoanListEntryTextProps {

--- a/src/apps/loan-list/materials/utils/status-badge.tsx
+++ b/src/apps/loan-list/materials/utils/status-badge.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from "react";
-import { ThresholdType } from "../../../../core/utils/types/threshold-type";
-import { useConfig } from "../../../../core/utils/config";
 import { daysBetweenTodayAndDate } from "../../../../core/utils/helpers/general";
+import useLoanThresholds from "../../../../core/utils/useLoanThresholds";
 
 interface StatusBadgeProps {
   badgeDate?: string | null;
@@ -20,26 +19,18 @@ const StatusBadge: FC<StatusBadgeProps> = ({
   infoText,
   neutralText
 }) => {
-  const config = useConfig();
+  const threshold = useLoanThresholds();
+  const daysBetweenTodayAndDue = badgeDate
+    ? daysBetweenTodayAndDate(badgeDate)
+    : 0;
 
-  const {
-    colorThresholds: { danger, warning }
-  } = config<ThresholdType>("thresholdConfig", {
-    transformer: "jsonParse"
-  });
-
-  let daysBetweenTodayAndDue = 0;
-  if (badgeDate) {
-    daysBetweenTodayAndDue = daysBetweenTodayAndDate(badgeDate);
-  }
-
-  if (daysBetweenTodayAndDue < Number(danger) && dangerText) {
+  if (daysBetweenTodayAndDue < threshold.danger && dangerText) {
     return (
       <div className="status-label status-label--danger">{dangerText}</div>
     );
   }
 
-  if (daysBetweenTodayAndDue <= Number(warning) && warningText) {
+  if (daysBetweenTodayAndDue <= threshold.warning && warningText) {
     return (
       <div className="status-label status-label--warning">{warningText}</div>
     );

--- a/src/apps/loan-list/materials/utils/status-circle.tsx
+++ b/src/apps/loan-list/materials/utils/status-circle.tsx
@@ -7,8 +7,7 @@ import {
   daysBetweenDates
 } from "../../../../core/utils/helpers/general";
 import { useText } from "../../../../core/utils/text";
-import { useConfig } from "../../../../core/utils/config";
-import { ThresholdType } from "../../../../core/utils/types/threshold-type";
+import useLoanThresholds from "../../../../core/utils/useLoanThresholds";
 
 interface StatusCircleProps {
   dueDate?: string | null;
@@ -17,13 +16,9 @@ interface StatusCircleProps {
 
 const StatusCircle: FC<StatusCircleProps> = ({ loanDate, dueDate }) => {
   const t = useText();
-  const config = useConfig();
   const colors = getColors();
-  const {
-    colorThresholds: { danger, warning }
-  } = config<ThresholdType>("thresholdConfig", {
-    transformer: "jsonParse"
-  });
+  const threshold = useLoanThresholds();
+
   let color = colors.default;
   let percent = 100;
   let daysBetweenTodayAndDue = null;
@@ -36,9 +31,9 @@ const StatusCircle: FC<StatusCircleProps> = ({ loanDate, dueDate }) => {
     if (percent < 0) {
       percent = 100;
     }
-    if (daysBetweenTodayAndDue < danger) {
+    if (daysBetweenTodayAndDue < threshold.danger) {
       color = colors.danger;
-    } else if (daysBetweenTodayAndDue <= warning) {
+    } else if (daysBetweenTodayAndDue <= threshold.warning) {
       color = colors.warning;
     }
   } else {

--- a/src/apps/menu/menu.dev.tsx
+++ b/src/apps/menu/menu.dev.tsx
@@ -144,9 +144,8 @@ export default {
       defaultValue: "/Signup",
       control: { type: "text" }
     },
-    thresholdConfig: {
-      defaultValue:
-        '{\n      "colorThresholds":{\n      "danger":"0",\n      "warning":"6"\n   }\n   }',
+    expirationWarningDaysBeforeConfig: {
+      defaultValue: "6",
       control: { type: "text" }
     }
   }

--- a/src/apps/menu/menu.entry.tsx
+++ b/src/apps/menu/menu.entry.tsx
@@ -29,7 +29,7 @@ export interface MenuProps {
   loansSoonOverdueText: string;
   loansOverdueText: string;
   logoutUrl: string;
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
   feeListDaysText: string;
   menuLoginText: string;
   menuLoginUrl: string;

--- a/src/apps/reservation-list/list/reservation-list.dev.tsx
+++ b/src/apps/reservation-list/list/reservation-list.dev.tsx
@@ -22,9 +22,8 @@ export default {
       defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
       control: { type: "text" }
     },
-    thresholdConfig: {
-      defaultValue:
-        '{\n      "colorThresholds":{\n      "danger":"0",\n      "warning":"6"\n   }\n   }',
+    expirationWarningDaysBeforeConfig: {
+      defaultValue: "6",
       control: { type: "text" }
     },
     pauseReservationStartDateConfig: {

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -11,13 +11,13 @@ import { ReservationMaterialDetailsProps } from "../../../core/storybook/reserva
 import { DeleteReservationModalArgs } from "../../../core/storybook/deleteReservationModalArgs";
 
 export interface ReservationListUrlProps {
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
   ereolenMyPageUrl: string;
   pauseReservationInfoUrl: string;
 }
 
 export interface ReservationListConfigProps {
-  thresholdConfig: string;
+  expirationWarningDaysBeforeConfig: string;
   pauseReservationStartDateConfig: string;
   blacklistedPickupBranchesConfig: string;
   branchesConfig: string;

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -4,9 +4,8 @@ export default {
     defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
     control: { type: "text" }
   },
-  thresholdConfig: {
-    defaultValue:
-      '{\n      "colorThresholds":{\n      "danger":"0",\n      "warning":"6"\n   }\n   }',
+  expirationWarningDaysBeforeConfig: {
+    defaultValue: "6",
     control: { type: "text" }
   },
   pauseReservationStartDateConfig: {

--- a/src/core/utils/config.tsx
+++ b/src/core/utils/config.tsx
@@ -17,6 +17,9 @@ function config(
     transformer: "stringToArray";
   }
 ): string[];
+
+function config<T>(key: string): T;
+
 function config<T>(): T | string | string[] {
   return [];
 }

--- a/src/core/utils/types/threshold-type.ts
+++ b/src/core/utils/types/threshold-type.ts
@@ -1,6 +1,0 @@
-export interface ThresholdType {
-  colorThresholds: {
-    danger: number;
-    warning: number;
-  };
-}

--- a/src/core/utils/useLoanThresholds.tsx
+++ b/src/core/utils/useLoanThresholds.tsx
@@ -1,0 +1,14 @@
+import { useConfig } from "./config";
+
+type Days = number;
+
+const useLoanThresholds = (): { warning: Days; danger: Days } => {
+  const config = useConfig();
+
+  return {
+    warning: Number(config<`${number}`>("expirationWarningDaysBeforeConfig")),
+    danger: 0
+  };
+};
+
+export default useLoanThresholds;

--- a/src/tests/unit/status-badge.test.tsx
+++ b/src/tests/unit/status-badge.test.tsx
@@ -1,0 +1,170 @@
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import React, { ReactNode } from "react";
+import { Provider } from "react-redux";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import configReducer from "../../core/config.slice";
+import StatusBadge from "../../apps/loan-list/materials/utils/status-badge";
+
+const store = configureStore({
+  reducer: combineReducers({
+    config: configReducer
+  }),
+  preloadedState: {
+    config: {
+      data: {
+        expirationWarningDaysBeforeConfig: "6"
+      }
+    }
+  }
+});
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={store}> {children} </Provider>
+);
+describe("Status Badge tests", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const date = new Date("2023-11-09T12:00:00+0100");
+    vi.setSystemTime(date);
+  });
+
+  test("Should not render anything if no props are given", () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <div data-testid="badge-wrapper">
+          <StatusBadge />
+        </div>
+      </Wrapper>
+    );
+
+    const html = getByTestId("badge-wrapper");
+
+    expect(html).toMatchInlineSnapshot(`
+    <div
+      data-testid="badge-wrapper"
+    />
+  `);
+  });
+
+  test("Expiring soon warning if within threshold", () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <div data-testid="badge-wrapper">
+          <StatusBadge
+            showBadgeWithDueDate
+            // Since the due date is tomorrow and the warning threshold is set to within 6 days
+            // we should get a warning.
+            badgeDate="2023-11-10 12:00:00+0100"
+            dangerText="Expired"
+            warningText="Expiring soon"
+          />
+        </div>
+      </Wrapper>
+    );
+
+    const html = getByTestId("badge-wrapper");
+
+    expect(html).toMatchInlineSnapshot(`
+      <div
+        data-testid="badge-wrapper"
+      >
+        <div
+          class="status-label status-label--warning"
+        >
+          Expiring soon
+        </div>
+      </div>
+    `);
+  });
+
+  test("No label if outside of threshold", () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <div data-testid="badge-wrapper">
+          <StatusBadge
+            showBadgeWithDueDate
+            // This is one day over the threshold, so no warning should be shown.
+            badgeDate="2023-11-16 12:00:00+0100"
+            dangerText="Expired"
+            warningText="Expiring soon"
+          />
+        </div>
+      </Wrapper>
+    );
+
+    const html = getByTestId("badge-wrapper");
+
+    expect(html).toMatchInlineSnapshot(`
+      <div
+        data-testid="badge-wrapper"
+      />
+    `);
+  });
+
+  test("Same day should show 'Expiring soon'", () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <div data-testid="badge-wrapper">
+          <StatusBadge
+            showBadgeWithDueDate
+            // We are at the exact same day/time as the due date,
+            // so we should get a warning.
+            badgeDate="2023-11-09 12:00:00+0100"
+            dangerText="Expired"
+            warningText="Expiring soon"
+          />
+        </div>
+      </Wrapper>
+    );
+
+    const html = getByTestId("badge-wrapper");
+
+    expect(html).toMatchInlineSnapshot(`
+      <div
+        data-testid="badge-wrapper"
+      >
+        <div
+          class="status-label status-label--warning"
+        >
+          Expiring soon
+        </div>
+      </div>
+    `);
+  });
+
+  test("One day over should show 'Expired'", () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <div data-testid="badge-wrapper">
+          <StatusBadge
+            showBadgeWithDueDate
+            // We are one day over the due date, so we should get a warning.
+            badgeDate="2023-11-08 12:00:00+0100"
+            dangerText="Expired"
+            warningText="Expiring soon"
+          />
+        </div>
+      </Wrapper>
+    );
+
+    const html = getByTestId("badge-wrapper");
+
+    expect(html).toMatchInlineSnapshot(`
+      <div
+        data-testid="badge-wrapper"
+      >
+        <div
+          class="status-label status-label--danger"
+        >
+          Expired
+        </div>
+      </div>
+    `);
+  });
+});


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSOEG-583

#### Description

Refactoring thresholdConfig => expirationWarningDaysBeforeConfig
Because it has been changed in the cms.
Also adding test and a hook for getting the loan thresholds.

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/998889/c2c6bce4-7fb8-4a9e-9403-19f68fb0edc0)

