### PR TITLE
DDFLSBP-377 - Added a check to see if blockedPatronELinkUrl is the sa…

### DIFF
--- a/src/components/blocked-patron/blocked-modal/BlockedModal.tsx
+++ b/src/components/blocked-patron/blocked-modal/BlockedModal.tsx
@@ -14,7 +14,7 @@ interface BlockedModalProps {
 const BlockedModal: FC<BlockedModalProps> = ({ blockedStatus }) => {
   const t = useText();
   const u = useUrls();
-  const blockedPatronELinkUrl = u("blockedPatronELinkUrl");
+  const blockedPatronELinkUrl = u("blockedPatronELinkUrl", true);
   const { blockedModal } = getModalIds();
 
   // If the user isn't actually blocked, don't render the modal.
@@ -38,12 +38,11 @@ const BlockedModal: FC<BlockedModalProps> = ({ blockedStatus }) => {
         <p className="mt-48 mb-48 text-body-large">
           {t(`blockedPatron${blockedStatus}BodyText`)}
         </p>
-        {blockedStatus === BlockedTypes.fee &&
-          blockedPatronELinkUrl.href !== getCurrentLocation() && (
-            <Link href={blockedPatronELinkUrl}>
-              {t(`blockedPatronELinkText`)}
-            </Link>
-          )}
+        {blockedStatus === BlockedTypes.fee && blockedPatronELinkUrl && (
+          <Link href={blockedPatronELinkUrl}>
+            {t(`blockedPatronELinkText`)}
+          </Link>
+        )}
       </div>
     </Modal>
   );

--- a/src/components/blocked-patron/blocked-modal/BlockedModal.tsx
+++ b/src/components/blocked-patron/blocked-modal/BlockedModal.tsx
@@ -5,7 +5,6 @@ import BlockedTypes from "../../../core/utils/types/BlockedTypes";
 import { useUrls } from "../../../core/utils/url";
 import Link from "../../atoms/links/Link";
 import { getModalIds } from "../../../core/utils/helpers/modal-helpers";
-import { getCurrentLocation } from "../../../core/utils/helpers/url";
 
 interface BlockedModalProps {
   blockedStatus: string;

--- a/src/components/blocked-patron/blocked-modal/BlockedModal.tsx
+++ b/src/components/blocked-patron/blocked-modal/BlockedModal.tsx
@@ -5,6 +5,7 @@ import BlockedTypes from "../../../core/utils/types/BlockedTypes";
 import { useUrls } from "../../../core/utils/url";
 import Link from "../../atoms/links/Link";
 import { getModalIds } from "../../../core/utils/helpers/modal-helpers";
+import { getCurrentLocation } from "../../../core/utils/helpers/url";
 
 interface BlockedModalProps {
   blockedStatus: string;
@@ -14,7 +15,6 @@ const BlockedModal: FC<BlockedModalProps> = ({ blockedStatus }) => {
   const t = useText();
   const u = useUrls();
   const blockedPatronELinkUrl = u("blockedPatronELinkUrl");
-
   const { blockedModal } = getModalIds();
 
   // If the user isn't actually blocked, don't render the modal.
@@ -38,11 +38,12 @@ const BlockedModal: FC<BlockedModalProps> = ({ blockedStatus }) => {
         <p className="mt-48 mb-48 text-body-large">
           {t(`blockedPatron${blockedStatus}BodyText`)}
         </p>
-        {blockedStatus === BlockedTypes.fee && (
-          <Link href={blockedPatronELinkUrl}>
-            {t(`blockedPatronELinkText`)}
-          </Link>
-        )}
+        {blockedStatus === BlockedTypes.fee &&
+          blockedPatronELinkUrl.href !== getCurrentLocation() && (
+            <Link href={blockedPatronELinkUrl}>
+              {t(`blockedPatronELinkText`)}
+            </Link>
+          )}
       </div>
     </Modal>
   );

--- a/src/core/utils/url.tsx
+++ b/src/core/utils/url.tsx
@@ -8,7 +8,11 @@ export const useUrls = () => {
   const { data } = useSelector((state: RootState) => state.url);
   const urls = useMemo(() => turnUrlStringsIntoObjects(data), [data]);
 
-  return (name: string) => {
+  return (name: string, returnFalseIfUndefined = false) => {
+    if (returnFalseIfUndefined) {
+      return urls[name] || false;
+    }
+
     if (!urls[name]) {
       throw new Error(`The url ${name} is not defined`);
     }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-377

#### Description

This PR checks if the blockedPatronELinkUrl is the same as the current location URL. If this is the case, we do not want to show the blockedPatronELinkUrl and text in the blockedUser Modal.

#### Additional comments or questions

This PR has a sister PR in dpl-cms. It can be found here: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/653
