### PR TITLE
Make "delete reservation" into a ghost button instead a text link

### DIFF
--- a/src/apps/reservation-list/modal/reservation-details/reservation-details-redirect.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details-redirect.tsx
@@ -36,6 +36,7 @@ const ReservationDetailsRedirect: FC<
         disabled={false}
         onClick={() => openReservationDeleteModal(reservation)}
         classNames={linkClassNames}
+        dataCy="remove-digital-reservation-button"
       />
       <LinkButton
         dataCy="go-to-ereolen-button"

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details-redirect.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details-redirect.tsx
@@ -4,6 +4,7 @@ import { useText } from "../../../../core/utils/text";
 import { MaterialProps } from "../../../loan-list/materials/utils/material-fetch-hoc";
 import { ReservationType } from "../../../../core/utils/types/reservation-type";
 import LinkButton from "../../../../components/Buttons/LinkButton";
+import { Button } from "../../../../components/Buttons/Button";
 
 export interface ReservationDetailsRedirectProps {
   reservation: ReservationType;
@@ -26,13 +27,16 @@ const ReservationDetailsRedirect: FC<
 
   return (
     <div className={`modal-details__buttons ${className}`}>
-      <button
-        type="button"
+      <Button
+        buttonType="none"
+        label={t("reservationDetailsRemoveDigitalReservationText")}
+        size="small"
+        variant="outline"
+        collapsible={false}
+        disabled={false}
         onClick={() => openReservationDeleteModal(reservation)}
-        className={`link-tag cursor-pointer ${linkClassNames}`}
-      >
-        {t("reservationDetailsRemoveDigitalReservationText")}
-      </button>
+        classNames={linkClassNames}
+      />
       <LinkButton
         dataCy="go-to-ereolen-button"
         size="small"

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -229,8 +229,7 @@ describe("Reservation details modal", () => {
       .find(".text-small-caption")
       .should("have.text", "16-08-2022 12:52");
 
-    cy.get(".modal")
-      .find("button.link-tag")
+    cy.getBySel("remove-digital-reservation-button")
       .eq(0)
       .should("have.text", "Remove your reservation")
       .click();


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-344

#### Description
A link text "delete reservation" was changed to an ghost button in the reservation details modal.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/fd89e5d9-99fc-440b-93cd-12740ba915ec)

#### Additional comments or questions
-