### PR TITLE
Show fees after payment change date on the fees page

### DIFF
--- a/src/apps/fee-list/FeeList.tsx
+++ b/src/apps/fee-list/FeeList.tsx
@@ -63,7 +63,7 @@ const FeeList: FC = () => {
       }
       const feesPostPaymentChange = getFeesInRelationToPaymentChangeDate(
         fbsFees,
-        true
+        false
       ).length;
       if (feesPostPaymentChange > 0) {
         setItemsPostPaymentChange(

--- a/src/apps/fee-list/utils/helper.ts
+++ b/src/apps/fee-list/utils/helper.ts
@@ -1,11 +1,19 @@
 import dayjs from "dayjs";
 import { FeeV2 } from "../../../core/fbs/model";
+import configuration, { getConf } from "../../../core/configuration";
+
+const paymentConf = getConf("payment", configuration);
+const {
+  paymentChangeDate
+}: // paymentChangeDate should never be undefined, but the config system requires
+// us to handle that case
+{ paymentChangeDate?: `${number}-${number}-${number}` } = paymentConf;
 
 export const getFeesInRelationToPaymentChangeDate = (
   feeObj: FeeV2[],
   beforePaymentChangeDate: boolean
 ) => {
-  const paymentMethodChangeDate = dayjs("2020-10-27"); // The Date fee-payment-method changed
+  const paymentMethodChangeDate = dayjs(paymentChangeDate); // The Date fee-payment-method changed
   return feeObj.filter((fee) => {
     const { dueDate } = fee;
     if (dueDate) {

--- a/src/core/configuration/index.ts
+++ b/src/core/configuration/index.ts
@@ -7,6 +7,7 @@ import coverTints from "./cover-tints.json";
 import colors from "./colors.json";
 import modalIds from "./modal-ids.json";
 import reservation from "./reservation.json";
+import payment from "./payment.json";
 
 export type ConfScope =
   | "pageSize"
@@ -16,7 +17,8 @@ export type ConfScope =
   | "recommenderMaterialLimits"
   | "colors"
   | "modalIds"
-  | "reservation";
+  | "reservation"
+  | "payment";
 type Device = "mobile" | "desktop";
 type ConfigurationEntry = {
   [key: string]: string | number | Record<string, unknown>;
@@ -54,5 +56,6 @@ export default {
   colors,
   recommenderMaterialLimits,
   modalIds,
-  reservation
+  reservation,
+  payment
 } as Configuration;

--- a/src/core/configuration/payment.json
+++ b/src/core/configuration/payment.json
@@ -1,0 +1,3 @@
+{
+  "paymentChangeDate": "2020-10-27"
+}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-349

#### Description
Fees after 27th of October were not showing (payment change happened on that date) on the fees page.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/d9fb9edd-cf48-4907-89be-c7a711d5a310)

#### Additional comments or questions
n/a