### PR TITLE
Change wrong wiremock request.url property

### DIFF
--- a/.docker/wiremock/fbs/mappings/external_agencyid_patron_patronid_fees_v2-bd783b91-b464-4137-9575-b093008866df.json
+++ b/.docker/wiremock/fbs/mappings/external_agencyid_patron_patronid_fees_v2-bd783b91-b464-4137-9575-b093008866df.json
@@ -2,7 +2,7 @@
   "id" : "bd783b91-b464-4137-9575-b093008866df",
   "name" : "Fees (v2)",
   "request" : {
-    "url" : "/external/agencyid/patron/patronid/fees/v2?includepaid=false&includenonpayable=true",
+    "urlPattern": "/external/agencyid/patron/patronid/fees/v2\\?includepaid=false&includenonpayable=true$",
     "method" : "GET"
   },
   "response" : {

--- a/.docker/wiremock/fbs/mappings/fees-v2-without-parameters-ed922f92-46bb-46c6-926f-73678410fcd0.json
+++ b/.docker/wiremock/fbs/mappings/fees-v2-without-parameters-ed922f92-46bb-46c6-926f-73678410fcd0.json
@@ -2,7 +2,7 @@
   "id" : "ed922f92-46bb-46c6-926f-73678410fcd0",
   "name" : "Fees (v2) (without parameters)",
   "request" : {
-    "urlPath" : "/external/agencyid/patron/patronid/fees/v2",
+    "urlPattern" : "/external/agencyid/patron/patronid/fees/v2$",
     "method" : "GET"
   },
   "response" : {


### PR DESCRIPTION
#### Description

Change wrong wiremock request.url property

The pattern matching should be more precise in order to match the exact
query parameters or no query parameters.

Wiremock is failing delivering fees which breaks stories that depends on those.

