### PR TITLE
Changes the status badge text if the material is digital [DDFLSBP-337]

### DIFF
--- a/src/components/GroupModal/GroupModalLoansList.tsx
+++ b/src/components/GroupModal/GroupModalLoansList.tsx
@@ -7,6 +7,7 @@ import StatusMessage from "../../apps/loan-list/materials/selectable-material/St
 import StatusBadge from "../../apps/loan-list/materials/utils/status-badge";
 import { formatDate } from "../../core/utils/helpers/date";
 import { ListType } from "../../core/utils/types/list-type";
+import { isDigital } from "../../apps/loan-list/utils/helpers";
 
 export interface GroupModalLoansListProps {
   materials: LoanType[];
@@ -56,10 +57,18 @@ const GroupModalLoansList: FC<GroupModalLoansListProps> = ({
               <StatusBadge
                 badgeDate={loanType.dueDate}
                 neutralText={
+                  // Set the value of 'neutralText' based on the material type and due date
                   loanType.dueDate
-                    ? t("groupModalDueDateMaterialText", {
-                        placeholders: { "@date": formatDate(loanType.dueDate) }
-                      })
+                    ? t(
+                        isDigital(loanType)
+                          ? "groupModalDueDateDigitalMaterialText"
+                          : "groupModalDueDateMaterialText",
+                        {
+                          placeholders: {
+                            "@date": formatDate(loanType.dueDate)
+                          }
+                        }
+                      )
                     : ""
                 }
               />

--- a/src/core/storybook/groupModalArgs.ts
+++ b/src/core/storybook/groupModalArgs.ts
@@ -11,6 +11,12 @@ export default {
     },
     defaultValue: "To be returned @date"
   },
+  groupModalDueDateDigitalMaterialText: {
+    control: {
+      type: "text"
+    },
+    defaultValue: "Expires @date"
+  },
   groupModalGoToMaterialText: {
     defaultValue: "Go to material details",
     control: { type: "text" }
@@ -61,6 +67,7 @@ export interface GroupModalProps {
   groupModalDueDateLinkToPageWithFeesText: string;
   showMoreText: string;
   groupModalDueDateMaterialText: string;
+  groupModalDueDateDigitalMaterialText: string;
   groupModalGoToMaterialText: string;
   groupModalDueDateHeaderText: string;
   groupModalReturnLibraryText: string;


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-337

#### Description

* Changes the status badge text from "To be returned" to "Expires" in the Group modal if the material is digital.
* `dpl-cms` PR: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/728

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/92b9e43b-8db0-49a6-a130-0653a2494245)

#### Additional comments or questions

*
