### PR TITLE
Only enable body scrolling after closing the last modal, not after every

### DIFF
--- a/src/core/modal.slice.ts
+++ b/src/core/modal.slice.ts
@@ -70,8 +70,6 @@ const modalSlice = createSlice({
       }
     },
     closeModal(state: StateProps, action: PayloadProps) {
-      // Enables background scrolling to use when Modal is closed
-      document.body.style.overflow = "";
       const modalId = state.modalIds.pop();
       if (state.modalIds.indexOf(action.payload.modalId) > -1) {
         state.modalIds.splice(
@@ -82,6 +80,12 @@ const modalSlice = createSlice({
       if (modalId) {
         removeModalIdFromUrl(state);
         returnFocusElement();
+      }
+      // Enables background scrolling to use when last modal is closed
+      // console.log(getConf("modalIds", configuration));
+      // console.log(state.modalIds.length);
+      if (state.modalIds.length === 0) {
+        document.body.style.overflow = "";
       }
     },
     closeLastModal(state: StateProps) {

--- a/src/core/modal.slice.ts
+++ b/src/core/modal.slice.ts
@@ -82,8 +82,6 @@ const modalSlice = createSlice({
         returnFocusElement();
       }
       // Enables background scrolling to use when last modal is closed
-      // console.log(getConf("modalIds", configuration));
-      // console.log(state.modalIds.length);
       if (state.modalIds.length === 0) {
         document.body.style.overflow = "";
       }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-283

#### Description
This PR fixes an issue with scrolling behind modals. The user shouldn't be able to scroll in the content behind a modal until the very last modal is closed. Before, the scrolling was made possible after any modal was closed.

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a