### PR TITLE
Fix Group Modal for Reservations [DDFLSBP-374]

### DIFF
--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -104,12 +104,19 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
   }
 
   if (state === "reserved" && pickupBranch && numberInQueue && expiryDate) {
+    const numberInLineLabel =
+      numberInQueue === 1
+        ? t("reservationListFirstInQueueText")
+        : t("reservationListNumberInQueueText", {
+            placeholders: { "@count": numberInQueue - 1 }
+          });
+
     return (
       <ReservationStatus
         // The decision regarding this is, that if the user is number 4
         // in the queue for a material, the "percent-wheel-thing" should be 1/4 full.
         percent={(1 / numberInQueue) * 100}
-        label=""
+        label={showStatusCircleIcon ? numberInLineLabel : ""}
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}
         empty={!showStatusCircleIcon}

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -176,6 +176,7 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
       percent={0}
       label=""
       empty
+      showArrow={showArrow}
       className={reservationStatusClassNameOverride}
     />
   );

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -104,19 +104,12 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
   }
 
   if (state === "reserved" && pickupBranch && numberInQueue && expiryDate) {
-    const numberInLineLabel =
-      numberInQueue === 1
-        ? t("reservationListFirstInQueueText")
-        : t("reservationListNumberInQueueText", {
-            placeholders: { "@count": numberInQueue - 1 }
-          });
-
     return (
       <ReservationStatus
         // The decision regarding this is, that if the user is number 4
         // in the queue for a material, the "percent-wheel-thing" should be 1/4 full.
         percent={(1 / numberInQueue) * 100}
-        label={numberInLineLabel}
+        label=""
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}
         empty={!showStatusCircleIcon}

--- a/src/apps/reservation-list/reservation-material/reservation-status.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-status.tsx
@@ -47,7 +47,7 @@ const ReservationStatus: FC<ReservationStatusProps> = ({
       <div>
         <div className="list-reservation__deadline">
           {info && <InfoLabel>{info}</InfoLabel>}
-          {typeof label === "string" && reservationInfo?.faust == null && (
+          {typeof label === "string" && (
             <p className="text-small-caption">{label}</p>
           )}
           {typeof label !== "string" &&

--- a/src/apps/reservation-list/reservation-material/reservation-status.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-status.tsx
@@ -47,7 +47,7 @@ const ReservationStatus: FC<ReservationStatusProps> = ({
       <div>
         <div className="list-reservation__deadline">
           {info && <InfoLabel>{info}</InfoLabel>}
-          {typeof label === "string" && (
+          {typeof label === "string" && reservationInfo?.faust == null && (
             <p className="text-small-caption">{label}</p>
           )}
           {typeof label !== "string" &&

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -45,7 +45,16 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
   const onMaterialChecked = (item: ListType) => {
     const selectedMaterialsCopy = [...selectedMaterials];
 
-    const indexOfItemToRemove = selectedMaterials.indexOf(item);
+    const indexOfItemToRemove = selectedMaterials.findIndex((obj) => {
+      if (item.faust !== null) {
+        return obj.faust === item.faust;
+      }
+      if (item.identifier !== undefined) {
+        return obj.identifier === item.identifier;
+      }
+      return -1;
+    });
+
     if (indexOfItemToRemove > -1) {
       selectedMaterialsCopy.splice(indexOfItemToRemove, 1);
     } else {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-374

#### Description

* Fixed double arrows by providing parameter for the "default case". 
* Changed `IndexOf()` to `findIndex()` for object array matching. `IndexOf()` compares objects based on their reference in memory, not their content. If you have a separate object with the same properties as an object in the array, `IndexOf()` won't find it because it checks for reference equality.
 
#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/f482f1c1-d6ee-491f-9803-3401246cf6ba

Updated screenshot with:
* Remove queue number label for physical materials
<img width="899" alt="Skærmbillede 2024-01-26 kl  10 56 10" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/9beefe3a-227f-4216-9d8c-86aed0c873b3">


#### Additional comments or questions

*