### PR TITLE
Move global text argument reservationListDigitalPickupText into global

### DIFF
--- a/src/apps/reservation-list/list/reservation-list.dev.tsx
+++ b/src/apps/reservation-list/list/reservation-list.dev.tsx
@@ -121,10 +121,6 @@ export default {
       defaultValue: "You are at the front of the queue",
       control: { type: "text" }
     },
-    reservationListDigitalPickupText: {
-      defaultValue: "Online access",
-      control: { type: "text" }
-    },
     reservationListInQueueText: {
       defaultValue: "queued",
       control: { type: "text" }

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -48,7 +48,6 @@ export interface ReservationListTextProps {
   reservationListAvailableInText: string;
   reservationListDaysText: string;
   reservationListDayText: string;
-  reservationListDigitalPickupText: string;
   reservationListDigitalReservationsEmptyText: string;
   reservationListDigitalReservationsHeaderText: string;
   reservationListFirstInQueueText: string;

--- a/src/core/storybook/globalTextArgs.ts
+++ b/src/core/storybook/globalTextArgs.ts
@@ -192,6 +192,10 @@ export default {
   reservationListReadyText: {
     defaultValue: "Ready",
     control: { type: "text" }
+  },
+  reservationListDigitalPickupText: {
+    defaultValue: "Online access",
+    control: { type: "text" }
   }
 };
 
@@ -236,4 +240,5 @@ export interface GlobalEntryTextProps {
   acceptModalAcceptButtonText: string;
   reservationPickUpLatestText: string;
   reservationListReadyText: string;
+  reservationListDigitalPickupText: string;
 }


### PR DESCRIPTION
#### Link to issue
-

#### Description
While testing for [this task](https://reload.atlassian.net/browse/DDFLSBP-170) I have discovered that the dashboard app is failing and ´reservationListDigitalPickupText´ needs to be in global text args definition.

#### Screenshot of the result
-

#### Additional comments or questions
-
