### PR TITLE
Set correct fees url

### DIFF
--- a/src/apps/loan-list/list/loan-list.dev.tsx
+++ b/src/apps/loan-list/list/loan-list.dev.tsx
@@ -23,10 +23,6 @@ export default {
     ...materialDetailsModalArgs,
     ...blockedArgs,
     // Config
-    materialOverdueUrl: {
-      defaultValue: "https://unsplash.com/photos/wd6YQy0PJt8", // open source image of a red panda
-      control: { type: "text" }
-    },
     pageSizeDesktop: {
       defaultValue: 10,
       control: { type: "number" }

--- a/src/apps/loan-list/list/loan-list.entry.tsx
+++ b/src/apps/loan-list/list/loan-list.entry.tsx
@@ -17,7 +17,6 @@ export interface LoanListEntryConfigProps {
   expirationWarningDaysBeforeConfig: string;
 }
 export interface LoanListEntryUrlProps {
-  materialOverdueUrl: string;
   expirationWarningDaysBeforeConfig: string;
 }
 

--- a/src/apps/loan-list/materials/stackable-material/material-overdue-link.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-overdue-link.tsx
@@ -13,13 +13,13 @@ const MaterialOverdueLink: FC<MaterialOverdueLinkProps> = ({
   dueDate,
   showOn
 }) => {
-  const { materialOverdueUrl } = useUrls();
+  const { viewFeesAndCompensationRatesUrl } = useUrls();
   const t = useText();
   if (!dueDate || (dueDate && !materialIsOverdue(dueDate))) return null;
 
   return (
     <Link
-      href={materialOverdueUrl}
+      href={viewFeesAndCompensationRatesUrl}
       className={`list-reservation__note list-reservation__note--${showOn} color-signal-alert`}
     >
       {t("loanListMaterialLateFeeText")}

--- a/src/core/utils/types/global-url-props.ts
+++ b/src/core/utils/types/global-url-props.ts
@@ -4,7 +4,6 @@ interface GlobalUrlEntryPropsInterface {
   advancedSearchUrl: string;
   fbsBaseUrl: string;
   loanListEreolenUrl: string;
-  materialOverdueUrl: string;
   feesPageUrl: string;
   publizonBaseUrl: string;
   dplCmsBaseUrl: string;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-313

#### Description
In an attempt to streamline the fee url to a single field from Drupal, we wan to use the feesAndCompensationRatesUrl instead. materialOverdueUrl has been depricated and removed from Drupal.
