### PR TITLE
Add fee list second text string

### DIFF
--- a/src/apps/fee-list/FeeList.dev.tsx
+++ b/src/apps/fee-list/FeeList.dev.tsx
@@ -164,6 +164,11 @@ export default {
         "Already paid? It can take up to 72 hours to register the transaction.",
       control: { type: "text" }
     },
+    feeListAlreadyPaidSecondInfoText: {
+      defaultValue:
+        "Already paid? It can take up to 72 hours to register the transaction. (not payable by user)",
+      control: { type: "text" }
+    },
     feeListMaterialNumberText: {
       defaultValue: "# @materialNumber",
       control: { type: "text" }

--- a/src/apps/fee-list/FeeList.entry.tsx
+++ b/src/apps/fee-list/FeeList.entry.tsx
@@ -49,6 +49,8 @@ export interface FeeListProps {
   unpaidFeesPayableByClientHeadlineText: string;
   viewFeesAndCompensationRatesText: string;
   viewFeesAndCompensationRatesUrl: string;
+  feeListAlreadyPaidInfoText: string;
+  feeListAlreadyPaidSecondInfoText: string;
 }
 
 const FeeListEntry: FC<

--- a/src/apps/fee-list/FeeList.tsx
+++ b/src/apps/fee-list/FeeList.tsx
@@ -92,6 +92,7 @@ const FeeList: FC = () => {
                 "@total": totalFeeAmountPayableByClient()
               }
             })}
+            alreadyPaidText={t("feeListAlreadyPaidInfoText")}
           />
         )}
         {/* List of fees that can only be paid by the user externally */}
@@ -107,6 +108,7 @@ const FeeList: FC = () => {
                 "@total": totalFeeAmountNotPayableByClient()
               }
             })}
+            alreadyPaidText={t("feeListAlreadyPaidSecondInfoText")}
           />
         )}
       </div>

--- a/src/apps/fee-list/list.tsx
+++ b/src/apps/fee-list/list.tsx
@@ -3,7 +3,6 @@ import ListHeader from "../../components/list-header/list-header";
 import { FeeV2 } from "../../core/fbs/model";
 import StackableFees from "./stackable-fees/stackable-fees";
 import { FaustId } from "../../core/utils/types/ids";
-import { useText } from "../../core/utils/text";
 
 interface ListProps {
   openDetailsModalClickEvent: (faustId: string) => void;
@@ -12,6 +11,7 @@ interface ListProps {
   listHeader: ReactNode;
   totalText: string;
   className?: string;
+  alreadyPaidText: string;
 }
 const List: FC<ListProps> = ({
   openDetailsModalClickEvent,
@@ -19,10 +19,9 @@ const List: FC<ListProps> = ({
   listHeader,
   dataCy,
   totalText,
-  className
+  className,
+  alreadyPaidText
 }) => {
-  const t = useText();
-
   return (
     <div>
       {fees && (
@@ -42,7 +41,7 @@ const List: FC<ListProps> = ({
             <div className="fee-list-bottom__paymenttypes" />
             <div className="fee-list-bottom__actions">
               <p className="text-small-caption color-secondary-gray">
-                {t("feeListAlreadyPaidInfoText")}
+                {alreadyPaidText}
               </p>
               <p className="text-body-small-medium mt-16">{totalText}</p>
             </div>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-387

#### Description
Fee list text needs to be under 2 lists and translated into 2 different things. So now we have 2 texts.

#### Screenshot of the result
-
#### Additional comments or questions
This PR has [a sibling in dpl-cms](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/689) 