### PR TITLE
Fix/extend-reservations

### DIFF
--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -18,7 +18,6 @@ import DeleteReservationModal, {
   deleteReservationModalId
 } from "../../reservation-list/modal/delete-reservation/delete-reservation-modal";
 import Notifications from "./Notifications";
-import AcceptModal from "../../../components/accept-fees-modal/AcceptFeesModal";
 import useReservations from "../../../core/utils/useReservations";
 import useLoans from "../../../core/utils/useLoans";
 import { ReservationType } from "../../../core/utils/types/reservation-type";
@@ -57,7 +56,6 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       farFromOverdue: loansFarFromOverdue
     }
   } = useLoans();
-  const [accepted, setAccepted] = useState<boolean>(false);
   const [reservationsForDeleting, setReservationsForDeleting] = useState<
     ReservationType[]
   >([]);
@@ -65,7 +63,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
   const [modalHeader, setModalHeader] = useState("");
 
   const { open } = useModalButtonHandler();
-  const { acceptModal, dueDateModal, deleteReservations } = getModalIds();
+  const { dueDateModal, deleteReservations } = getModalIds();
   const [dueDate, setDueDate] = useState<string | null>(null);
   const [modalLoan, setModalLoan] = useState<LoanType | null>(null);
   const [reservationForModal, setReservationForModal] =
@@ -178,10 +176,6 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
     }
   ];
 
-  const openAcceptModal = useCallback(() => {
-    open(`${acceptModal}`);
-  }, [acceptModal, open]);
-
   const dashboardNotificationsReservations = [
     {
       listLength: reservationsReadyToLoan.length,
@@ -207,9 +201,6 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           : openModalHandler(reservationsQueueID as string)
     }
   ];
-  const resetAccepted = () => {
-    setAccepted(false);
-  };
 
   return (
     <>
@@ -254,9 +245,6 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       )}
       {dueDate && loans && loansToDisplay && (
         <LoansGroupModal
-          accepted={accepted}
-          resetAccepted={() => resetAccepted()}
-          openAcceptModal={openAcceptModal}
           pageSize={pageSize}
           openDetailsModal={openLoanDetailsModal}
           dueDate={dueDate}
@@ -296,7 +284,6 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           />
         </MaterialDetailsModal>
       )}
-      <AcceptModal accept={() => setAccepted(true)} />
     </>
   );
 };

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -37,7 +37,6 @@ import LoansGroupModal from "../../../components/GroupModal/LoansGroupModal";
 import SimpleModalHeader from "../../../components/GroupModal/SimpleModalHeader";
 import StatusCircleModalHeader from "../../../components/GroupModal/StatusCircleModalHeader";
 import StatusCircle from "../materials/utils/status-circle";
-import AcceptModal from "../../../components/accept-fees-modal/AcceptFeesModal";
 import { formatDate } from "../../../core/utils/helpers/date";
 import useLoans from "../../../core/utils/useLoans";
 
