### PR TITLE
Fix Group Modal for Reservations - part II [DDFLSBP-408]

### DIFF
--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -130,25 +130,6 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
                 isDigital={isDigital(displayedMaterial)}
               />
             )}
-            {openDetailsModal && (
-              <button
-                type="button"
-                // This is to handle focus when more items are loaded via pagination
-                // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus={disabled && focused}
-                className="list-reservation__note"
-                onClick={() => openDetailsModal(item)}
-                aria-label={
-                  title
-                    ? t("groupModalGoToMaterialAriaLabelText", {
-                        placeholders: { "@label": title }
-                      })
-                    : ""
-                }
-              >
-                {t("groupModalGoToMaterialText")}
-              </button>
-            )}
           </div>
         </div>
         {openDetailsModal && (

--- a/src/apps/reservation-list/list/reservation-list.dev.tsx
+++ b/src/apps/reservation-list/list/reservation-list.dev.tsx
@@ -153,6 +153,10 @@ export default {
       defaultValue: "Borrow before @date",
       control: { type: "text" }
     },
+    reservationQueueText: {
+      defaultValue: "You are in the reservation queue",
+      control: { type: "text" }
+    },
     reservationListAvailableInText: {
       defaultValue: "Available in @count days",
       control: { type: "text" }

--- a/src/apps/reservation-list/list/reservation-list.dev.tsx
+++ b/src/apps/reservation-list/list/reservation-list.dev.tsx
@@ -153,7 +153,7 @@ export default {
       defaultValue: "Borrow before @date",
       control: { type: "text" }
     },
-    reservationQueueText: {
+    reservationListYouAreInQueueText: {
       defaultValue: "You are in the reservation queue",
       control: { type: "text" }
     },

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -45,7 +45,7 @@ export interface ReservationListTextProps {
   reservationDetailsExpiresTitleText: string;
   reservationDetailsOthersInQueueText: string;
   reservationListAllEmptyText: string;
-  reservationQueueText: string;
+  reservationListYouAreInQueueText: string;
   reservationListAvailableInText: string;
   reservationListDaysText: string;
   reservationListDayText: string;

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -45,6 +45,7 @@ export interface ReservationListTextProps {
   reservationDetailsExpiresTitleText: string;
   reservationDetailsOthersInQueueText: string;
   reservationListAllEmptyText: string;
+  reservationQueueText: string;
   reservationListAvailableInText: string;
   reservationListDaysText: string;
   reservationListDayText: string;

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -139,12 +139,16 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
 
   if (state === "reserved" && !pickupBranch && pickupDeadline) {
     const daysBetweenTodayAndPickup = daysBetweenTodayAndDate(pickupDeadline);
+    const reservationAvailableLabel = showStatusCircleIcon
+      ? t("reservationListAvailableInText", {
+          placeholders: { "@count": daysBetweenTodayAndDate(pickupDeadline) }
+        })
+      : "";
+
     return (
       <ReservationStatus
         percent={daysBetweenTodayAndDate(pickupDeadline) / 100}
-        label={t("reservationListAvailableInText", {
-          placeholders: { "@count": daysBetweenTodayAndDate(pickupDeadline) }
-        })}
+        label={reservationAvailableLabel}
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}
         empty={!showStatusCircleIcon}

--- a/src/apps/reservation-list/reservation-material/reservation-status.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-status.tsx
@@ -35,6 +35,9 @@ const ReservationStatus: FC<ReservationStatusProps> = ({
     }
   };
 
+  const shouldRenderReservationDeadline =
+    info || (Array.isArray(label) ? label.length > 0 : !!label);
+
   return (
     <div className={className ?? "list-reservation__status"}>
       <div className="list-reservation__counter color-secondary-gray">
@@ -44,18 +47,22 @@ const ReservationStatus: FC<ReservationStatusProps> = ({
           </StatusCircleIcon>
         )}
       </div>
-      <div>
-        <div className="list-reservation__deadline">
-          {info && <InfoLabel>{info}</InfoLabel>}
-          {typeof label === "string" && (
-            <p className="text-small-caption">{label}</p>
-          )}
-          {typeof label !== "string" &&
-            label.map((localLabel) => {
-              return <p className="text-small-caption">{localLabel}</p>;
-            })}
+
+      {shouldRenderReservationDeadline && (
+        <div>
+          <div className="list-reservation__deadline">
+            {info && <InfoLabel>{info}</InfoLabel>}
+            {typeof label === "string" && (
+              <p className="text-small-caption">{label}</p>
+            )}
+            {Array.isArray(label) &&
+              label.map((localLabel) => (
+                <p className="text-small-caption">{localLabel}</p>
+              ))}
+          </div>
         </div>
-      </div>
+      )}
+
       {showArrow && (
         <ArrowButton
           arrowLabelledBy={`${

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -87,11 +87,15 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
           let statusText = "";
 
           if (identifier && state === "reserved") {
-            statusText = t("reservationListAvailableInText", {
-              placeholders: {
-                "@count": daysBetweenTodayAndDate(pickupDeadline ?? "")
-              }
-            });
+            if (pickupDeadline === null || pickupDeadline === "") {
+              statusText = t("reservationQueueText");
+            } else {
+              statusText = t("reservationListAvailableInText", {
+                placeholders: {
+                  "@count": daysBetweenTodayAndDate(pickupDeadline ?? "")
+                }
+              });
+            }
           } else if (faust && numberInQueue) {
             statusText = t("dashboardNumberInLineText", {
               count: numberInQueue,

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -88,7 +88,7 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
 
           if (identifier && state === "reserved") {
             if (pickupDeadline === null || pickupDeadline === "") {
-              statusText = t("reservationQueueText");
+              statusText = t("reservationListYouAreInQueueText");
             } else {
               statusText = t("reservationListAvailableInText", {
                 placeholders: {

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -77,7 +77,8 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
             identifier,
             numberInQueue,
             pickupDeadline,
-            reservationIds
+            reservationIds,
+            state
           } = material;
           const selected = selectedMaterials?.some((selectedMaterial) =>
             isEqual(selectedMaterial, material)
@@ -85,7 +86,7 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
 
           let statusText = "";
 
-          if (identifier) {
+          if (identifier && state === "reserved") {
             statusText = t("reservationListAvailableInText", {
               placeholders: {
                 "@count": daysBetweenTodayAndDate(pickupDeadline ?? "")

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../core/utils/types/reservation-type";
 import StatusBadge from "../../apps/loan-list/materials/utils/status-badge";
 import { ListType } from "../../core/utils/types/list-type";
+import { daysBetweenTodayAndDate } from "../../core/utils/helpers/general";
 
 export interface GroupModalReservationsListProps {
   materials: ReservationType[];
@@ -75,33 +76,43 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
             faust,
             identifier,
             numberInQueue,
+            pickupDeadline,
             reservationIds
           } = material;
           const selected = selectedMaterials?.some((selectedMaterial) =>
             isEqual(selectedMaterial, material)
           );
+
+          let statusText = "";
+
+          if (identifier) {
+            statusText = t("reservationListAvailableInText", {
+              placeholders: {
+                "@count": daysBetweenTodayAndDate(pickupDeadline ?? "")
+              }
+            });
+          } else if (faust && numberInQueue) {
+            statusText = t("dashboardNumberInLineText", {
+              count: numberInQueue,
+              placeholders: { "@count": numberInQueue }
+            });
+          }
+
+          const statusBadgeComponent = statusText ? (
+            <StatusBadge
+              badgeDate={expiryDate}
+              neutralText={statusText}
+              infoText=""
+            />
+          ) : null;
+
           return (
             (identifier || reservationIds || faust) && (
               <SelectableMaterial
                 item={material}
                 displayedMaterial={material}
                 focused={i === firstInNewPage}
-                statusBadgeComponent={
-                  faust && (
-                    <StatusBadge
-                      badgeDate={expiryDate}
-                      neutralText={
-                        numberInQueue
-                          ? t("dashboardNumberInLineText", {
-                              count: numberInQueue,
-                              placeholders: { "@count": numberInQueue }
-                            })
-                          : ""
-                      }
-                      infoText=""
-                    />
-                  )
-                }
+                statusBadgeComponent={statusBadgeComponent}
                 openDetailsModal={openDetailsModal}
                 key={reservationId(material)}
                 selected={selected}

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -81,39 +81,36 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
             isEqual(selectedMaterial, material)
           );
           return (
-            <>
-              {(identifier || reservationIds || faust) && (
-                <SelectableMaterial
-                  item={material}
-                  displayedMaterial={material}
-                  focused={i === firstInNewPage}
-                  statusBadgeComponent={
-                    faust && (
-                      <StatusBadge
-                        badgeDate={expiryDate}
-                        neutralText={
-                          numberInQueue
-                            ? t("dashboardNumberInLineText", {
-                                count: numberInQueue,
-                                placeholders: { "@count": numberInQueue }
-                              })
-                            : ""
-                        }
-                        infoText=""
-                      />
-                    )
-                  }
-                  openDetailsModal={openDetailsModal}
-                  key={reservationId(material)}
-                  selected={selected}
-                  onMaterialChecked={onMaterialChecked}
-                  disabled={false}
-                  statusMessageComponentMobile={null}
-                  statusMessageComponentDesktop={null}
-                />
-              )}
-              {!identifier && null}
-            </>
+            (identifier || reservationIds || faust) && (
+              <SelectableMaterial
+                item={material}
+                displayedMaterial={material}
+                focused={i === firstInNewPage}
+                statusBadgeComponent={
+                  faust && (
+                    <StatusBadge
+                      badgeDate={expiryDate}
+                      neutralText={
+                        numberInQueue
+                          ? t("dashboardNumberInLineText", {
+                              count: numberInQueue,
+                              placeholders: { "@count": numberInQueue }
+                            })
+                          : ""
+                      }
+                      infoText=""
+                    />
+                  )
+                }
+                openDetailsModal={openDetailsModal}
+                key={reservationId(material)}
+                selected={selected}
+                onMaterialChecked={onMaterialChecked}
+                disabled={false}
+                statusMessageComponentMobile={null}
+                statusMessageComponentDesktop={null}
+              />
+            )
           );
         })}
       </ul>

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -123,6 +123,10 @@ export default {
     defaultValue: "Borrow before @date",
     control: { type: "text" }
   },
+  reservationQueueText: {
+    defaultValue: "You are in the reservation queue",
+    control: { type: "text" }
+  },
   reservationListAvailableInText: {
     defaultValue: "Available in @count days",
     control: { type: "text" }

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -123,7 +123,7 @@ export default {
     defaultValue: "Borrow before @date",
     control: { type: "text" }
   },
-  reservationQueueText: {
+  reservationListYouAreInQueueText: {
     defaultValue: "You are in the reservation queue",
     control: { type: "text" }
   },


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-408

#### Description

- General cleanup of the group reservations modal.
- In cases where the expected redeem date is unknown, it will now display 'You are in the reservation queue.'
- The link 'See details for the material' has been removed.
- The design of the expected redeem date has been adjusted in accordance with Figma.
- Alignment has been verified.

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/cc0f9ab7-b279-4c29-bf08-c681a287c505)

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/4ef55819-a08d-4a28-ab64-0d795b54adfe)

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/ef325449-c36b-41c0-8eba-49561150e095)

#### Additional comments or questions

*