### PR TITLE
Fix/advanced search cql state

### DIFF
--- a/src/apps/advanced-search/CqlSearchHeader.tsx
+++ b/src/apps/advanced-search/CqlSearchHeader.tsx
@@ -18,7 +18,7 @@ const CqlSearchHeader: React.FC<CqlSearchHeaderProps> = ({
     if (initialCql.trim() !== "") {
       setCql(initialCql);
     }
-  });
+  }, [initialCql, setCql]);
 
   return (
     <>

--- a/src/apps/advanced-search/advanced-search.test.ts
+++ b/src/apps/advanced-search/advanced-search.test.ts
@@ -213,6 +213,18 @@ describe("Search Result", () => {
     cy.getBySel("card-list-item").should("have.length", 2);
   });
 
+  it.only("Updates search string after initial search is executed", () => {
+    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
+    cy.getBySel("preview-section").first().should("contain", "'Harry'");
+    cy.getBySel("search-button").click();
+    cy.wait("@complexSearchWithPagination GraphQL operation");
+    cy.getBySel("search-result-list").should("exist");
+    cy.getBySel("advanced-search-header-row").eq(1).click().type("Potter");
+    cy.getBySel("preview-section")
+      .first()
+      .should("contain", "'Harry' AND 'Potter'");
+  });
+
   beforeEach(() => {
     cy.visit(
       "/iframe.html?id=apps-advanced-search--advanced-search&viewMode=story"

--- a/src/components/multiselect/Multiselect.test.ts
+++ b/src/components/multiselect/Multiselect.test.ts
@@ -60,6 +60,49 @@ describe("Multiselect", () => {
       .and("have.attr", "aria-selected", "false");
   });
 
+  it("Allows to remove an item", () => {
+    cy.getBySel("multiselect").should("contain", "All").click();
+    cy.get("[role=option]").eq(1).should("contain", "First item").click();
+    cy.get("[role=option]").eq(2).should("contain", "2. item").click();
+    cy.get("[role=option]")
+      .eq(1)
+      .should("contain", "First item")
+      .and("have.attr", "aria-selected", "true");
+    cy.get("[role=option]")
+      .eq(2)
+      .should("contain", "2. item")
+      .and("have.attr", "aria-selected", "true");
+    cy.get("[role=option]")
+      .eq(3)
+      .should("contain", "III")
+      .and("have.attr", "aria-selected", "false");
+    // Now we click the first item to deselect it..
+    cy.get("[role=option]").eq(1).should("contain", "First item").click();
+    // ..and the only selected one should be the second item.
+    cy.get("[role=option]")
+      .eq(1)
+      .should("contain", "First item")
+      .and("have.attr", "aria-selected", "false");
+    cy.get("[role=option]")
+      .eq(2)
+      .should("contain", "2. item")
+      .and("have.attr", "aria-selected", "true");
+  });
+
+  it("Doesn't allow to remove an item if it's the only selected", () => {
+    cy.getBySel("multiselect").should("contain", "All").click();
+    cy.get("[role=option]").eq(1).should("contain", "First item").click();
+    cy.get("[role=option]")
+      .eq(1)
+      .should("contain", "First item")
+      .and("have.attr", "aria-selected", "true");
+    cy.get("[role=option]").eq(1).should("contain", "First item").click();
+    cy.get("[role=option]")
+      .eq(1)
+      .should("contain", "First item")
+      .and("have.attr", "aria-selected", "true");
+  });
+
   it("Selects the all option if all values are selected", () => {
     cy.get("button:visible").click();
     cy.get("[role=option]").click({ multiple: true });

--- a/src/components/multiselect/Multiselect.tsx
+++ b/src/components/multiselect/Multiselect.tsx
@@ -11,6 +11,7 @@ import {
   deselectMultiselectAllOption,
   selectMultiselectAllOption,
   selectMultiselectOption,
+  setMultiselectOptions,
   useGetMultiselectDownshiftProps
 } from "./helper";
 
@@ -53,11 +54,20 @@ const Multiselect: FC<MultiselectProps> = ({
   const { getDropdownProps, setSelectedItems, selectedItems } =
     useMultipleSelection({ initialSelectedItems: initialSelectedOptions });
 
-  const addNewSelectedItem = (
+  const handleSelectedItems = (
     allCurrentlySelected: MultiselectOption[],
-    newSelected: MultiselectOption,
+    newSelected: MultiselectOption | null,
     allPossibleOptions: number
   ) => {
+    // If newSelected doesn't exist, then we instead are removing an item
+    if (!newSelected) {
+      return setMultiselectOptions(
+        allCurrentlySelected,
+        updateState,
+        updateExternalState,
+        setSelectedItems
+      );
+    }
     // If new selection is not "all" we make sure "all" is deselected
     if (
       allCurrentlySelected.find((item) => item.value === allValue) &&
@@ -111,7 +121,7 @@ const Multiselect: FC<MultiselectProps> = ({
       allOptions,
       selectedItems,
       setSelectedItems,
-      addNewSelectedItem
+      handleSelectedItems
     );
 
   return (

--- a/src/components/multiselect/helper.ts
+++ b/src/components/multiselect/helper.ts
@@ -20,6 +20,20 @@ export const deselectMultiselectAllOption = (
   return newValue;
 };
 
+export const setMultiselectOptions = (
+  newSelected: MultiselectOption[],
+  updateState: (
+    updateKey: string | undefined,
+    value: MultiselectOption[]
+  ) => void,
+  updateExternalState: MultiselectExternalUpdate | undefined,
+  setSelectedItems: (items: MultiselectOption[]) => void
+) => {
+  updateState(updateExternalState?.key, newSelected);
+  setSelectedItems(newSelected);
+  return newSelected;
+};
+
 export const selectMultiselectAllOption = (
   updateState: (
     updateKey: string | undefined,
@@ -54,9 +68,9 @@ export const useGetMultiselectDownshiftProps = (
   allOptions: MultiselectOption[],
   selectedItems: MultiselectOption[],
   setSelectedItems: (items: MultiselectOption[]) => void,
-  addNewSelectedItem: (
+  handleSelectedItems: (
     allCurrentlySelected: MultiselectOption[],
-    newSelected: MultiselectOption,
+    newSelected: MultiselectOption | null,
     allPossibleOptions: number
   ) => MultiselectOption[]
 ) => {
@@ -90,7 +104,7 @@ export const useGetMultiselectDownshiftProps = (
             !selectedItems.find((item) => item.value === newSelectedItem.value)
           ) {
             setSelectedItems(
-              addNewSelectedItem(
+              handleSelectedItems(
                 selectedItems,
                 newSelectedItem,
                 allOptions.length
@@ -110,7 +124,9 @@ export const useGetMultiselectDownshiftProps = (
             const newSelectedItems = selectedItems.filter((item) => {
               return item.value !== newSelectedItem.value;
             });
-            setSelectedItems(newSelectedItems);
+            setSelectedItems(
+              handleSelectedItems(newSelectedItems, null, allOptions.length)
+            );
           }
           break;
         default:


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-77
https://reload.atlassian.net/browse/DSC-78

#### Description
This PR fixes the root problem of two bugs, where after performing an initial search in the advanced search app, the consequent searches would always use the initial cql query for searching without adjusting based on user input.

During this work, a new bug was discovered, that this PR also addresses - when removing multiselect dropdown items the external state wasn't being updated. 
Example:
- user wrote "Harry potter" into the text field on Advanced search page
- user chose "book" and "e-book" as filters from multiselect dropdown
- user then decided to remove "book" from filters
- -> this change wasn't being reflected in the "translated CQL" preview field, or upon consequent search

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a