### PR TITLE
Refactor `getInstantLoanBranchHoldings`

### DIFF
--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -230,9 +230,10 @@ export const getInstantLoanBranchHoldings = (
         // if a material group description contains any of the instant loan strings
         // and is available, it is an instant loan.
         return (
-          instantLoanStrings.some((instantLoanString) => {
-            return materialGroup.description?.includes(instantLoanString);
-          }) && available
+          instantLoanStrings.some(
+            (instantLoanString) =>
+              instantLoanString === materialGroup.description
+          ) && available
         );
       });
 

--- a/src/tests/unit/__vitest_data__/instant-loan.ts
+++ b/src/tests/unit/__vitest_data__/instant-loan.ts
@@ -22,7 +22,7 @@ const branchHoldings: HoldingsV3[] = [
         periodical: undefined,
         materialGroup: {
           name: "standard",
-          description: "I am supposed to be matched, but I am not available"
+          description: "I NOT supposed to be matched"
         }
       },
       {
@@ -57,7 +57,7 @@ const branchHoldings: HoldingsV3[] = [
         periodical: undefined,
         materialGroup: {
           name: "standard",
-          description: "I am supposed to be matched, but I am not available"
+          description: "I am also supposed to be matched"
         }
       },
       {
@@ -83,7 +83,7 @@ const branchHoldings: HoldingsV3[] = [
         periodical: undefined,
         materialGroup: {
           name: "standard",
-          description: "I am supposed to be matched, seriously!"
+          description: "I am supposed to be matched"
         }
       },
       {

--- a/src/tests/unit/__vitest_data__/instant-loan.ts
+++ b/src/tests/unit/__vitest_data__/instant-loan.ts
@@ -22,7 +22,7 @@ const branchHoldings: HoldingsV3[] = [
         periodical: undefined,
         materialGroup: {
           name: "standard",
-          description: "I NOT supposed to be matched"
+          description: "I am supposed to be matched" // But am not available
         }
       },
       {

--- a/src/tests/unit/instant-loan.test.ts
+++ b/src/tests/unit/instant-loan.test.ts
@@ -43,16 +43,15 @@ test("getInstantLoanBranchHoldings should return materials grouped by branches f
     "I am supposed to be matched"
   );
 
-  // Hasle is matched with 2 materials out of 3.
+  // Hasle is matched with 2 materials out of 2.
   // The materials are matched because they both are available
-  // and contain the strings "I am supposed to be matched, seriously!"
-  // (which is a substring of "I am supposed to be matched")
+  // and contain the strings "I am supposed to be matched"
   // and "I am also supposed to be matched".
   expect(result[2].branch.title).toBe("Hasle");
   expect(result[2].materials).toHaveLength(2);
   expect(result[2].materials[0].available).toBe(true);
   expect(result[2].materials[0].materialGroup.description).toBe(
-    "I am supposed to be matched, seriously!"
+    "I am supposed to be matched"
   );
   expect(result[2].materials[1].available).toBe(true);
   expect(result[2].materials[1].materialGroup.description).toBe(


### PR DESCRIPTION
#### Description
This PR modified the `getInstantLoanBranchHoldings` to use precise matching with `===` instead of using the `includes` method for material group description.