### PR TITLE
Fix/double fees in group modal

### DIFF
--- a/src/apps/fee-list/stackable-fees/fee-details-content.tsx
+++ b/src/apps/fee-list/stackable-fees/fee-details-content.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { FC } from "react";
 import { FeeV2 } from "../../../core/fbs/model";
 import { useText } from "../../../core/utils/text";
-import { FaustId } from "../../../core/utils/types/ids";
 import { dateFormatCustom } from "../../../core/configuration/date-format.json";
 import StackableFeesList from "./stackable-fees-list";
 import GroupModalContent from "../../../components/GroupModal/GroupModalContent";
@@ -47,14 +46,7 @@ const FeeDetailsContent: FC<FeeDetailsContentProps> = ({ feeDetailsData }) => {
       >
         <div />
       </GroupModalContent>
-      {materials.map(({ recordId }) => (
-        <StackableFeesList
-          reasonForFee={reasonMessage}
-          materials={materials}
-          key={recordId}
-          item={{ faust: `${recordId}` as FaustId }}
-        />
-      ))}
+      <StackableFeesList reasonForFee={reasonMessage} materials={materials} />
     </div>
   );
 };

--- a/src/apps/fee-list/stackable-fees/stackable-fees-list.tsx
+++ b/src/apps/fee-list/stackable-fees/stackable-fees-list.tsx
@@ -1,8 +1,6 @@
 import React, { FC } from "react";
 import { useText } from "../../../core/utils/text";
-import fetchMaterial, {
-  MaterialProps
-} from "../../loan-list/materials/utils/material-fetch-hoc";
+import { MaterialProps } from "../../loan-list/materials/utils/material-fetch-hoc";
 import { FeeMaterialV2 } from "../../../core/fbs/model";
 import SelectableMaterial from "../../loan-list/materials/selectable-material/selectable-material";
 import StatusBadge from "../../loan-list/materials/utils/status-badge";
@@ -48,4 +46,4 @@ const StackableFeeList: FC<StackableFeeListProps & MaterialProps> = ({
   );
 };
 
-export default fetchMaterial(StackableFeeList);
+export default StackableFeeList;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-365

#### Description
Fee detail materials were shown multiple time on the list inside the fee list details modal. Now they only show a singular time per piece.

#### Screenshot of the result
-
#### Additional comments or questions
-