### PR TITLE
Provide all translation texts to all react apps

### DIFF
--- a/src/apps/favorites-list/FavoritesList.dev.tsx
+++ b/src/apps/favorites-list/FavoritesList.dev.tsx
@@ -46,6 +46,16 @@ export default {
       defaultValue: "/work/:workid",
       control: { type: "text" }
     },
+    availabilityAvailableText: {
+      name: "Availability: available text",
+      defaultValue: "Available",
+      control: { type: "text" }
+    },
+    availabilityUnavailableText: {
+      name: "Availability: unavailable text",
+      defaultValue: "Unavailable",
+      control: { type: "text" }
+    },
     favoritesListMaterialsText: {
       defaultValue: "@count materials",
       control: { type: "text" }

--- a/src/apps/favorites-list/FavoritesList.entry.tsx
+++ b/src/apps/favorites-list/FavoritesList.entry.tsx
@@ -11,6 +11,8 @@ interface FavoritesListConfigEntryProps {
   fbsBaseUrlConfig: string;
 }
 interface FavoritesListTextEntryProps {
+  availabilityAvailableText: string;
+  availabilityUnavailableText: string;
   favoritesListMaterialsText: string;
   favoritesListHeaderText: string;
   byAuthorText: string;

--- a/src/apps/loan-list/list/loan-list.entry.tsx
+++ b/src/apps/loan-list/list/loan-list.entry.tsx
@@ -22,6 +22,7 @@ export interface LoanListEntryUrlProps {
 }
 
 interface LoanListEntryTextProps {
+  groupModalGoToMaterialAriaLabelText: string;
   loanListAriaLabelListButtonText: string;
   loanListAriaLabelStackButtonText: string;
   loanListDigitalLoansEmptyListText: string;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-245

#### Description

This PR adds missing translations to .dev & .entry files: `groupModalGoToMaterialAriaLabelText` was missing in loan-list.entry, and `availabilityAvailableText` & `availabilityUnavailableText` in FavoritesList.dev and .entry

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a