### PR TITLE
Added ability to cancel pause period

### DIFF
--- a/src/apps/patron-page/PatronPage.dev.tsx
+++ b/src/apps/patron-page/PatronPage.dev.tsx
@@ -85,6 +85,10 @@ export default {
       defaultValue: "Save",
       control: { type: "text" }
     },
+    pauseReservationModalCancelButtonLabelText: {
+      defaultValue: "Cancel pause",
+      control: { type: "text" }
+    },
     patronPageBasicDetailsHeaderText: {
       defaultValue: "Basic details",
       control: { type: "text" }

--- a/src/apps/patron-page/PatronPage.entry.tsx
+++ b/src/apps/patron-page/PatronPage.entry.tsx
@@ -34,6 +34,7 @@ interface PatronPageTextProps {
   pauseReservationModalBelowInputsTextText: string;
   pauseReservationModalLinkText: string;
   pauseReservationModalSaveButtonLabelText: string;
+  pauseReservationModalCancelButtonLabelText: string;
   patronPageBasicDetailsHeaderText: string;
   patronPageBasicDetailsNameLabelText: string;
   patronPageBasicDetailsAddressLabelText: string;

--- a/src/apps/reservation-list/modal/pause-reservation/pause-reservation.tsx
+++ b/src/apps/reservation-list/modal/pause-reservation/pause-reservation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState, useEffect, FormEvent } from "react";
+import React, { FC, useCallback, useState, useEffect, useId } from "react";
 import { useQueryClient } from "react-query";
 import Link from "../../../../components/atoms/links/Link";
 import Modal, { useModalButtonHandler } from "../../../../core/utils/modal";
@@ -25,15 +25,17 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
   const { mutate } = useUpdateV5();
   const { close } = useModalButtonHandler();
   const { pauseReservation } = getModalIds();
+  const saveFormId = useId();
+
   const config = useConfig();
   const [startDate, setStartDate] = useState<string>(
     config("pauseReservationStartDateConfig")
   );
   const [endDate, setEndDate] = useState<string>("");
+  const pauseActive = user?.onHold?.from && user?.onHold?.to;
 
   const save = useCallback(
-    (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
+    (localStartDate?: string, localEndDate?: string) => {
       if (!user) {
         return;
       }
@@ -46,12 +48,10 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
         receiveSms: user.receiveSms
       } as Patron;
 
-      if (startDate || endDate) {
-        saveData.onHold = {
-          from: startDate === "" ? undefined : startDate,
-          to: endDate === "" ? undefined : endDate
-        };
-      }
+      saveData.onHold = {
+        from: localStartDate === "" ? undefined : localStartDate,
+        to: localEndDate === "" ? undefined : localEndDate
+      };
 
       mutate(
         {
@@ -69,8 +69,14 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
         }
       );
     },
-    [close, endDate, mutate, pauseReservation, queryClient, startDate, user]
+    [close, mutate, pauseReservation, queryClient, user]
   );
+
+  const resetPauseDates = useCallback(() => {
+    setStartDate(config("pauseReservationStartDateConfig"));
+    setEndDate("");
+    save();
+  }, [config, save]);
 
   useEffect(() => {
     if (user?.onHold?.from) {
@@ -90,7 +96,7 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
         "pauseReservationModalAriaDescriptionText"
       )}
     >
-      <form onSubmit={(e) => save(e)} className="modal-pause__container">
+      <div className="modal-pause__container">
         <h2 className="text-header-h3">
           {t("pauseReservationModalHeaderText")}
         </h2>
@@ -99,12 +105,20 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
             {t("pauseReservationModalBodyText")}
           </p>
         </div>
-        <DateInputs
-          setStartDate={setStartDate}
-          setEndDate={setEndDate}
-          startDate={startDate}
-          endDate={endDate}
-        />
+        <form
+          id={saveFormId}
+          onSubmit={(e) => {
+            e.preventDefault();
+            save(startDate, endDate);
+          }}
+        >
+          <DateInputs
+            setStartDate={setStartDate}
+            setEndDate={setEndDate}
+            startDate={startDate}
+            endDate={endDate}
+          />
+        </form>
         <div className="modal-pause__text-link mt-24 color-secondary-gray">
           <p className="text-body-small-regular">
             {t("pauseReservationModalBelowInputsTextText")}
@@ -120,12 +134,22 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
         <div className="modal-pause__button mt-48">
           <button
             type="submit"
-            className="btn-primary btn-filled btn-small arrow__hover--right-small"
+            form={saveFormId}
+            className="btn-primary btn-filled btn-small"
           >
             {t("pauseReservationModalSaveButtonLabelText")}
           </button>
+          {pauseActive && (
+            <button
+              type="button"
+              onClick={resetPauseDates}
+              className="btn-primary btn-small mt-16"
+            >
+              {t("pauseReservationModalCancelButtonLabelText")}
+            </button>
+          )}
         </div>
-      </form>
+      </div>
     </Modal>
   );
 };

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -211,6 +211,10 @@ export default {
     defaultValue: "Save",
     control: { type: "text" }
   },
+  pauseReservationModalCancelButtonLabelText: {
+    defaultValue: "Cancel pause",
+    control: { type: "text" }
+  },
   listDetailsNothingSelectedLabelText: {
     defaultValue: "Pick",
     control: { type: "text" }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-209

#### Description
This adds the ability to cancel an ongoing pause period after it has been set. 
The issue suggests, that the user should be prompted with a success message, but when #680 is introduced, the banner will update according to the current pause settings.

#### Screenshot of the result when #680 is also merged in
https://github.com/danskernesdigitalebibliotek/dpl-react/assets/14014012/ca7908a8-b2c0-4368-bd5b-1527a9685bf7

