### PR TITLE
Fix/reservation and loan skeletons

### DIFF
--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -110,14 +110,19 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
     }
   }, [loansPhysical, loansDigital, loanDetails, openDueDateModal]);
 
+  const shouldShowSkeletons =
+    isLoadingFbs &&
+    isLoadingPublizon &&
+    loansPhysical.length === 0 &&
+    loansDigital.length === 0;
+
   return (
     <>
       <div className={`loan-list-page ${getScrollClass(modalIds)}`}>
         <h1 className="text-header-h1 my-32">{t("loanListTitleText")}</h1>
-        {isLoadingFbs && isLoadingPublizon && <LoanListSkeleton />}
+        {shouldShowSkeletons && <LoanListSkeleton />}
 
-        {!isLoadingFbs &&
-          !isLoadingPublizon &&
+        {!shouldShowSkeletons &&
           (!loansAreEmpty(loansPhysical) || !loansAreEmpty(loansDigital)) && (
             <>
               {loansPhysical && (

--- a/src/apps/reservation-list/list/reservation-list.tsx
+++ b/src/apps/reservation-list/list/reservation-list.tsx
@@ -114,7 +114,9 @@ const ReservationList: FC<ReservationListProps> = ({ pageSize }) => {
 
         {userData?.patron && <ReservationPauseToggler user={userData.patron} />}
 
-        {isLoading && <ReservationListSkeleton />}
+        {isLoading && allReservations.length === 0 && (
+          <ReservationListSkeleton />
+        )}
 
         {allListsEmpty && <EmptyReservations />}
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-456

#### Description
The skeleton screens were behaving a bit strangely where they would still show even when we already had some items to show on the reservation list. And on the loan list they would flicker between skeletons and loaded items with a noticable empty page screen. This PR fixes both issues.

#### Screenshot of the result
-

#### Additional comments or questions
-
