### PR TITLE
Add all packages related to GraphQL codegen to existing Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
       graphql-codegen:
         patterns:
           - "@graphql-codegen/*"
+          - "@graphql-typed-document-node/core"
+          - "replace-in-file"
+          - "typescript-graphql-typed-files-modules"
       storybook:
         patterns:
           - "@storybook/*"


### PR DESCRIPTION
#### Description

All these modules work with generated code. Thus generated code should  be updated when updating these modules.

With that in mind it makes sense include all of them in the same group.

The list of added modules are taken from the commit which introduced GraphQL Codegen:
https://github.com/danskernesdigitalebibliotek/dpl-react/commit/22e016d72a30ef3685784668f51b8ce7b48c8d2d

Our currently separate PRs related to this: #659 #598.