### PR TITLE
Do not use prerelease in branch releases

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -82,7 +82,6 @@ jobs:
         id: create-release
         uses: softprops/action-gh-release@v1
         with:
-          prerelease: true
           target_commitish: ${{ env.RELEASE_SHA }}
           tag_name: ${{ env.TAG_NAME }}
           body: ${{ env.RELEASE_DESCRIPTION }}

--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -43,11 +43,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
-          registry-url: 'https://npm.pkg.github.com'
-          always-auth: true
-          scope: '@danskernesdigitalebibliotek'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create NPMRC
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "[@danskernesdigitalebibliotek]:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo 'registry "https://registry.yarnpkg.com"' >> ~/.yarnrc
 
       - uses: Wandalen/wretry.action@v1.3.0
         with:


### PR DESCRIPTION
We often end up having releases with "untagged" in the asset url wich srews up our build pipeline. This could be a fix.
