### PR TITLE
Fix single vs group loan click events

### DIFF
--- a/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
+++ b/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
@@ -29,10 +29,6 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
 }) => {
   const { dueDate, identifier, periodical } = loan;
 
-  const openLoanDetailsModalHandler = () => {
-    openLoanDetailsModal(loan);
-  };
-
   const handleOpenDueDateModal = () => {
     if (openDueDateModal && dueDate) {
       openDueDateModal(dueDate);
@@ -58,7 +54,7 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
       {material && (
         <MaterialInfo
           arrowLabelledBy={`${loanId || identifier}-title`}
-          openDetailsModal={openLoanDetailsModalHandler}
+          openDetailsModal={handleOpenDueDateModal}
           periodical={periodical}
           material={material}
           focused={focused}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-338

#### Description
Some of the business logic needed to be updated for loan list cards. When clicking on the title of a grouped loan, it is the group modal that should open, not a modal with details. 

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a