### PR TITLE
Change the 'Reserve' button text to the standard and move the notice about material ordered from other libraries to the `MaterialAvailabilityTextParagraph`.

### DIFF
--- a/cypress/fixtures/material/open-order/open-order-accepted.json
+++ b/cypress/fixtures/material/open-order/open-order-accepted.json
@@ -1,9 +1,9 @@
 {
   "data": {
     "submitOrder": {
-      "status": "OWNED_ACCEPTED",
-      "message": "Item available at pickupAgency, order accepted",
-      "orderId": "1234"
+      "status": "NOT_OWNED_ILL_LOC",
+      "message": "Item not available at pickupAgency, item localised for ILL",
+      "orderId": "1048265231"
     }
   }
 }

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -86,7 +86,7 @@ export default {
     },
     reservableFromAnotherLibraryText: {
       name: "Reservable on another library",
-      defaultValue: "Reservable on another library",
+      defaultValue: "Ordered from another library.",
       control: { type: "text" }
     },
     findOnBookshelfText: {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -84,6 +84,11 @@ export default {
       defaultValue: "Reserve",
       control: { type: "text" }
     },
+    reserveWithMaterialTypeText: {
+      name: "Reserve",
+      defaultValue: "Reserve @materialType",
+      control: { type: "text" }
+    },
     reservableFromAnotherLibraryText: {
       name: "Reservable on another library",
       defaultValue: "Ordered from another library.",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -767,7 +767,7 @@ export default {
     },
     openOrderNotOwnedIllLocText: {
       name: "Open order item localized for ILL text",
-      defaultValue: "Item not available at pickup agency but localized for ILL",
+      defaultValue: "Your material has been ordered from another library",
       control: { type: "text" }
     },
     openOrderNotOwnedNoIllLocText: {

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -153,6 +153,7 @@ interface MaterialEntryTextProps {
   reservationSuccesTitleText: string;
   reserveBookText: string;
   reserveText: string;
+  reserveWithMaterialTypeText: string;
   reviewsText: string;
   saveButtonText: string;
   seeOnlineText: string;

--- a/src/apps/material/open-order.test.ts
+++ b/src/apps/material/open-order.test.ts
@@ -9,7 +9,7 @@ const navigateToMaterial = () => {
   cy.getBySel("material-button-reservable-on-another-library")
     .first()
     .should("be.visible")
-    .and("contain", "Reservable on another library")
+    .and("contain", "Reserve bog")
     .click();
   cy.getBySel("material-description").scrollIntoView();
   cy.getBySel("reservation-modal-submit-button", true)
@@ -45,7 +45,7 @@ describe("Open Order Functionality", () => {
 
     cy.getBySel("open-oprder-response-status-text")
       .should("be.visible")
-      .and("contain", "Your order is accepted");
+      .and("contain", "Your material has been ordered from another library");
 
     closeModal();
   });

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -10,17 +10,30 @@ import { Manifestation } from "../../../core/utils/types/entities";
 import { hasCorrectAccessType } from "../material-buttons/helper";
 import MaterialAvailabilityTextOnline from "./online/MaterialAvailabilityTextOnline";
 import MaterialAvailabilityTextPhysical from "./physical/MaterialAvailabilityTextPhysical";
+import useReservableFromAnotherLibrary from "../../../core/utils/useReservableFromAnotherLibrary";
+import MaterialAvailabilityTextParagraph from "./generic/MaterialAvailabilityTextParagraph";
+import { useText } from "../../../core/utils/text";
 
 interface Props {
   manifestations: Manifestation[];
 }
 
 const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
+  const t = useText();
   const materialType = head(getMaterialTypes(manifestations));
   const isbns = getAllIdentifiers(manifestations);
+  const reservablePidsFromAnotherLibrary =
+    useReservableFromAnotherLibrary(manifestations);
 
   if (hasCorrectAccessType(AccessTypeCode.Physical, manifestations)) {
     const pids = getAllPids(manifestations);
+    if (reservablePidsFromAnotherLibrary.length) {
+      return (
+        <MaterialAvailabilityTextParagraph>
+          {t("reservableFromAnotherLibraryText")}
+        </MaterialAvailabilityTextParagraph>
+      );
+    }
     return <MaterialAvailabilityTextPhysical pids={pids} />;
   }
 

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -22,12 +22,12 @@ const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
   const t = useText();
   const materialType = head(getMaterialTypes(manifestations));
   const isbns = getAllIdentifiers(manifestations);
-  const reservablePidsFromAnotherLibrary =
+  const { materialIsReservableFromAnotherLibrary } =
     useReservableFromAnotherLibrary(manifestations);
 
   if (hasCorrectAccessType(AccessTypeCode.Physical, manifestations)) {
     const pids = getAllPids(manifestations);
-    if (reservablePidsFromAnotherLibrary.length) {
+    if (materialIsReservableFromAnotherLibrary) {
       return (
         <MaterialAvailabilityTextParagraph>
           {t("reservableFromAnotherLibraryText")}

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -35,10 +35,10 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   // articles appear as a part of journal/periodical publications and can't be
   // physically loaned for themseleves.
 
-  const reservablePidsFromAnotherLibrary =
+  const { materialIsReservableFromAnotherLibrary } =
     useReservableFromAnotherLibrary(manifestations);
 
-  if (reservablePidsFromAnotherLibrary.length > 0) {
+  if (materialIsReservableFromAnotherLibrary) {
     return (
       <MaterialButtonReservableFromAnotherLibrary
         size={size}

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -39,7 +39,9 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
       label={
         size === "small"
           ? t("reserveText")
-          : `${t("reserveText")} ${manifestationMaterialType}`
+          : `${t("reserveWithMaterialTypeText", {
+              placeholders: { "@materialType": manifestationMaterialType }
+            })}`
       }
       buttonType="none"
       variant="filled"

--- a/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
@@ -41,7 +41,9 @@ const MaterialButtonReservableFromAnotherLibrary: FC<
       label={
         size === "small"
           ? t("reserveText")
-          : `${t("reserveText")} ${manifestationMaterialType}`
+          : `${t("reserveWithMaterialTypeText", {
+              placeholders: { "@materialType": manifestationMaterialType }
+            })}`
       }
       buttonType="none"
       variant="filled"

--- a/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
@@ -40,10 +40,8 @@ const MaterialButtonReservableFromAnotherLibrary: FC<
       dataCy={dataCy}
       label={
         size === "small"
-          ? t("reservableFromAnotherLibraryText")
-          : `${t(
-              "reservableFromAnotherLibraryText"
-            )} ${manifestationMaterialType}`
+          ? t("reserveText")
+          : `${t("reserveText")} ${manifestationMaterialType}`
       }
       buttonType="none"
       variant="filled"

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -129,9 +129,10 @@ export const ReservationModalBody = ({
     !!selectedPeriodical
   );
 
-  const reservablePidsFromAnotherLibrary = useReservableFromAnotherLibrary(
-    selectedManifestations
-  );
+  const {
+    reservablePidsFromAnotherLibrary,
+    materialIsReservableFromAnotherLibrary
+  } = useReservableFromAnotherLibrary(selectedManifestations);
 
   // If we don't have all data for displaying the view render nothing.
   if (!userResponse.data || !holdingsResponse.data) {
@@ -178,14 +179,14 @@ export const ReservationModalBody = ({
       );
     }
 
-    if (reservablePidsFromAnotherLibrary?.length > 0 && patron) {
+    if (materialIsReservableFromAnotherLibrary && patron) {
       const { patronId, name, emailAddress, preferredPickupBranch } = patron;
 
       // Save reservation to open order.
       mutateOpenOrder(
         {
           input: {
-            pids: [...reservablePidsFromAnotherLibrary],
+            pids: reservablePidsFromAnotherLibrary,
             pickUpBranch: selectedBranch
               ? removePrefixFromBranchId(selectedBranch)
               : removePrefixFromBranchId(preferredPickupBranch),
@@ -253,7 +254,7 @@ export const ReservationModalBody = ({
           <div>
             <div className="reservation-modal-submit">
               <MaterialAvailabilityTextParagraph>
-                {reservablePidsFromAnotherLibrary?.length > 0 ? (
+                {materialIsReservableFromAnotherLibrary ? (
                   t("reservableFromAnotherLibraryText")
                 ) : (
                   <StockAndReservationInfo
@@ -302,7 +303,7 @@ export const ReservationModalBody = ({
                   selectedBranch={selectedBranch}
                   selectBranchHandler={setSelectedBranch}
                   selectedInterest={
-                    reservablePidsFromAnotherLibrary?.length > 0 &&
+                    materialIsReservableFromAnotherLibrary &&
                     selectedInterest === null
                       ? Number(defaultInterestDaysForOpenOrder)
                       : selectedInterest

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -251,10 +251,14 @@ export const ReservationModalBody = ({
           <div>
             <div className="reservation-modal-submit">
               <MaterialAvailabilityTextParagraph>
-                <StockAndReservationInfo
-                  stockCount={holdings}
-                  reservationCount={reservations}
-                />
+                {reservablePidsFromAnotherLibrary?.length ? (
+                  t("reservableFromAnotherLibraryText")
+                ) : (
+                  <StockAndReservationInfo
+                    stockCount={holdings}
+                    reservationCount={reservations}
+                  />
+                )}
               </MaterialAvailabilityTextParagraph>
               <Button
                 dataCy="reservation-modal-submit-button"

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -41,7 +41,8 @@ import {
   getInstantLoanBranchHoldings,
   getInstantLoanBranchHoldingsAboveThreshold,
   removePrefixFromBranchId,
-  translateOpenOrderStatus
+  translateOpenOrderStatus,
+  getFutureDateStringISO
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
 import { PeriodicalEdition } from "../material/periodical/helper";
@@ -177,8 +178,9 @@ export const ReservationModalBody = ({
       );
     }
 
-    if (reservablePidsFromAnotherLibrary?.length && patron) {
+    if (reservablePidsFromAnotherLibrary?.length > 0 && patron) {
       const { patronId, name, emailAddress, preferredPickupBranch } = patron;
+
       // Save reservation to open order.
       mutateOpenOrder(
         {
@@ -187,9 +189,9 @@ export const ReservationModalBody = ({
             pickUpBranch: selectedBranch
               ? removePrefixFromBranchId(selectedBranch)
               : removePrefixFromBranchId(preferredPickupBranch),
-            expires:
-              selectedInterest?.toString() ||
-              defaultInterestDaysForOpenOrder.toString(),
+            expires: getFutureDateStringISO(
+              Number(selectedInterest ?? defaultInterestDaysForOpenOrder)
+            ),
             userParameters: {
               userId: patronId.toString(),
               userName: name,
@@ -251,7 +253,7 @@ export const ReservationModalBody = ({
           <div>
             <div className="reservation-modal-submit">
               <MaterialAvailabilityTextParagraph>
-                {reservablePidsFromAnotherLibrary?.length ? (
+                {reservablePidsFromAnotherLibrary?.length > 0 ? (
                   t("reservableFromAnotherLibraryText")
                 ) : (
                   <StockAndReservationInfo
@@ -299,7 +301,12 @@ export const ReservationModalBody = ({
                   branches={branches}
                   selectedBranch={selectedBranch}
                   selectBranchHandler={setSelectedBranch}
-                  selectedInterest={selectedInterest}
+                  selectedInterest={
+                    reservablePidsFromAnotherLibrary?.length > 0 &&
+                    selectedInterest === null
+                      ? Number(defaultInterestDaysForOpenOrder)
+                      : selectedInterest
+                  }
                   setSelectedInterest={setSelectedInterest}
                 />
               )}

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -48,6 +48,12 @@ export const getFutureDateString = (num: number) => {
   const futureDate = dayjs().add(num, "day").format("YYYY-MM-DD");
   return futureDate;
 };
+
+export const getFutureDateStringISO = (num: number) => {
+  const futureDate = dayjs().add(num, "day").format("YYYY-MM-DDTHH:mm:ssZ");
+  return futureDate;
+};
+
 type Periodical = Pick<PeriodicalEdition, "volumeNumber" | "volumeYear">;
 
 const constructReservation = ({

--- a/src/core/utils/useReservableFromAnotherLibrary.tsx
+++ b/src/core/utils/useReservableFromAnotherLibrary.tsx
@@ -6,7 +6,10 @@ import { Pid } from "./types/ids";
 
 const useReservableFromAnotherLibrary = (
   manifestations: Manifestation[]
-): Pid[] => {
+): {
+  reservablePidsFromAnotherLibrary: Pid[];
+  materialIsReservableFromAnotherLibrary: boolean;
+} => {
   const config = useConfig();
   const { data: holdingsData } = useGetHoldings({
     faustIds: getAllFaustIds(manifestations),
@@ -16,14 +19,26 @@ const useReservableFromAnotherLibrary = (
   // If there is no holdings data or if there are holdings that are reservable, we return an empty array.
   // Because we use the array length to determine if we should show the button or not.
   if (holdingsData?.some(({ reservable }) => reservable === true)) {
-    return [];
+    return {
+      reservablePidsFromAnotherLibrary: [],
+      materialIsReservableFromAnotherLibrary: false
+    };
   }
 
-  return manifestations
+  const reservablePidsFromAnotherLibrary = manifestations
     .filter(({ catalogueCodes }) =>
       catalogueCodes?.otherCatalogues.some((code) => code.startsWith("OVE"))
     )
     .map(({ pid }) => pid);
+
+  const materialIsReservableFromAnotherLibrary = Boolean(
+    reservablePidsFromAnotherLibrary.length
+  );
+
+  return {
+    reservablePidsFromAnotherLibrary,
+    materialIsReservableFromAnotherLibrary
+  };
 };
 
 export default useReservableFromAnotherLibrary;

--- a/src/tests/unit/useReservableFromAnotherLibrary.test.tsx
+++ b/src/tests/unit/useReservableFromAnotherLibrary.test.tsx
@@ -73,7 +73,10 @@ describe("useReservableFromAnotherLibrary", () => {
     );
 
     act(() => {
-      expect(result.current).toEqual(["870970-basis:27721257"]);
+      expect(result.current.reservablePidsFromAnotherLibrary).toEqual([
+        "870970-basis:27721257"
+      ]);
+      expect(result.current.materialIsReservableFromAnotherLibrary).toBe(true);
     });
   });
 
@@ -103,7 +106,8 @@ describe("useReservableFromAnotherLibrary", () => {
     );
 
     act(() => {
-      expect(result.current).toEqual([]);
+      expect(result.current.reservablePidsFromAnotherLibrary).toEqual([]);
+      expect(result.current.materialIsReservableFromAnotherLibrary).toBe(false);
     });
   });
 });


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSOEG-528


#### Description
This PR enhances the user experience by providing a more streamlined interface, while still effectively notifying the user when the material is ordered from an another library.

In this revision, I have incorporated a useEffect hook within the `UserListItems` component. This modification ensures that the default branch and interest period, as specified in the `ModalReservationFormSelect`, are consistently used as the values transmitted with the request.


#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/d1823d27-6faa-4cad-9370-eaa84d7260c8


