### PR TITLE
Don't show material type badge on reservation page if no data is present

### DIFF
--- a/src/apps/loan-list/materials/stackable-material/material-info.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-info.tsx
@@ -50,11 +50,13 @@ const MaterialInfo: FC<MaterialInfoProps> = ({
         />
       </div>
       <div className="list-reservation__information">
-        <div>
-          <div className="status-label status-label--outline">
-            {materialType}
+        {materialType && (
+          <div>
+            <div className="status-label status-label--outline">
+              {materialType}
+            </div>
           </div>
-        </div>
+        )}
         <div className="list-reservation__about">
           <button
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-234

#### Description
We no longer show material type on reservation page if no data is present.

#### Screenshot of the result
-

#### Additional comments or questions
-