### PR TITLE
Distinguish singular/plural on delete reservation

### DIFF
--- a/src/apps/dashboard/dashboard.test.tsx
+++ b/src/apps/dashboard/dashboard.test.tsx
@@ -1445,10 +1445,14 @@ describe("Dashboard", () => {
   };
 
   const validateReservationsRemovalButtonWithCount = (items: number) => {
+    const deleteButtonText =
+      items > 1
+        ? `Remove reservations (${items})`
+        : `Remove reservation (${items})`;
     cy.getBySel("remove-reservations-button")
       .first()
       .should("not.be.disabled")
-      .and("have.text", `Remove reservations (${items})`)
+      .and("have.text", deleteButtonText)
       .click();
 
     const buttonText = items > 1 ? "Cancel reservations" : "Cancel reservation";

--- a/src/apps/dashboard/modal/ReservationsGroupModal.tsx
+++ b/src/apps/dashboard/modal/ReservationsGroupModal.tsx
@@ -87,6 +87,7 @@ const ReservationGroupModal: FC<ReservationGroupModalProps> = ({
             buttonComponent={
               <Button
                 label={t("removeAllReservationsText", {
+                  count: materialsToDelete.length,
                   placeholders: {
                     "@amount": materialsToDelete.length
                   }

--- a/src/apps/reservation-list/modal/delete-reservation/delete-reservation-modal.tsx
+++ b/src/apps/reservation-list/modal/delete-reservation/delete-reservation-modal.tsx
@@ -125,7 +125,9 @@ const DeleteReservationModal: FC<DeleteReservationModalProps> = ({
       )}
       {requestStatus === "success" && (
         <ModalMessage
-          title={t("deleteReservationModalSuccessTitleText")}
+          title={t("deleteReservationModalSuccessTitleText", {
+            count: deletedReservations ?? 1
+          })}
           subTitle={t("deleteReservationModalSuccessStatusText", {
             count: deletedReservations ?? 0
           })}

--- a/src/apps/reservation-list/modal/delete-reservation/delete-reservation.test.ts
+++ b/src/apps/reservation-list/modal/delete-reservation/delete-reservation.test.ts
@@ -228,7 +228,7 @@ describe("Delete reservation modal", () => {
     // ID 18 4 system closes modal
     cy.get(".modal.modal-cta")
       .getBySel("message-title")
-      .should("have.text", "Reservations deleted");
+      .should("have.text", "Reservation deleted");
 
     // Close confirmation modal.
     cy.get(".modal.modal-cta")

--- a/src/core/storybook/reservationGroupModalArgs.ts
+++ b/src/core/storybook/reservationGroupModalArgs.ts
@@ -16,7 +16,8 @@ export default {
     control: { type: "text" }
   },
   removeAllReservationsText: {
-    defaultValue: "Remove reservations (@amount)",
+    defaultValue:
+      '{"type":"plural","text":["Remove reservation (@amount)","Remove reservations (@amount)"]}',
     control: { type: "text" }
   },
   pickUpLatestText: {

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -230,7 +230,8 @@ export default {
   },
   deleteReservationModalSuccessTitleText: {
     name: "Delete reservation modal success title text",
-    defaultValue: "Reservations deleted",
+    defaultValue:
+      '{"type":"plural","text":["Reservation deleted","Reservations deleted"]}',
     control: { type: "text" }
   },
   deleteReservationModalSuccessStatusText: {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-172

#### Description
In this PR we adjust two text string definitions for when the user is deleting their queued reservations from the dashboard. There was no distinction between singular and plural form depending on how many reservations were deleted before, which is now fixed. 

#### Screenshot of the result
-

#### Additional comments or questions
[Sibling PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/767)
