### PR TITLE
Update interest period treshold with drupal

### DIFF
--- a/.docker/wiremock/fbs/mappings/fbs-availability-31ef8b31-c7f7-4463-89e9-1b1f9875864b.json
+++ b/.docker/wiremock/fbs/mappings/fbs-availability-31ef8b31-c7f7-4463-89e9-1b1f9875864b.json
@@ -1,0 +1,18 @@
+{
+  "id" : "31ef8b31-c7f7-4463-89e9-1b1f9875864b",
+  "name" : "FBS availability",
+  "request" : {
+    "urlPath" : "/external/agencyid/catalog/availability/v3",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "[\n  {\n    \"available\": true,\n    \"recordId\": \"52557240\",\n    \"reservable\": true,\n    \"reservations\": 2\n  },\n  {\n    \"available\": true,\n    \"recordId\": \"52643414\",\n    \"reservable\": true,\n    \"reservations\": 2\n  }\n]",
+    "headers" : { }
+  },
+  "uuid" : "31ef8b31-c7f7-4463-89e9-1b1f9875864b",
+  "persistent" : true,
+  "priority" : 5,
+  "insertionIndex" : 2,
+  "postServeActions" : [ ]
+}

--- a/.docker/wiremock/fbs/mappings/fbs-holdings-a530c110-c4a9-42f4-a06f-9390744b8b00.json
+++ b/.docker/wiremock/fbs/mappings/fbs-holdings-a530c110-c4a9-42f4-a06f-9390744b8b00.json
@@ -1,0 +1,18 @@
+{
+  "id" : "a530c110-c4a9-42f4-a06f-9390744b8b00",
+  "name" : "FBS holdings",
+  "request" : {
+    "urlPath" : "/external/agencyid/catalog/holdings/v3",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "[\n  {\n    \"recordId\": \"52557240\",\n    \"reservable\": false,\n    \"reservations\": 0,\n    \"holdings\": []\n  },\n  {\n    \"recordId\": \"52643414\",\n    \"reservable\": false,\n    \"reservations\": 0,\n    \"holdings\": []\n  }\n]\n",
+    "headers" : { }
+  },
+  "uuid" : "a530c110-c4a9-42f4-a06f-9390744b8b00",
+  "persistent" : true,
+  "priority" : 5,
+  "insertionIndex" : 16,
+  "postServeActions" : [ ]
+}

--- a/docs/request_mocking_wiremock.md
+++ b/docs/request_mocking_wiremock.md
@@ -52,7 +52,9 @@ To set up a mocked response for a new request to FBS do the following:
 2. Click "FBS" to manage the Wiremock instance for FBS
 3. Click "Stubs" to see a list of existing requests/responses
 4. Click "New" to create a new request/response set and provide a name
