### PR TITLE
Do not allow only() in tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,9 @@
     "plugin:prettier/recommended",
     "plugin:cypress/recommended"
   ],
+  "plugins": [
+    "no-only-tests"
+  ],
   "settings": {
     "react": {
       "version": "16.11.0"
@@ -81,7 +84,8 @@
       {
         "additionalHooks": "useDeepCompareEffect"
       }
-    ]
+    ],
+    "no-only-tests/no-only-tests": "warn"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/apps/advanced-search/advanced-search.test.ts
+++ b/src/apps/advanced-search/advanced-search.test.ts
@@ -213,7 +213,7 @@ describe("Search Result", () => {
     cy.getBySel("card-list-item").should("have.length", 2);
   });
 
-  it.only("Updates search string after initial search is executed", () => {
+  it("Updates search string after initial search is executed", () => {
     cy.getBySel("advanced-search-header-row").first().click().type("Harry");
     cy.getBySel("preview-section").first().should("contain", "'Harry'");
     cy.getBySel("search-button").click();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9292,6 +9292,11 @@ eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz"


### PR DESCRIPTION
#### Description

While it may be best practice to use this when developing tests it is not a good idea to have it commit to VCS.

Doing so will prevent our CI (and future developers) from running other tests.

This is especially severe when running all tests locally as this means that only tests using only() will be used.

Using eslint-plugin-no-only-tests seems to be the suggested solution: https://github.com/cypress-io/eslint-plugin-cypress/issues/28

#### Additional comments or questions

This will fail at the moment. It should be merged once we have removed all the onlys. This occurs as a part of #612.