@@ -48,11 +47,10 @@ interface LoanListProps {
 const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const { modalIds } = useSelector((s: ModalIdsProps) => s.modal);
   const { open } = useModalButtonHandler();
-  const { loanDetails, allLoansId, dueDateModal, acceptModal } = getModalIds();
+  const { loanDetails, allLoansId, dueDateModal } = getModalIds();
   const t = useText();
   const [view, setView] = useState<ListView>("list");
   const [dueDate, setDueDate] = useState<string | null>(null);
-  const [accepted, setAccepted] = useState<boolean>(false);
   const [modalLoan, setModalLoan] = useState<LoanType | null>(null);
   const {
     fbs: {
@@ -61,11 +59,6 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
     },
     publizon: { loans: loansDigital }
   } = useLoans();
-
-  const openAcceptModal = useCallback(() => {
-    open(`${acceptModal}`);
-  }, [acceptModal, open]);
-
   const openLoanDetailsModal = useCallback(
     (loan: LoanType) => {
       setModalLoan(loan);
@@ -118,10 +111,6 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const listContainsLoans =
     (Array.isArray(loansPhysical) && loansPhysical.length > 0) ||
     (Array.isArray(loansDigital) && loansDigital.length > 0);
-
-  const resetAccepted = () => {
-    setAccepted(false);
-  };
 
   return (
     <>
@@ -199,12 +188,9 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
       )}
       {loansPhysical && (
         <LoansGroupModal
-          accepted={accepted}
-          resetAccepted={() => resetAccepted()}
           pageSize={pageSize}
           openDetailsModal={openLoanDetailsModal}
           dueDate={dueDate}
-          openAcceptModal={openAcceptModal}
           loansModal={
             dueDate
               ? removeLoansWithDuplicateDueDate(dueDate, loansPhysical)
@@ -231,7 +217,6 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
           {!dueDate && <SimpleModalHeader header={t("groupModalHeaderText")} />}
         </LoansGroupModal>
       )}
-      <AcceptModal accept={() => setAccepted(true)} />
     </>
   );
 };

--- a/src/components/GroupModal/LoansGroupModal.tsx
+++ b/src/components/GroupModal/LoansGroupModal.tsx
@@ -5,9 +5,7 @@ import { useText } from "../../core/utils/text";
 import GroupModalContent from "./GroupModalContent";
 import {
   getAmountOfRenewableLoans,
-  getRenewableMaterials,
-  loansOverdue,
-  sameLoanDate
+  getRenewableMaterials
 } from "../../core/utils/helpers/general";
 import { LoanType } from "../../core/utils/types/loan-type";
 import { useRenewLoansV2, getGetLoansV2QueryKey } from "../../core/fbs/fbs";
@@ -24,27 +22,19 @@ interface LoansGroupModalProps {
   dueDate?: string | null;
   loansModal: LoanType[];
   pageSize: number;
-  accepted: boolean;
   openDetailsModal: (loan: LoanType) => void;
-  openAcceptModal: () => void;
   children: ReactNode;
-  resetAccepted: () => void;
 }
 
 const LoansGroupModal: FC<LoansGroupModalProps> = ({
   dueDate,
   loansModal,
   openDetailsModal,
-  openAcceptModal,
   pageSize,
-  accepted,
-  resetAccepted,
   children
 }) => {
   const t = useText();
   const { mutate } = useRenewLoansV2();
-  const [acceptedButtonPressed, setAcceptedButtonPressed] =
-    useState<boolean>(accepted);
   const { dueDateModal, allLoansId } = getModalIds();
   const queryClient = useQueryClient();
   const modalIdUsed = dueDate ? `${dueDateModal}-${dueDate}` : allLoansId;
@@ -82,43 +72,16 @@ const LoansGroupModal: FC<LoansGroupModalProps> = ({
   });
 
   const renewSelected = useCallback(() => {
-    const selectedLoansLoanDate = loansModal
-      .filter((loan) => materialsToRenew.includes(loan))
-      .map(({ loanDate: localLoanDate }) => localLoanDate)
-      .filter((item) => item !== undefined && item !== null);
-    const acceptModal =
-      loansOverdue(loansModal) &&
-      sameLoanDate(selectedLoansLoanDate as string[]);
-
-    if (acceptModal) {
-      openAcceptModal();
-    } else if (!acceptModal) {
-      renew();
-    }
-  }, [loansModal, materialsToRenew, openAcceptModal, renew]);
+    renew();
+  }, [renew]);
 
   useEffect(() => {
     setMaterialsToRenew(getRenewableMaterials(loansModal));
   }, [loansModal]);
 
-  useEffect(() => {
-    if (accepted) {
-      setAcceptedButtonPressed(accepted);
-      resetAccepted();
-    }
-  }, [accepted, resetAccepted]);
-
   const selectMaterials = (materialIds: ListType[]) => {
     setMaterialsToRenew(materialIds);
   };
-
-  useEffect(() => {
-    if (acceptedButtonPressed) {
-      renew();
-      setAcceptedButtonPressed(false);
-    }
-  }, [acceptedButtonPressed, renew]);
-
   const showSuccessMessage = renewingStatus === "success";
   const countRenewed = succeededRenewalCount(renewingResponse);
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-407
https://reload.atlassian.net/browse/DDFLSBP-382

#### Description
We don't use the accept extra fees modal for renewing reservationsOn the dashboard + loan list anymore. The business logic is moving away from this functionality for now. It was also causing errors submitting the renewal request.
I kept the actual accept modal component as it is highly likely that this functionality will need to be implemented in the future.

#### Screenshot of the result
-
#### Additional comments or questions
-