### PR TITLE
Don't open material details modal after interacting with the pager

### DIFF
--- a/src/apps/loan-list/materials/stackable-material/material-info.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-info.tsx
@@ -61,7 +61,10 @@ const MaterialInfo: FC<MaterialInfoProps> = ({
               handleDetailsModal(e);
             }}
             onKeyUp={(e) => {
-              if (e.key === "Enter" || e.key === "Space") {
+              // `!focused` prevents opening material details modal after clicking
+              // enter on pager. Pager gives focus to the next stackable material too
+              // quickly while still registering the enter key press.
+              if ((e.key === "Enter" || e.key === "Space") && !focused) {
                 handleDetailsModal(e);
               }
             }}

--- a/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
+++ b/src/apps/loan-list/materials/stackable-material/stackable-material.tsx
@@ -48,7 +48,10 @@ const StackableMaterial: FC<StackableMaterialProps & MaterialProps> = ({
       role="button"
       onClick={handleOpenDueDateModal}
       onKeyUp={(e) => {
-        if (e.key === "Enter" || e.key === "Space") {
+        // `!focused` prevents opening material details modal after clicking
+        // enter on pager. Pager gives focus to the next stackable material too
+        // quickly while still registering the enter key press.
+        if ((e.key === "Enter" || e.key === "Space") && !focused) {
           handleOpenDueDateModal();
         }
       }}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-367

#### Description
Pager gives focus to the next stackable material too quickly while still
registering the key press. So when interacting with the pager on the
keyboard, material details of the following, newly shown item would open
unintentionally.


#### Screenshot of the result
-
#### Additional comments or questions
-