### PR TITLE
DDFLSBP-217 - Added blockedModal to dashboard

### DIFF
--- a/src/apps/dashboard/dashboard.entry.tsx
+++ b/src/apps/dashboard/dashboard.entry.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from "react";
+import withIsPatronBlockedHoc from "../../core/utils/withIsPatronBlockedHoc";
 import { withConfig } from "../../core/utils/config";
 import { pageSizeGlobal } from "../../core/utils/helpers/general";
 import { withText } from "../../core/utils/text";
 import { withUrls } from "../../core/utils/url";
 import DashBoard from "./dashboard";
+import { BlockedPatronEntryTextProps } from "../../core/storybook/blockedArgs";
 import { GroupModalProps } from "../../core/storybook/groupModalArgs";
 import { GroupModalLoansProps } from "../../core/storybook/loanGroupModalArgs";
 import { ReservationMaterialDetailsProps } from "../../core/storybook/reservationMaterialDetailsArgs";
@@ -60,6 +62,7 @@ export interface DashBoardProps {
 
 const DashboardEntry: FC<
   DashBoardProps &
+    BlockedPatronEntryTextProps &
     GroupModalProps &
     GroupModalLoansProps &
     DeleteReservationModalArgs &
@@ -80,4 +83,6 @@ const DashboardEntry: FC<
   return <DashBoard pageSize={pageSize} />;
 };
 
-export default withConfig(withUrls(withText(DashboardEntry)));
+export default withConfig(
+  withUrls(withText(withIsPatronBlockedHoc(DashboardEntry)))
+);


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-217

#### Description

This PR adds the blockedModal on dashboard for blocked patrons, just as it is shown on other pages.

The blockedModal is not centered, but this is a general thing and is corrected in another PR. 

#### Screenshot of the result

![Screenshot 2024-02-07 at 20 57 13](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/6142323/edbd5341-53be-473a-8aa6-679bc242a695)

