### PR TITLE
Show "online access" label for all digital materials

### DIFF
--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -82,9 +82,9 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
         percent={100}
         info={getInfo()}
         label={
-          !isDigital
-            ? [pickupLibrary, pickupNumber || ""]
-            : [t("reservationListDigitalPickupText")]
+          isDigital
+            ? [t("reservationListDigitalPickupText")]
+            : [pickupLibrary, pickupNumber || ""]
         }
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -81,10 +81,11 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
         color={success as string}
         percent={100}
         info={getInfo()}
-        label={[
-          pickupLibrary,
-          pickupNumber || t("reservationListDigitalPickupText")
-        ]}
+        label={
+          !isDigital
+            ? [pickupLibrary, pickupNumber || ""]
+            : [t("reservationListDigitalPickupText")]
+        }
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}
         empty={!showStatusCircleIcon}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-213

#### Description
This PR introduces a fix so that all digital reservations get the correct label, instead of the physical reservation address.

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a