### PR TITLE
Disable "renew multiple loans" button on mobile if there aren't any

### DIFF
--- a/src/apps/loan-list/list/ToggleListViewButtons.tsx
+++ b/src/apps/loan-list/list/ToggleListViewButtons.tsx
@@ -89,10 +89,10 @@ const ToggleListViewButtons: FC<ToggleListViewButtonsProps> = ({
           <Button
             label={t("loanListRenewMultipleButtonText")}
             buttonType="none"
-            disabled={false}
+            disabled={disableRenewLoansButton}
             collapsible={false}
             size="small"
-            variant="filled"
+            variant={disableRenewLoansButton ? "outline" : "filled"}
             onClick={() => {
               openRenewLoansModal();
             }}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-369

#### Description
Disable "renew multiple loans" button on mobile if there aren't any

#### Screenshot of the result
The mobile button for the test user mentioned in the ticket:
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/9bf6d285-b763-46ee-b6d2-63179ca1591f)

#### Additional comments or questions
-