### PR TITLE
Make it possible to give arrow button component classes

### DIFF
--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -152,14 +152,13 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
           </div>
         </div>
         {openDetailsModal && (
-          <div className="list-materials__arrow">
-            <ArrowButton
-              arrowLabelledBy={listId(item)}
-              cursorPointer
-              clickEventHandler={handleOnClick}
-              keyUpEventHandler={handleOnKeyUp}
-            />
-          </div>
+          <ArrowButton
+            arrowLabelledBy={listId(item)}
+            cursorPointer
+            clickEventHandler={handleOnClick}
+            keyUpEventHandler={handleOnKeyUp}
+            classNames="list-materials__arrow"
+          />
         )}
       </div>
     </li>

--- a/src/components/Buttons/ArrowButton.tsx
+++ b/src/components/Buttons/ArrowButton.tsx
@@ -6,13 +6,15 @@ export interface ArrowButtonProps {
   clickEventHandler?: () => void;
   keyUpEventHandler?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
   arrowLabelledBy: string;
+  classNames?: string;
 }
 
 const ArrowButton: React.FC<ArrowButtonProps> = ({
   cursorPointer = false,
   clickEventHandler,
   keyUpEventHandler,
-  arrowLabelledBy
+  arrowLabelledBy,
+  classNames = ""
 }) => {
   const pointer = (cursorPointer && { cursor: "pointer" }) || {
     cursor: "inherit"
@@ -20,7 +22,7 @@ const ArrowButton: React.FC<ArrowButtonProps> = ({
   return (
     <button
       aria-labelledby={arrowLabelledBy}
-      className="arrow-button"
+      className={`${classNames} arrow-button`}
       style={pointer}
       type="button"
       onClick={(e) => {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-276

#### Description
The arrows in material details modal were being shown inconsistently to the rest of the site. This PR in combination with its [sibling PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/436) fixes that.

#### Screenshot of the result
-

#### Additional comments or questions
-