### PR TITLE
Decimals with comma

### DIFF
--- a/src/apps/dashboard/dashboard.dev.tsx
+++ b/src/apps/dashboard/dashboard.dev.tsx
@@ -59,7 +59,7 @@ export default {
       control: { type: "text" }
     },
     totalAmountFeeText: {
-      defaultValue: "@total,-",
+      defaultValue: "@total DKK",
       control: { type: "text" }
     },
     physicalLoansText: {

--- a/src/apps/dashboard/dashboard.test.tsx
+++ b/src/apps/dashboard/dashboard.test.tsx
@@ -1363,7 +1363,7 @@ describe("Dashboard", () => {
     cy.getBySel("warning-bar-text").should("have.text", "You owe in total");
 
     // The amount the patron ows
-    cy.getBySel("warning-bar-right-text").should("have.text", "265,06,-");
+    cy.getBySel("warning-bar-right-text").should("have.text", "265,06 DKK");
 
     // A pay button that links to fees page
     cy.getBySel("warning-bar-right-link")

--- a/src/apps/fee-list/FeeList.dev.tsx
+++ b/src/apps/fee-list/FeeList.dev.tsx
@@ -62,7 +62,7 @@ export default {
       control: { type: "text" }
     },
     totalText: {
-      defaultValue: "Total @total,-",
+      defaultValue: "Total @total DKK",
       control: { type: "text" }
     },
     expirationWarningDaysBeforeConfig: {
@@ -147,7 +147,7 @@ export default {
       control: {
         type: "text"
       },
-      defaultValue: "Fee @fee,-"
+      defaultValue: "Fee @fee DKK"
     },
     feeCreatedText: {
       control: {

--- a/src/apps/fee-list/FeeList.tsx
+++ b/src/apps/fee-list/FeeList.tsx
@@ -89,7 +89,8 @@ const FeeList: FC = () => {
             fees={getFeesBasedOnPayableByClient(fbsFees, true)}
             totalText={t("totalText", {
               placeholders: {
-                "@total": totalFeeAmountPayableByClient()
+                "@total":
+                  totalFeeAmountPayableByClient().toLocaleString("da-DK")
               }
             })}
           />
@@ -104,7 +105,8 @@ const FeeList: FC = () => {
             fees={getFeesBasedOnPayableByClient(fbsFees, false)}
             totalText={t("totalText", {
               placeholders: {
-                "@total": totalFeeAmountNotPayableByClient()
+                "@total":
+                  totalFeeAmountNotPayableByClient().toLocaleString("da-DK")
               }
             })}
           />

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -213,7 +213,7 @@ describe("Fee list", () => {
       .find(".list-reservation__fee")
       .find(".text-body-medium-regular")
       .should("exist")
-      .should("have.text", "Fee 70,-");
+      .should("have.text", "Fee 70 DKK");
 
     // 4.b +x other materials
     cy.getBySel("fee-list-page")

--- a/src/apps/fee-list/stackable-fees/stackable-fees.tsx
+++ b/src/apps/fee-list/stackable-fees/stackable-fees.tsx
@@ -63,7 +63,7 @@ const StackableFees: FC<StackableFeeProps & MaterialProps> = ({
         <div className="list-reservation__fee">
           <p className="text-body-medium-regular">
             {t("itemFeeAmountText", {
-              placeholders: { "@fee": amount }
+              placeholders: { "@fee": amount.toLocaleString("da-DK") }
             })}
           </p>
         </div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-386

#### Description

This PR makes sure that when rendering currency we use comma instead of a dot for decimals as per European standards.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/4a4a1eaa-e953-4bd2-959c-8d404b7b4a2a)

#### Additional comments or questions
-
