### PR TITLE
Use correct semantics for header

### DIFF
--- a/src/apps/loan-list/list/ListHeader.tsx
+++ b/src/apps/loan-list/list/ListHeader.tsx
@@ -11,9 +11,7 @@ const ListHeader: FC<ListHeaderProps> = ({ header, amount, children }) => {
     <div className="dpl-list-buttons">
       <h2 className="dpl-list-buttons__header">
         {header}
-        <span role="text" className="dpl-list-buttons__power">
-          {amount}
-        </span>
+        <span className="dpl-list-buttons__power">{amount}</span>
       </h2>
       <div className="dpl-list-buttons__buttons">{children}</div>
     </div>

--- a/src/apps/loan-list/list/ListHeader.tsx
+++ b/src/apps/loan-list/list/ListHeader.tsx
@@ -11,7 +11,9 @@ const ListHeader: FC<ListHeaderProps> = ({ header, amount, children }) => {
     <div className="dpl-list-buttons">
       <h2 className="dpl-list-buttons__header">
         {header}
-        <div className="dpl-list-buttons__power">{amount}</div>
+        <span role="text" className="dpl-list-buttons__power">
+          {amount}
+        </span>
       </h2>
       <div className="dpl-list-buttons__buttons">{children}</div>
     </div>

--- a/src/apps/reservation-list/list/list.tsx
+++ b/src/apps/reservation-list/list/list.tsx
@@ -83,9 +83,7 @@ const List: FC<ListProps> = ({
             <h2 className="dpl-list-buttons__header">
               <>
                 {header}
-                <span role="text" className="dpl-list-buttons__power">
-                  0
-                </span>
+                <span className="dpl-list-buttons__power">0</span>
               </>
             </h2>
           </div>

--- a/src/apps/reservation-list/list/list.tsx
+++ b/src/apps/reservation-list/list/list.tsx
@@ -83,7 +83,9 @@ const List: FC<ListProps> = ({
             <h2 className="dpl-list-buttons__header">
               <>
                 {header}
-                <div className="dpl-list-buttons__power">0</div>
+                <span role="text" className="dpl-list-buttons__power">
+                  0
+                </span>
               </>
             </h2>
           </div>

--- a/src/components/list-header/list-header.tsx
+++ b/src/components/list-header/list-header.tsx
@@ -18,7 +18,9 @@ const ListHeader: FC<ListHeaderProps> = ({
       <h2 data-cy={dataCy} className="dpl-list-buttons__header">
         {header}
         {amount !== null && (
-          <div className="dpl-list-buttons__power">{amount}</div>
+          <span role="text" className="dpl-list-buttons__power">
+            {amount}
+          </span>
         )}
       </h2>
       <div className="dpl-list-buttons__buttons">{children}</div>

--- a/src/components/list-header/list-header.tsx
+++ b/src/components/list-header/list-header.tsx
@@ -18,9 +18,7 @@ const ListHeader: FC<ListHeaderProps> = ({
       <h2 data-cy={dataCy} className="dpl-list-buttons__header">
         {header}
         {amount !== null && (
-          <span role="text" className="dpl-list-buttons__power">
-            {amount}
-          </span>
+          <span className="dpl-list-buttons__power">{amount}</span>
         )}
       </h2>
       <div className="dpl-list-buttons__buttons">{children}</div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-177

#### Description
A div is not semantically correct to use inside a h-tag. Instead we should use a span and tell the screen reader to percieve it as a text.
