### PR TITLE
Don't show "Select all" in group renew loan modal if none are selectable

### DIFF
--- a/src/components/GroupModal/GroupModalContent.tsx
+++ b/src/components/GroupModal/GroupModalContent.tsx
@@ -40,7 +40,7 @@ const GroupModalContent: FC<GroupModalContentProps> = ({
   };
 
   const checkBoxComponent =
-    selectMaterials !== undefined ? (
+    selectMaterials !== undefined && amountOfSelectableMaterials > 0 ? (
       <CheckBox
         selected={
           amountOfSelectableMaterials !== 0 &&


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-347

#### Description
Don't show "Select all" in group renew loan modal if none are selectable

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/2c2f974f-df1f-4507-ac0b-5a955ac75201)

#### Additional comments or questions
-
