### PR TITLE
Remove status labels in the user menu [DDFLSBP-252]

### DIFF
--- a/src/apps/dashboard/dashboard-notification-list/NotificationColumn.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/NotificationColumn.tsx
@@ -35,7 +35,11 @@ const NotificationColumn: FC<NotificationColumnProps> = ({
       </div>
       {materialsCount === 0 && <EmptyList emptyListText={emptyListText} />}
       {materialsCount !== 0 && (
-        <Notifications showOnlyNotifications={false} materials={materials} />
+        <Notifications
+          showOnlyNotifications={false}
+          materials={materials}
+          showStatusLabel
+        />
       )}
     </div>
   );

--- a/src/apps/dashboard/dashboard-notification-list/NotificationColumn.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/NotificationColumn.tsx
@@ -35,11 +35,7 @@ const NotificationColumn: FC<NotificationColumnProps> = ({
       </div>
       {materialsCount === 0 && <EmptyList emptyListText={emptyListText} />}
       {materialsCount !== 0 && (
-        <Notifications
-          showOnlyNotifications={false}
-          materials={materials}
-          showStatusLabel
-        />
+        <Notifications materials={materials} showStatusLabel />
       )}
     </div>
   );

--- a/src/apps/dashboard/dashboard-notification-list/Notifications.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/Notifications.tsx
@@ -19,8 +19,8 @@ export interface NotificationsProps {
 
 const Notifications: FC<NotificationsProps> = ({
   materials,
-  showOnlyNotifications,
-  showStatusLabel
+  showOnlyNotifications = false,
+  showStatusLabel = false
 }) => {
   const displayedNotifications = showOnlyNotifications
     ? materials.filter(({ showNotificationDot }) => showNotificationDot)

--- a/src/apps/dashboard/dashboard-notification-list/Notifications.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/Notifications.tsx
@@ -14,11 +14,13 @@ export interface NotificationMaterialsList {
 export interface NotificationsProps {
   materials: NotificationMaterialsList[];
   showOnlyNotifications: boolean;
+  showStatusLabel: boolean;
 }
 
 const Notifications: FC<NotificationsProps> = ({
   materials,
-  showOnlyNotifications
+  showOnlyNotifications,
+  showStatusLabel
 }) => {
   const displayedNotifications = showOnlyNotifications
     ? materials.filter(({ showNotificationDot }) => showNotificationDot)
@@ -45,6 +47,7 @@ const Notifications: FC<NotificationsProps> = ({
             key={headerNotification}
             notificationColor={color}
             notificationClickEvent={notificationClickEvent}
+            showStatusLabel={showStatusLabel}
           />
         )
       )}

--- a/src/apps/dashboard/dashboard-notification-list/Notifications.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/Notifications.tsx
@@ -13,8 +13,8 @@ export interface NotificationMaterialsList {
 
 export interface NotificationsProps {
   materials: NotificationMaterialsList[];
-  showOnlyNotifications: boolean;
-  showStatusLabel: boolean;
+  showOnlyNotifications?: boolean;
+  showStatusLabel?: boolean;
 }
 
 const Notifications: FC<NotificationsProps> = ({

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -227,7 +227,6 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       {!columns && (
         <Notifications
           showOnlyNotifications
-          showStatusLabel={false}
           materials={[
             ...dashboardNotificationsLoan,
             ...dashboardNotificationsReservations

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -227,6 +227,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       {!columns && (
         <Notifications
           showOnlyNotifications
+          showStatusLabel={false}
           materials={[
             ...dashboardNotificationsLoan,
             ...dashboardNotificationsReservations

--- a/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
+++ b/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
@@ -5,7 +5,7 @@ import StatusBadge from "../../loan-list/materials/utils/status-badge";
 interface DashboardNotificationProps {
   notificationNumber: number;
   showNotificationDot: boolean;
-  showStatusLabel: boolean;
+  showStatusLabel?: boolean;
   notificationText: string;
   dataCy: string;
   notificationColor: string;

--- a/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
+++ b/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
@@ -53,7 +53,6 @@ const DashboardNotification: FC<DashboardNotificationProps> = ({
             {notificationColor === "info" && <StatusBadge infoText={badge} />}
           </>
         )}
-
         {showNotificationDot && <div className="list-dashboard__dot" />}
         <div className="list-dashboard__arrow">
           <Arrow />

--- a/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
+++ b/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
@@ -5,6 +5,7 @@ import StatusBadge from "../../loan-list/materials/utils/status-badge";
 interface DashboardNotificationProps {
   notificationNumber: number;
   showNotificationDot: boolean;
+  showStatusLabel: boolean;
   notificationText: string;
   dataCy: string;
   notificationColor: string;
@@ -20,6 +21,7 @@ const DashboardNotification: FC<DashboardNotificationProps> = ({
   notificationColor,
   notificationClickEvent,
   showNotificationDot,
+  showStatusLabel,
   badge
 }) => {
   if (notificationNumber === 0) return null;
@@ -40,9 +42,18 @@ const DashboardNotification: FC<DashboardNotificationProps> = ({
         <span className="list-dashboard__title text-header-h4 color-secondary-gray">
           {notificationText}
         </span>
-        {notificationColor === "danger" && <StatusBadge dangerText={badge} />}
-        {notificationColor === "warning" && <StatusBadge warningText={badge} />}
-        {notificationColor === "info" && <StatusBadge infoText={badge} />}
+        {showStatusLabel && (
+          <>
+            {notificationColor === "danger" && (
+              <StatusBadge dangerText={badge} />
+            )}
+            {notificationColor === "warning" && (
+              <StatusBadge warningText={badge} />
+            )}
+            {notificationColor === "info" && <StatusBadge infoText={badge} />}
+          </>
+        )}
+
         {showNotificationDot && <div className="list-dashboard__dot" />}
         <div className="list-dashboard__arrow">
           <Arrow />

--- a/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
+++ b/src/apps/dashboard/dashboard-notification/dashboard-notification.tsx
@@ -21,7 +21,7 @@ const DashboardNotification: FC<DashboardNotificationProps> = ({
   notificationColor,
   notificationClickEvent,
   showNotificationDot,
-  showStatusLabel,
+  showStatusLabel = false,
   badge
 }) => {
   if (notificationNumber === 0) return null;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-252

#### Description

This PR removes status labels in the user menu due to limited space.

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/9b3e43ed-02f1-47f4-b7a2-5019f9941d88)

#### Additional comments or questions

*
