### PR TITLE
Add Dependabot group for Redux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,13 @@ updates:
           - "@graphql-typed-document-node/core"
           - "replace-in-file"
           - "typescript-graphql-typed-files-modules"
+      redux:
+        patterns:
+          - "@reduxjs/toolkit"
+          - "@types/react-redux"
+          - "react-redux"
+          - "redux"
+          - "redux-persist"
       storybook:
         patterns:
           - "@storybook/*"


### PR DESCRIPTION
#### Description

There are often dependencies between core Redux and packages building on Redux like Redux Toolkit, React Redux, Redux Persist e.g. #760 and #765.

Group them to make them move in parallel.