### PR TITLE
DDFFORM 313

### DIFF
--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { useState } from "react";
+import { WorkId } from "../../core/utils/types/ids";
+import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
+import { useText } from "../../core/utils/text";
+import {
+  MaterialGridValidIncrements,
+  ValidSelectedIncrements,
+  calculateAmountToDisplay
+} from "./materiel-grid-util";
+
+export type MaterialGridProps = {
+  materialIDs: WorkId[];
+  title: string;
+  selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
+};
+const MaterialGrid: React.FC<MaterialGridProps> = ({
+  materialIDs,
+  title,
+  selectedAmountOfMaterialsForDisplay
+}) => {
+  const t = useText();
+
+  const initialMaximumDisplay = MaterialGridValidIncrements[0];
+  const maximumCalculatedDisplay = calculateAmountToDisplay(
+    materialIDs.length,
+    selectedAmountOfMaterialsForDisplay
+  );
+  const moreMaterialsThanInitialMaximum =
+    maximumCalculatedDisplay > initialMaximumDisplay;
+
+  const [
+    currentAmountOfDisplayedMaterials,
+    setCurrentMaterialsDisplayedMaterials
+  ] = useState(initialMaximumDisplay);
+
+  const [showAllMaterials, setShowAllMaterials] = useState(false);
+
+  function handleShowAllMaterials() {
+    setCurrentMaterialsDisplayedMaterials(maximumCalculatedDisplay);
+    setShowAllMaterials(!showAllMaterials);
+  }
+
+  return (
+    <div className="material-grid">
+      <h2 className="material-grid__title">{title}</h2>
+      {materialIDs?.length && (
+        <ul className="material-grid__items">
+          {materialIDs
+            .slice(0, currentAmountOfDisplayedMaterials)
+            .map((materialID) => (
+              <li key={materialID}>
+                <RecommendedMaterial wid={materialID} />
+              </li>
+            ))}
+        </ul>
+      )}
+
+      {moreMaterialsThanInitialMaximum && !showAllMaterials && (
+        <button
+          className="material-grid__show-more btn-primary btn-outline btn-medium"
+          data-show-more
+          aria-expanded={showAllMaterials ? "true" : "false"}
+          type="button"
+          onClick={() => handleShowAllMaterials()}
+        >
+          {t("buttonText")}
+        </button>
+      )}
+    </div>
+  );
+};
+export default MaterialGrid;

--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -50,7 +50,7 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
             .slice(0, currentAmountOfDisplayedMaterials)
             .map((materialID) => (
               <li key={materialID}>
-                <RecommendedMaterial wid={materialID} />
+                <RecommendedMaterial wid={materialID} partOfGrid />
               </li>
             ))}
         </ul>