-5. Provide the HTTP method, path and other parts of the request to match
+5. Provide the HTTP method, path and other parts of the request to match (note:
+make sure to check "advanced" option out, and match either path, or path AND the
+query.)
 6. Provide the response HTTP status code and body to return
 7. Click "Save"
 8. See that the stub has been persisted as a new file in

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -809,7 +809,7 @@ export default {
     },
     interestPeriodsConfig: {
       defaultValue:
-        '[\n   {\n      "value":"30",\n      "label":"1 month"\n   },\n   {\n      "value":"60",\n      "label":"2 months"\n   },\n   {\n      "value":"90",\n      "label":"3 months"\n   },\n   {\n      "value":"180",\n      "label":"6 months"\n   },\n   {\n      "value":"360",\n      "label":"1 year"\n   }\n]',
+        '{ "interestPeriods":[ { "value":14, "label":"14 days" }, { "value":30, "label":"1 month" }, { "value":60, "label":"2 months" }, { "value":90, "label":"3 months" }, { "value":180, "label":"6 months" }, { "value":365, "label":"1 year" } ], "defaultInterestPeriod":{ "value":"14", "label":"14 days" } }',
       control: { type: "text" }
     },
     openOrderResponseTitleText: {

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -532,7 +532,7 @@ describe("Reservation details modal", () => {
 
     cy.getBySel("modal-reservation-form-select").should(
       "have.text",
-      "Choose one1 month2 months3 months6 months1 year"
+      "Choose one14 days1 month2 months3 months6 months1 year"
     );
 
     cy.getBySel("reservation-form-button", true).click();

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -51,7 +51,7 @@ const UserListItems: FC<UserListItemsProps> = ({
 }) => {
   const t = useText();
   const config = useConfig();
-  const interstPeriods = config<InterestPeriods>("interestPeriodsConfig", {
+  const interestPeriods = config<InterestPeriods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });
 
@@ -61,10 +61,10 @@ const UserListItems: FC<UserListItemsProps> = ({
   };
 
   const interestPeriod = selectedInterest
-    ? getNoInterestAfter(selectedInterest, interstPeriods, t)
+    ? getNoInterestAfter(selectedInterest, interestPeriods, t)
     : getNoInterestAfter(
-        Number(interstPeriods.defaultInterestPeriod.value),
-        interstPeriods,
+        Number(interestPeriods.defaultInterestPeriod.value),
+        interestPeriods,
         t
       );
 

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -22,7 +22,7 @@ import {
 } from "./helper";
 import PickupModal from "./forms/PickupModal";
 import NoInterestAfterModal from "./forms/NoInterestAfterModal";
-import { InterestPeriods } from "./types";
+import { Periods } from "./types";
 
 export interface UserListItemsProps {
   patron: PatronV5;
@@ -51,7 +51,7 @@ const UserListItems: FC<UserListItemsProps> = ({
 }) => {
   const t = useText();
   const config = useConfig();
-  const interestPeriods = config<InterestPeriods>("interestPeriodsConfig", {
+  const interestPeriods = config<Periods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });
 

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -22,7 +22,7 @@ import {
 } from "./helper";
 import PickupModal from "./forms/PickupModal";
 import NoInterestAfterModal from "./forms/NoInterestAfterModal";
-import { Option } from "../Dropdown/Dropdown";
+import { InterestPeriods } from "./types";
 
 export interface UserListItemsProps {
   patron: PatronV5;
@@ -51,7 +51,7 @@ const UserListItems: FC<UserListItemsProps> = ({
 }) => {
   const t = useText();
   const config = useConfig();
-  const interstPeriods = config<Option[]>("interestPeriodsConfig", {
+  const interstPeriods = config<InterestPeriods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });
 
@@ -62,7 +62,11 @@ const UserListItems: FC<UserListItemsProps> = ({
 
   const interestPeriod = selectedInterest
     ? getNoInterestAfter(selectedInterest, interstPeriods, t)
-    : getNoInterestAfter(defaultInterestPeriod, interstPeriods, t);
+    : getNoInterestAfter(
+        Number(interstPeriods.defaultInterestPeriod.value),
+        interstPeriods,
+        t
+      );
 
   const pickupBranch = selectedBranch
     ? getPreferredBranch(selectedBranch, branches)

--- a/src/components/reservation/forms/NoInterestAfterModal.tsx
+++ b/src/components/reservation/forms/NoInterestAfterModal.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useText } from "../../../core/utils/text";
 import ModalReservationFormSelect from "./ModalReservationFormSelect";
 import { useConfig } from "../../../core/utils/config";
-import { Option } from "../../Dropdown/Dropdown";
 import { RequestStatus } from "../../../core/utils/types/request";
+import { InterestPeriods } from "../types";
 
 export interface PickupModalProps {
   selectedInterest: number;
@@ -22,7 +22,7 @@ const NoInterestAfterModal = ({
 }: PickupModalProps) => {
   const t = useText();
   const config = useConfig();
-  const interstPeriods = config<Option[]>("interestPeriodsConfig", {
+  const interstPeriods = config<InterestPeriods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });
 
@@ -35,7 +35,7 @@ const NoInterestAfterModal = ({
           t("modalReservationFormNoInterestAfterHeaderDescriptionText")
         ]
       }}
-      items={interstPeriods}
+      items={interstPeriods.interestPeriods}
       defaultSelectedItem={String(selectedInterest)}
       selectHandler={(value: string) => setSelectedInterest(Number(value))}
       ariaLabel={t("modalReservationFormNoInterestAfterLabelText")}

--- a/src/components/reservation/forms/NoInterestAfterModal.tsx
+++ b/src/components/reservation/forms/NoInterestAfterModal.tsx
@@ -3,7 +3,7 @@ import { useText } from "../../../core/utils/text";
 import ModalReservationFormSelect from "./ModalReservationFormSelect";
 import { useConfig } from "../../../core/utils/config";
 import { RequestStatus } from "../../../core/utils/types/request";
-import { InterestPeriods } from "../types";
+import { Periods } from "../types";
 
 export interface PickupModalProps {
   selectedInterest: number;
@@ -22,7 +22,7 @@ const NoInterestAfterModal = ({
 }: PickupModalProps) => {
   const t = useText();
   const config = useConfig();
-  const interstPeriods = config<InterestPeriods>("interestPeriodsConfig", {
+  const interstPeriods = config<Periods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });
 

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -19,7 +19,7 @@ import { PeriodicalEdition } from "../material/periodical/helper";
 import { ModalReservationFormTextType } from "./forms/helper";
 import invalidSwitchCase from "../../core/utils/helpers/invalid-switch-case";
 import { SubmitOrderStatus } from "../../core/dbc-gateway/generated/graphql";
-import { Option } from "../Dropdown/Dropdown";
+import { InterestPeriods } from "./types";
 
 export const isConfigValueOne = (configValue: string | undefined | string[]) =>
   configValue === "1";
@@ -31,10 +31,10 @@ export const getPreferredBranch = (id: string, array: AgencyBranch[]) => {
 
 export const getNoInterestAfter = (
   days: number,
-  interestPeriod: Option[],
+  interestPeriod: InterestPeriods,
   t: UseTextFunction
 ) => {
-  const interestPeriodFound = interestPeriod.find(
+  const interestPeriodFound = interestPeriod.interestPeriods.find(
     ({ value }) => value === String(days)
   );
 

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -19,7 +19,7 @@ import { PeriodicalEdition } from "../material/periodical/helper";
 import { ModalReservationFormTextType } from "./forms/helper";
 import invalidSwitchCase from "../../core/utils/helpers/invalid-switch-case";
 import { SubmitOrderStatus } from "../../core/dbc-gateway/generated/graphql";
-import { InterestPeriods } from "./types";
+import { Periods } from "./types";
 
 export const isConfigValueOne = (configValue: string | undefined | string[]) =>
   configValue === "1";
@@ -31,7 +31,7 @@ export const getPreferredBranch = (id: string, array: AgencyBranch[]) => {
 
 export const getNoInterestAfter = (
   days: number,
-  interestPeriod: InterestPeriods,
+  interestPeriod: Periods,
   t: UseTextFunction
 ) => {
   const interestPeriodFound = interestPeriod.interestPeriods.find(

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,6 +1,6 @@
 import { Option } from "../Dropdown/Dropdown";
 
-export type InterestPeriods = {
+export type Periods = {
   interestPeriods: Option[];
   defaultInterestPeriod: Option;
 };

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,0 +1,6 @@
+import { Option } from "../Dropdown/Dropdown";
+
+export type InterestPeriods = {
+  interestPeriods: Option[];
+  defaultInterestPeriod: Option;
+};

--- a/src/core/storybook/reservationMaterialDetailsArgs.ts
+++ b/src/core/storybook/reservationMaterialDetailsArgs.ts
@@ -16,7 +16,7 @@ export default {
   },
   interestPeriodsConfig: {
     defaultValue:
-      '[\n   {\n      "value":"30",\n      "label":"1 month"\n   },\n   {\n      "value":"60",\n      "label":"2 months"\n   },\n   {\n      "value":"90",\n      "label":"3 months"\n   },\n   {\n      "value":"180",\n      "label":"6 months"\n   },\n   {\n      "value":"360",\n      "label":"1 year"\n   }\n]',
+      '{ "interestPeriods":[ { "value":14, "label":"14 days" }, { "value":30, "label":"1 month" }, { "value":60, "label":"2 months" }, { "value":90, "label":"3 months" }, { "value":180, "label":"6 months" }, { "value":365, "label":"1 year" } ], "defaultInterestPeriod":{ "value":"14", "label":"14 days" } }',
     control: { type: "text" }
   },
   reservationDetailsRemoveDigitalReservationText: {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-150

#### Description
This PR updates the usage of the "interest period" after which a loaner is no longer interested in a material when reserving it. There were [some updates in the backend](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/475) to the structure of the data we use, so here we update the frontend part.
We also add new wiremock stubs for the material page (so that it doesn't crash when running it locally).

#### Screenshot of the result
n/a
#### Additional comments or questions
n/a