### PR TITLE
Fix/translation error throwing

### DIFF
--- a/src/core/utils/text.tsx
+++ b/src/core/utils/text.tsx
@@ -105,13 +105,15 @@ const processTexts = (texts: string[], placeholders: Placeholders) =>
   );
 
 export const useText = (): UseTextFunction => {
-  const { data } = useSelector((state: RootState) => state.text);
+  const { data } = useSelector<{ data: Record<string, string> }>(
+    (state: RootState) => state.text
+  );
 
   return (key: string, { placeholders, count } = { count: 0 }) => {
     if (!data) {
       throw new Error(`The translation store is broken.`);
     }
-    if (!data[key]) {
+    if (data[key] === undefined) {
       throw new Error(`The translation for ${key} is not defined.`);
     }
     const textDefinition = constructTextDefinitionFromRawTextTextEntry(

--- a/src/tests/unit/text.test.tsx
+++ b/src/tests/unit/text.test.tsx
@@ -15,7 +15,8 @@ const store = configureStore({
       data: {
         simpleText: "This is a @simple test",
         placeholdersText: `{"type":"simple","text":["This is a text with a @placeholder embedded. Does it work? @result it does!"]}`,
-        pluralText: `{"type":"plural","text":["You have 1 material on the waiting list","You have @count materials on the waiting list"]}`
+        pluralText: `{"type":"plural","text":["You have 1 material on the waiting list","You have @count materials on the waiting list"]}`,
+        emptyStringText: ""
       }
     }
   }
@@ -86,5 +87,17 @@ test("Should throw an error if the text definition is not found", () => {
     expect(() => t("nonExistingText")).toThrowError(
       "The translation for nonExistingText is not defined."
     );
+  });
+});
+
+test("Shouldn't throw an error if the text is an empty string", () => {
+  const { result } = renderHook(() => useText(), { wrapper: Wrapper });
+  // We name it t, because that is how we normally use it in the code.
+  const t = result.current;
+
+  act(() => {
+    // This test would be failing if an error was thrown for empty strings.
+    // That's why we don't need to define anything else here to know that it works.
+    t("emptyStringText");
   });
 });


### PR DESCRIPTION
#### Link to issue
-

#### Description
Errors were being thrown left and right for translations defined as empty strings. That shouldn't be the case.

#### Screenshot of the result
n/a

#### Additional comments or questions
n/a