### PR TITLE
Improve rendering of reservation labels (don't merge b4 design)

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "prop-types": "Since we use former ddb-react components that depend on prop-types we keep this. Should be removed when usage of prop-types is deprecated."
   },
   "dependencies": {
-    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-a88798519f8e7eac8b03350aa3f1f75299697b32",
+    "@danskernesdigitalebibliotek/dpl-design-system": "0.0.0-2b4afa5859903cafa32ba5e331592f2895c1f1aa",
     "@reach/alert": "^0.17.0",
     "@reach/dialog": "^0.17.0",
     "@reduxjs/toolkit": "^1.9.7",

--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -72,7 +72,7 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
         })}
       >
         {onMaterialChecked && (
-          <div className="list-materials__checkbox mr-32">
+          <div className="list-materials__checkbox mr-16">
             {!disabled && title && (
               <CheckBox
                 onChecked={() => onMaterialChecked(id)}
@@ -131,7 +131,7 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
         </div>
         {openDetailsModal && (
           <div
-            className="mr-16 ml-32 cursor-pointer"
+            className="list-materials__arrow"
             role="button"
             onClick={handleOnClick}
             onKeyUp={handleOnKeyUp}

--- a/src/apps/reservation-list/list/list.tsx
+++ b/src/apps/reservation-list/list/list.tsx
@@ -59,7 +59,7 @@ const List: FC<ListProps> = ({
             </h2>
           </div>
           <div data-cy="list-reservation-container">
-            <ul className="list-reservation-container m-32">
+            <ul className="list-reservation-container">
               {displayedReservations.map((reservation, i) => (
                 <ReservationMaterial
                   focused={firstInNewPage === i}
@@ -84,7 +84,7 @@ const List: FC<ListProps> = ({
               </>
             </h2>
           </div>
-          <div className="list-reservation-container m-32">
+          <div className="list-reservation-container">
             <EmptyList
               classNames="mt-24"
               dataCy={emptyListDataCy}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,10 +1471,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-a88798519f8e7eac8b03350aa3f1f75299697b32":
-  version "0.0.0-a88798519f8e7eac8b03350aa3f1f75299697b32"
-  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-a88798519f8e7eac8b03350aa3f1f75299697b32/7c53246b449eeb0b31ba381e344763073b4715d6#7c53246b449eeb0b31ba381e344763073b4715d6"
-  integrity sha512-Syl/xZX+p8EHUVYCOZf77dt9PuTnj+EO8hFcWYbCWy/U8zPE0IJjTK6hEdMLA2TqH7dEp6ywFs2cFvYr1vdYmg==
+"@danskernesdigitalebibliotek/dpl-design-system@0.0.0-2b4afa5859903cafa32ba5e331592f2895c1f1aa":
+  version "0.0.0-2b4afa5859903cafa32ba5e331592f2895c1f1aa"
+  resolved "https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/0.0.0-2b4afa5859903cafa32ba5e331592f2895c1f1aa/af1c3de867401e354ca24b34447c78669d18096f#af1c3de867401e354ca24b34447c78669d18096f"
+  integrity sha512-KIvFsrEIKOVAaiF2JFbBU8MmVNpr5kTBQlkSRXl7d7H4WFb7mtxF29o4biOPlvAEZpm82XriAo92uJiAd89yhg==
 
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-278
https://reload.atlassian.net/browse/DDFLSBP-279

#### Description

They were just put in roughly everywhere needed so the different views in group-modal and reservation-list had to be adjusted.

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/998889/e93e3c99-832c-43d3-98a8-5d21f0b2df39)

#### Additional comments or questions

Depending on [PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/341) in design system.
When the other PR has been merged the dependency to the design system in package.json should be merged.