### PR TITLE
Remove 'Others in queue' from a physical reservation view‚ [DDFLSBP-154]

### DIFF
--- a/src/apps/dashboard/dashboard.dev.tsx
+++ b/src/apps/dashboard/dashboard.dev.tsx
@@ -128,10 +128,6 @@ export default {
       },
       defaultValue: "Number @count in line"
     },
-    reservationDetailsOthersInQueueText: {
-      defaultValue: "Others are queueing for this material",
-      control: { type: "text" }
-    },
     loanListMaterialDaysText: {
       control: {
         type: "text"

--- a/src/apps/dashboard/dashboard.entry.tsx
+++ b/src/apps/dashboard/dashboard.entry.tsx
@@ -49,7 +49,6 @@ export interface DashBoardProps {
   publizonPodcastText: string;
   queuedReservationsText: string;
   readyForLoanText: string;
-  reservationDetailsOthersInQueueText: string;
   reservationsReadyText: string;
   reservationsText: string;
   resultPagerStatusText: string;

--- a/src/apps/menu/menu.dev.tsx
+++ b/src/apps/menu/menu.dev.tsx
@@ -110,10 +110,6 @@ export default {
       defaultValue: "Ready for pickup",
       control: { type: "text" }
     },
-    reservationDetailsOthersInQueueText: {
-      defaultValue: "Others are queueing for this material",
-      control: { type: "text" }
-    },
     loansSoonOverdueText: {
       defaultValue: "To be returned soon",
       control: { type: "text" }

--- a/src/apps/menu/menu.entry.tsx
+++ b/src/apps/menu/menu.entry.tsx
@@ -20,7 +20,6 @@ export interface MenuProps {
   menuNavigationDataConfig: string;
   menuNotificationLoansExpiredText: string;
   menuNotificationLoansExpiredUrl: string;
-  reservationDetailsOthersInQueueText: string;
   readyForLoanText: string;
   menuNotificationLoansExpiringSoonText: string;
   menuNotificationLoansExpiringSoonUrl: string;

--- a/src/apps/reservation-list/list/reservation-list.dev.tsx
+++ b/src/apps/reservation-list/list/reservation-list.dev.tsx
@@ -165,10 +165,6 @@ export default {
       defaultValue: "day",
       control: { type: "text" }
     },
-    reservationDetailsOthersInQueueText: {
-      defaultValue: "Others are queueing for this material",
-      control: { type: "text" }
-    },
     reservationDetailsExpiresTitleText: {
       defaultValue: "Pickup deadline",
       control: { type: "text" }

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -43,7 +43,6 @@ export interface ReservationListTextProps {
   publizonPodcastText: string;
   reservationDetailsExpiresText: string;
   reservationDetailsExpiresTitleText: string;
-  reservationDetailsOthersInQueueText: string;
   reservationListAllEmptyText: string;
   reservationListAvailableInText: string;
   reservationListDaysText: string;

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details-buttons.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details-buttons.tsx
@@ -6,7 +6,6 @@ import { MaterialProps } from "../../../loan-list/materials/utils/material-fetch
 
 export interface ReservationDetailsButtonProps {
   reservation: ReservationType;
-  numberInQueue?: number | null;
   classNames?: string;
   buttonClassNames?: string;
   openReservationDeleteModal: (deleteReservation: ReservationType) => void;
@@ -15,7 +14,6 @@ export interface ReservationDetailsButtonProps {
 const ReservationDetailsButton: FC<
   ReservationDetailsButtonProps & MaterialProps
 > = ({
-  numberInQueue,
   openReservationDeleteModal,
   classNames,
   buttonClassNames,
@@ -25,11 +23,6 @@ const ReservationDetailsButton: FC<
 
   return (
     <div className={`modal-details__buttons ${classNames}`}>
-      {numberInQueue && numberInQueue > 0 && (
-        <div className="my-8 mr-16 text-body-medium-regular">
-          {t("reservationDetailsOthersInQueueText")}
-        </div>
-      )}
       <Button
         label={t("reservationDetailsButtonRemoveText")}
         onClick={() => openReservationDeleteModal(reservation)}

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -434,13 +434,6 @@ describe("Reservation details modal", () => {
       .eq(0)
       .should("have.text", "Dummy bog");
 
-    // ID 13 2.b. Text: “Others in queue” if numberInQueue > 0
-    cy.get(".modal")
-      .find(".modal-details__buttons")
-      .eq(0)
-      .find(".text-body-medium-regular")
-      .should("have.text", "Others are queueing for this material");
-
     // ID 13 2.d. header "status"
     cy.getBySel("reservation-form-list-item")
       .eq(0)

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.tsx
@@ -39,7 +39,7 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
 
   const config = useConfig();
   const [externalUrl, setExternalUrl] = useState<URL | null>(null);
-  const { state, identifier, numberInQueue } = reservation;
+  const { state, identifier } = reservation;
   const { authors, pid, year, title, description, materialType } =
     material || {};
   const { allowRemoveReadyReservations } = config<{
@@ -100,7 +100,6 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
                 classNames="modal-details__buttons--hide-on-mobile"
                 openReservationDeleteModal={openReservationDeleteModal}
                 reservation={reservation}
-                numberInQueue={numberInQueue}
               />
             )}
           {isDigitalReservation(reservation) && isLoadingComplexSearch && (
@@ -132,7 +131,6 @@ const ReservationDetails: FC<ReservationDetailsProps & MaterialProps> = ({
               <ReservationDetailsButton
                 buttonClassNames="modal-details__buttons__full-width"
                 openReservationDeleteModal={openReservationDeleteModal}
-                numberInQueue={numberInQueue}
                 reservation={reservation}
               />
             )}

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -135,10 +135,6 @@ export default {
     defaultValue: "day",
     control: { type: "text" }
   },
-  reservationDetailsOthersInQueueText: {
-    defaultValue: "Others are queueing for this material",
-    control: { type: "text" }
-  },
   reservationDetailsExpiresTitleText: {
     defaultValue: "Pickup deadline",
     control: { type: "text" }


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-154

#### Description

* Removes display of 'Others in queue' from the details of a physical reservation.

#### Screenshot of the result

<img width="729" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/622ff73a-cd6a-48d5-887e-9e3897bac4d3">

#### Additional comments or questions

*