--- a/src/apps/material-grid/MaterialGridSkeleton.tsx
+++ b/src/apps/material-grid/MaterialGridSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import RecommendedMaterialSkeleton from "../recommended-material/RecommendedMaterialSkeleton";
+
+const MaterialGridAutomaticSkeleton: React.FC = () => {
+  return (
+    <div className="material-grid">
+      <div className="material-grid__title ssc-line" />
+      <div className="material-grid__items">
+        {[...Array(4)].map(() => (
+          <div className="material-grid__item">
+            <RecommendedMaterialSkeleton />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MaterialGridAutomaticSkeleton;

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.dev.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.dev.tsx
@@ -1,0 +1,80 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import globalTextArgs, {
+  GlobalEntryTextProps
+} from "../../../core/storybook/globalTextArgs";
+import serviceUrlArgs from "../../../core/storybook/serviceUrlArgs";
+
+import MaterialGridAutomatic, {
+  MaterialGridAutomaticEntryProps
+} from "./MaterialGridAutomatic.entry";
+
+export default {
+  title: "Apps / Material Grid Automatic",
+  component: MaterialGridAutomatic,
+  argTypes: {
+    title: {
+      name: "Title",
+      defaultValue: "Recommended materials",
+      control: { type: "text" }
+    },
+    cql: {
+      name: "CQL Search String",
+      defaultValue: "'heste' OR 'PIPPI'",
+      control: { type: "text" },
+      description:
+        "CQL search string to use for the material grid, search for a result and copy the CQL string from an advanced search"
+    },
+    selectedAmountOfMaterialsForDisplay: {
+      name: "Amount of materials to show",
+      defaultValue: 12,
+      control: {
+        type: "select",
+        options: [4, 8, 12, 16, 20, 24, 28, 32]
+      }
+    },
+    buttonText: {
+      name: "Button text",
+      defaultValue: "Show all",
+      control: { type: "text" }
+    },
+    materialUrl: {
+      name: "Path to the material page",
+      defaultValue: "/work/:workid",
+      control: { type: "text" }
+    },
+    etAlText: {
+      name: "Et al. Text",
+      defaultValue: "et al.",
+      control: { type: "text" }
+    },
+    ...globalTextArgs,
+    ...serviceUrlArgs,
+    blacklistedPickupBranchesConfig: {
+      name: "Blacklisted Pickup branches",
+      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      control: { type: "text" }
+    },
+    blacklistedAvailabilityBranchesConfig: {
+      name: "Blacklisted Availability branches",
+      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      control: { type: "text" }
+    },
+    blacklistedSearchBranchesConfig: {
+      name: "Blacklisted branches",
+      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      control: { type: "text" }
+    },
+    branchesConfig: {
+      name: "Branches",
+      defaultValue:
+        '[\n   {\n      "branchId":"DK-775120",\n      "title":"Højbjerg"\n   },\n   {\n      "branchId":"DK-775122",\n      "title":"Beder-Malling"\n   },\n   {\n      "branchId":"DK-775144",\n      "title":"Gellerup"\n   },\n   {\n      "branchId":"DK-775167",\n      "title":"Lystrup"\n   },\n   {\n      "branchId":"DK-775146",\n      "title":"Harlev"\n   },\n   {\n      "branchId":"DK-775168",\n      "title":"Skødstrup"\n   },\n   {\n      "branchId":"FBS-751010",\n      "title":"Arresten"\n   },\n   {\n      "branchId":"DK-775147",\n      "title":"Hasle"\n   },\n   {\n      "branchId":"FBS-751032",\n      "title":"Må ikke benyttes"\n   },\n   {\n      "branchId":"FBS-751031",\n      "title":"Fjernlager 1"\n   },\n   {\n      "branchId":"DK-775126",\n      "title":"Solbjerg"\n   },\n   {\n      "branchId":"FBS-751030",\n      "title":"ITK"\n   },\n   {\n      "branchId":"DK-775149",\n      "title":"Sabro"\n   },\n   {\n      "branchId":"DK-775127",\n      "title":"Tranbjerg"\n   },\n   {\n      "branchId":"DK-775160",\n      "title":"Risskov"\n   },\n   {\n      "branchId":"DK-775162",\n      "title":"Hjortshøj"\n   },\n   {\n      "branchId":"DK-775140",\n      "title":"Åby"\n   },\n   {\n      "branchId":"FBS-751009",\n      "title":"Fjernlager 2"\n   },\n   {\n      "branchId":"FBS-751029",\n      "title":"Stadsarkivet"\n   },\n   {\n      "branchId":"FBS-751027",\n      "title":"Intern"\n   },\n   {\n      "branchId":"FBS-751026",\n      "title":"Fælles undervejs"\n   },\n   {\n      "branchId":"FBS-751025",\n      "title":"Fællessekretariatet"\n   },\n   {\n      "branchId":"DK-775133",\n      "title":"Bavnehøj"\n   },\n   {\n      "branchId":"FBS-751024",\n      "title":"Fjernlånte materialer"\n   },\n   {\n      "branchId":"DK-775100",\n      "title":"Hovedbiblioteket"\n   },\n   {\n      "branchId":"DK-775170",\n      "title":"Trige"\n   },\n   {\n      "branchId":"DK-775150",\n      "title":"Tilst"\n   },\n   {\n      "branchId":"DK-775130",\n      "title":"Viby"\n   },\n   {\n      "branchId":"DK-775164",\n      "title":"Egå"\n   }\n]',
+      control: { type: "text" }
+    }
+  }
+} as ComponentMeta<typeof MaterialGridAutomatic>;
+
+export const App: ComponentStory<typeof MaterialGridAutomatic> = (
+  args: MaterialGridAutomaticEntryProps & GlobalEntryTextProps
+) => <MaterialGridAutomatic {...args} />;

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.entry.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.entry.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import GuardedApp from "../../../components/guarded-app";
+import { GlobalEntryTextProps } from "../../../core/storybook/globalTextArgs";
+import { withConfig } from "../../../core/utils/config";
+import { withText } from "../../../core/utils/text";
+import { withUrls } from "../../../core/utils/url";
+import MaterialGridAutomatic from "./MaterialGridAutomatic";
+import { ValidSelectedIncrements } from "../materiel-grid-util";
+
+interface MaterialGridAutomaticEntryConfigProps {
+  blacklistedAvailabilityBranchesConfig: string;
+  blacklistedPickupBranchesConfig?: string;
+  blacklistedSearchBranchesConfig?: string;
+  branchesConfig: string;
+}
+
+export interface MaterialGridAutomaticEntryProps
+  extends GlobalEntryTextProps,
+    MaterialGridAutomaticEntryConfigProps {
+  cql: string;
+  title: string;
+  selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
+  buttonText: string;
+}
+
+const MaterialGridAutomaticEntry: React.FC<MaterialGridAutomaticEntryProps> = ({
+  cql,
+  title,
+  selectedAmountOfMaterialsForDisplay,
+  buttonText
+}) => {
+  return (
+    <GuardedApp app="material-grid-automatic">
+      <MaterialGridAutomatic
+        cql={cql}
+        title={title}
+        selectedAmountOfMaterialsForDisplay={
+          selectedAmountOfMaterialsForDisplay
+        }
+        buttonText={buttonText}
+      />
+    </GuardedApp>
+  );
+};
+
+export default withConfig(withUrls(withText(MaterialGridAutomaticEntry)));

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.mount.ts
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.mount.ts
@@ -1,0 +1,7 @@
+import addMount from "../../../core/addMount";
+import MaterialGridAutomaticEntry from "./MaterialGridAutomatic.entry";
+
+addMount({
+  appName: "material-grid-automatic",
+  app: MaterialGridAutomaticEntry
+});

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { useComplexSearchWithPaginationQuery } from "../../../core/dbc-gateway/generated/graphql";
+import useGetCleanBranches from "../../../core/utils/branches";
+import { Work } from "../../../core/utils/types/entities";
+import MaterialGrid from "../MaterialGrid";
+import MaterialGridAutomaticSkeleton from "../MaterialGridSkeleton";
+import { ValidSelectedIncrements } from "../materiel-grid-util";
+
+export type MaterialGridAutomaticProps = {
+  cql: string;
+  title: string;
+  selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
+  buttonText: string;
+};
+
+const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
+  cql,
+  title,
+  selectedAmountOfMaterialsForDisplay
+}) => {
+  const cleanBranches = useGetCleanBranches();
+  const { data, isLoading } = useComplexSearchWithPaginationQuery({
+    cql,
+    offset: 0,
+    limit: selectedAmountOfMaterialsForDisplay,
+    filters: {
+      branchId: cleanBranches
+    }
+  });
+
+  if (isLoading || !data) {
+    return <MaterialGridAutomaticSkeleton />;
+  }
+
+  const resultWorks: Work[] = data.complexSearch.works as Work[];
+  const materialIDs = resultWorks.map((work) => work.workId);
+
+  return (
+    <MaterialGrid
+      title={title}
+      materialIDs={materialIDs}
+      selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
+    />
+  );
+};
+export default MaterialGridAutomatic;

--- a/src/apps/material-grid/materiel-grid-util.ts
+++ b/src/apps/material-grid/materiel-grid-util.ts
@@ -1,0 +1,20 @@
+export type ValidSelectedIncrements = 4 | 8 | 12 | 16 | 20 | 24 | 28 | 32;
+
+export const MaterialGridValidIncrements: ValidSelectedIncrements[] = [
+  4, 8, 12, 16, 20, 24, 28, 32
+];
+
+export function calculateAmountToDisplay(
+  fetchedCount: number,
+  selectedAmount: ValidSelectedIncrements
+): ValidSelectedIncrements {
+  if (fetchedCount >= selectedAmount) {
+    return selectedAmount;
+  }
+
+  const suitableIncrement = MaterialGridValidIncrements.reverse().find(
+    (increment) => increment <= fetchedCount
+  );
+
+  return suitableIncrement || MaterialGridValidIncrements[0];
+}

--- a/src/apps/recommended-material/RecommendedMaterial.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.tsx
@@ -19,9 +19,13 @@ import RecommendedMaterialSkeleton from "./RecommendedMaterialSkeleton";
 
 export type RecommendedMaterialProps = {
   wid: WorkId;
+  partOfGrid?: boolean;
 };
 
-const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({ wid }) => {
+const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({
+  wid,
+  partOfGrid = false
+}) => {
   const t = useText();
   const u = useUrls();
   const materialUrl = u("materialUrl");
@@ -57,7 +61,11 @@ const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({ wid }) => {
   };
 
   return (
-    <div className="recommended-material">
+    <div
+      className={`recommended-material ${
+        partOfGrid && "recommended-material--in-grid "
+      }`}
+    >
       <div className="recommended-material__icon">
         <ButtonFavourite
           title={String(fullTitle)}

--- a/src/core/utils/types/ids.ts
+++ b/src/core/utils/types/ids.ts
@@ -12,6 +12,8 @@ export type GuardedAppId =
   | "favorites-list-mc"
   | "inspiration-recommender"
   | "recommended-material"
-  | "recommendation";
+  | "recommendation"
+  | "material-grid-automatic";
+
 export type IssnId = DigitalArticleService["issn"];
 export type LoanId = number;


### PR DESCRIPTION
- Use release 2024.9.0 branch of design system
- Add component & Story MaterialGridAutomatic
- Add Entry, mount  for MaterialGridAutomatic
- Add skeleton component for MaterialGridAutomatic

#### Link to issue

[DDFFORM-313](https://reload.atlassian.net/browse/DDFFORM-313)

Other relevant PRS: 

- CMS PR: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/796
- Design system PR: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/517 

#### Description

This PR adds a react app <MaterialGridAutomatic/> which displays a list of up to 32 materials based on a search string. 

At the time of this PR, a search string is generated manually by copying the 'CQL Search String' from an advanced search. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/13272656/ea81fea0-6b14-4cf6-8625-1312b6f03fb8)


#### Comments or questions

Be thorough when looking through the configurations regarding config-branches or the use of the hook for querying the materials. 
