### PR TITLE
Reintroduce initial support for Cypress Cloud

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,13 +50,13 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots-${{ matrix.containers }}
           path: cypress/screenshots
       - name: Upload videos
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos
+          name: cypress-videos-${{ matrix.containers }}
           path: cypress/videos
       - name: Generate code coverage report
         run: yarn run nyc report --reporter=clover --reporter=text --report-dir=./coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,14 @@ jobs:
       options: --user 1001
     env:
       TZ: Europe/Copenhagen
+    strategy:
+      # When one test fails, DO NOT cancel the other containers, because this
+      # will kill Cypress processes leaving Cypress Cloud hanging.
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # Run 3 copies of the current job in parallel
+        containers: [1, 2, 3]
     steps:
       - uses: actions/checkout@master
       - name: Setup Node
@@ -28,9 +36,16 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
+          install: false
           start: yarn start:storybook:test
           wait-on: "http://localhost:57021"
           browser: chrome
+          group: "Integration tests"
+          parallel: true
+          record: true
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
         if: failure()

--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,6 @@
   "retries": {
     "runMode": 3,
     "openMode": 0
-  }
+  },
+  "projectId": "4trcdv"
 }


### PR DESCRIPTION
#### Description

This should allow running tests in parallel to provide a faster testing process. Also it may provide a better test debugging experience.

All setup is based on the example from the documentation: https://github.com/cypress-io/github-action#split-install-and-tests.

#### Additional comments or questions

My own observations:

- Parallelization  brings down integration test time from 10 mins in #683 , 9 mins in #681 and 25 mins(!) in #680 to ~5 mins (x3). Of this 5 minutes ~2 minutes are spent setting up containers, Node and running `yarn install`.
- I find the PR comment annoying. It is just noise.
- We currently run tests on both pushes and pull requests. Perhaps we could reduce this.
- If we want to go with this we need to update required GitHub Actions 
- For the moment I do not think Cypress Cloud provides something unique that we do not already have (logs, screenshots, videos etc.) but the UI they provide is a nice way to access this. 

Note: This was originally introduced in #684 but reverted in 773bb0a. This puts the integration back in place.