### PR TITLE
Try to fix dependency problem in the branch release workflow

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -44,6 +44,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
           registry-url: 'https://npm.pkg.github.com'
+          always-auth: true
+          scope: '@danskernesdigitalebibliotek'
 
       - run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
It has been unstable to download the dpl-design-system during the Github workflow that creates releases on branch changes. This seems to be a fix...

Solution found at:
https://stackoverflow.com/questions/61817010/installing-private-github-package-using-yarn-on-github-actions-is-unauthorized-w
