### PR TITLE
Fix/stacked card click

### DIFF
--- a/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
+++ b/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
@@ -38,16 +38,22 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
     }
   };
 
+  const handleOpenDueDateModal = () => {
+    if (openDueDateModal && dueDate) {
+      openDueDateModal(dueDate);
+    }
+  };
+
   return (
     <div
       className={clsx("list-reservation my-32 cursor-pointer", {
         "list-reservation--stacked": additionalMaterials > 0
       })}
       role="button"
-      onClick={() => openDueDateModal && dueDate && openDueDateModal(dueDate)}
+      onClick={() => handleOpenDueDateModal()}
       onKeyUp={(e) => {
         if (e.key === "Enter" || e.key === "Space") {
-          openLoanDetailsModalHandler();
+          handleOpenDueDateModal();
         }
       }}
       tabIndex={0}
@@ -63,9 +69,7 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
         >
           <AdditionalMaterialsButton
             showOn="desktop"
-            openDueDateModal={() =>
-              openDueDateModal && dueDate && openDueDateModal(dueDate)
-            }
+            openDueDateModal={() => handleOpenDueDateModal()}
             additionalMaterials={additionalMaterials}
           />
           <MaterialOverdueLink showOn="desktop" dueDate={dueDate} />
@@ -75,16 +79,12 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
         arrowLabelledBy={`${loanId || identifier}-title`}
         loan={loan}
         openDetailsModal={openLoanDetailsModal}
-        openDueDateModal={() =>
-          openDueDateModal && dueDate && openDueDateModal(dueDate)
-        }
+        openDueDateModal={() => handleOpenDueDateModal()}
         additionalMaterials={additionalMaterials}
       >
         <AdditionalMaterialsButton
           showOn="mobile"
-          openDueDateModal={() =>
-            openDueDateModal && dueDate && openDueDateModal(dueDate)
-          }
+          openDueDateModal={() => handleOpenDueDateModal()}
           additionalMaterials={additionalMaterials}
         />
         <MaterialOverdueLink showOn="mobile" dueDate={dueDate} />

--- a/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
+++ b/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
@@ -44,7 +44,7 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
         "list-reservation--stacked": additionalMaterials > 0
       })}
       role="button"
-      onClick={() => openLoanDetailsModalHandler()}
+      onClick={() => openDueDateModal && dueDate && openDueDateModal(dueDate)}
       onKeyUp={(e) => {
         if (e.key === "Enter" || e.key === "Space") {
           openLoanDetailsModalHandler();

--- a/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
+++ b/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
@@ -50,7 +50,7 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
         "list-reservation--stacked": additionalMaterials > 0
       })}
       role="button"
-      onClick={() => handleOpenDueDateModal()}
+      onClick={handleOpenDueDateModal}
       onKeyUp={(e) => {
         if (e.key === "Enter" || e.key === "Space") {
           handleOpenDueDateModal();
@@ -69,7 +69,7 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
         >
           <AdditionalMaterialsButton
             showOn="desktop"
-            openDueDateModal={() => handleOpenDueDateModal()}
+            openDueDateModal={handleOpenDueDateModal}
             additionalMaterials={additionalMaterials}
           />
           <MaterialOverdueLink showOn="desktop" dueDate={dueDate} />
@@ -79,12 +79,12 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
         arrowLabelledBy={`${loanId || identifier}-title`}
         loan={loan}
         openDetailsModal={openLoanDetailsModal}
-        openDueDateModal={() => handleOpenDueDateModal()}
+        openDueDateModal={handleOpenDueDateModal}
         additionalMaterials={additionalMaterials}
       >
         <AdditionalMaterialsButton
           showOn="mobile"
-          openDueDateModal={() => handleOpenDueDateModal()}
+          openDueDateModal={handleOpenDueDateModal}
           additionalMaterials={additionalMaterials}
         />
         <MaterialOverdueLink showOn="mobile" dueDate={dueDate} />


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-280

#### Description
This PR fixes an issue where on the loan list, when clicking on a stacked loans card, only the first material would open in a modal. Now We open group modal.

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a
