### PR TITLE
Update advanced search filters

### DIFF
--- a/src/apps/advanced-search/AdvancedSearchResults.tsx
+++ b/src/apps/advanced-search/AdvancedSearchResults.tsx
@@ -88,7 +88,7 @@ const AdvancedSearchResult: React.FC<AdvancedSearchResultProps> = ({
   }, [data, page]);
 
   const shouldShowSearchResults = isLoading || (!isLoading && hitcount > 0);
-  const shouldShowResultHeadline = hitcount && !isLoading;
+  const shouldShowResultHeadline = !!(hitcount && !isLoading);
 
   useEffect(() => {
     if (copiedLinkToSearch) {
@@ -108,11 +108,14 @@ const AdvancedSearchResult: React.FC<AdvancedSearchResultProps> = ({
         /* ID is used to scroll to the results upon hitting the search button. */
         id="advanced-search-result"
       >
-        {isLoading && t("loadingResultsText")}
-        {shouldShowResultHeadline &&
-          t("showingMaterialsText", {
-            placeholders: { "@hitcount": hitcount }
-          })}
+        {isLoading && <>{t("loadingResultsText")}</>}
+        {shouldShowResultHeadline && (
+          <>
+            {t("showingMaterialsText", {
+              placeholders: { "@hitcount": hitcount }
+            })}
+          </>
+        )}
       </h2>
       {!showContentOnly && (
         <button

--- a/src/apps/advanced-search/advanced-search.test.ts
+++ b/src/apps/advanced-search/advanced-search.test.ts
@@ -45,7 +45,7 @@ describe("Search Result", () => {
     cy.getBySel("advanced-search-material-types").first().click();
     cy.getBySel("preview-section", true).should(
       "contain",
-      "'Harry' AND 'Prince' AND generalmaterialtype='bøger'"
+      "'Harry' AND 'Prince' AND term.generalmaterialtype='bøger'"
     );
   });
 
@@ -170,7 +170,7 @@ describe("Search Result", () => {
       .eq(1)
       .within(() => {
         cy.get("input").should("have.value", "Rowling");
-        cy.get("select").should("have.value", "creator");
+        cy.get("select").should("have.value", "term.creatorcontributor");
       });
     // We currently have no good way to identify selected options in the
     // multiselect so checking the text of the button is the best we can do.

--- a/src/apps/advanced-search/types.ts
+++ b/src/apps/advanced-search/types.ts
@@ -2,40 +2,36 @@ import { MultiselectOption } from "../../components/multiselect/types";
 
 export const advancedSearchIndexes = [
   "all",
-  "creator",
-  "subject",
-  "genre",
-  "language",
-  "date",
-  "mainCreator",
-  "mainTitle",
-  "source",
-  "dateFirstEdition",
-  "decimaldk5",
-  "type",
-  "audience",
-  "publisher",
-  "identifier",
-  "acSource"
+  "term.creatorcontributor",
+  "term.subject",
+  "term.genreandform",
+  "term.mainlanguage",
+  "datefirstedition",
+  "term.creator",
+  "term.title",
+  "term.source",
+  "dk5",
+  "term.specificmaterialtype",
+  "term.childrenoradults",
+  "term.publisher",
+  "term.isbn"
 ] as const;
 
 export const advancedSearchIndexTranslations = {
   all: "advancedSearchAllIndexesText",
-  creator: "advancedSearchCreatorText",
-  subject: "advancedSearchSubjectText",
-  genre: "advancedSearchGenreText",
-  language: "advancedSearchLanguageText",
-  date: "advancedSearchDateText",
-  mainCreator: "advancedSearchMainCreatorText",
-  mainTitle: "advancedSearchMainTitleText",
-  source: "advancedSearchSourceText",
-  dateFirstEdition: "advancedSearchDateFirstEditionText",
-  decimaldk5: "advancedSearchDecimalDk5Text",
-  type: "advancedSearchTypeText",
-  audience: "advancedSearchAudienceText",
-  publisher: "advancedSearchPublisherText",
-  identifier: "advancedSearchIdentifierText",
-  acSource: "advancedSearchAcSourceText"
+  "term.creatorcontributor": "advancedSearchCreatorText",
+  "term.subject": "advancedSearchSubjectText",
+  "term.genreandform": "advancedSearchGenreText",
+  "term.mainlanguage": "advancedSearchLanguageText",
+  datefirstedition: "advancedSearchDateText",
+  "term.creator": "advancedSearchMainCreatorText",
+  "term.title": "advancedSearchMainTitleText",
+  "term.source": "advancedSearchSourceText",
+  dk5: "advancedSearchDecimalDk5Text",
+  "term.specificmaterialtype": "advancedSearchTypeText",
+  "term.childrenoradults": "advancedSearchAudienceText",
+  "term.publisher": "advancedSearchPublisherText",
+  "term.isbn": "advancedSearchIdentifierText"
 } as const;
 
 export type AdvancedSearchIndex = typeof advancedSearchIndexes[number];
@@ -80,9 +76,9 @@ export const initialAdvancedSearchQuery: AdvancedSearchQuery = {
     { term: "", searchIndex: "all", clause: advancedSearchClauses[0], id: 1 }
   ],
   filters: {
-    materialTypes: [{ item: "All", value: "all" }],
-    fiction: [{ item: "All", value: "all" }],
-    accessibility: [{ item: "All", value: "all" }]
+    materialTypes: [{ item: "multiselectAllOptionText", value: "all" }],
+    fiction: [{ item: "multiselectAllOptionText", value: "all" }],
+    accessibility: [{ item: "multiselectAllOptionText", value: "all" }]
   }
 };
 
@@ -106,7 +102,7 @@ export const advancedSearchFiction: MultiselectOption[] = [
 ];
 
 export const advancedSearchFilters = {
-  materialTypes: "generalmaterialtype",
-  fiction: "fictionnonfiction",
-  accessibility: "accesstype"
+  materialTypes: "term.generalmaterialtype",
+  fiction: "term.fictionnonfiction",
+  accessibility: "term.accesstype"
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DSC-81

#### Description
The FBI API came out with some changes to their specs, so we now need to update how we contact it. As a part of this, most keys of advancedSearchIndexTranslations also needed to be updated to match.
As a part of this PR, a minor bug was also fixed where the number 0 was showing on the page as a part of the loading results text headline

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a