### PR TITLE
Update unpaid fees headline text

### DIFF
--- a/src/apps/fee-list/FeeList.tsx
+++ b/src/apps/fee-list/FeeList.tsx
@@ -114,7 +114,10 @@ const FeeList: FC = () => {
         </span>
         {!itemsPrePaymentChange && !itemsPostPaymentChange && (
           <>
-            <ListHeader header={<>{t("unpaidFeesText")}</>} amount={0} />
+            <ListHeader
+              header={<>{t("unpaidFeesFirstHeadlineText")}</>}
+              amount={0}
+            />
             <EmptyList
               classNames="mt-24"
               emptyListText={t("emptyFeeListText")}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-245

#### Description
This PR fixes an issue where we were using a previously deleted translation string - unpaidFeesText. We now use unpaidFeesFirstHeadlineText over the removed one.

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a