### PR TITLE
DDFFORM 314

### DIFF
--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -44,18 +44,15 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
   return (
     <div className="material-grid">
       <h2 className="material-grid__title">{title}</h2>
-      {materialIDs?.length && (
-        <ul className="material-grid__items">
-          {materialIDs
-            .slice(0, currentAmountOfDisplayedMaterials)
-            .map((materialID) => (
-              <li key={materialID}>
-                <RecommendedMaterial wid={materialID} partOfGrid />
-              </li>
-            ))}
-        </ul>
-      )}
-
+      <ul className="material-grid__items">
+        {materialIDs
+          .slice(0, currentAmountOfDisplayedMaterials)
+          .map((materialId) => (
+            <li key={materialId}>
+              <RecommendedMaterial wid={materialId} partOfGrid />
+            </li>
+          ))}
+      </ul>
       {moreMaterialsThanInitialMaximum && !showAllMaterials && (
         <button
           className="material-grid__show-more btn-primary btn-outline btn-medium"

--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -10,12 +10,12 @@ import {
 } from "./materiel-grid-util";
 
 export type MaterialGridProps = {
-  materialIDs: WorkId[];
+  materialIds: WorkId[];
   title: string;
   selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
 };
 const MaterialGrid: React.FC<MaterialGridProps> = ({
-  materialIDs,
+  materialIds,
   title,
   selectedAmountOfMaterialsForDisplay
 }) => {
@@ -23,7 +23,7 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
 
   const initialMaximumDisplay = MaterialGridValidIncrements[0];
   const maximumCalculatedDisplay = calculateAmountToDisplay(
-    materialIDs.length,
+    materialIds.length,
     selectedAmountOfMaterialsForDisplay
   );
   const moreMaterialsThanInitialMaximum =
@@ -45,7 +45,7 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
     <div className="material-grid">
       <h2 className="material-grid__title">{title}</h2>
       <ul className="material-grid__items">
-        {materialIDs
+        {materialIds
           .slice(0, currentAmountOfDisplayedMaterials)
           .map((materialId) => (
             <li key={materialId}>

--- a/src/apps/material-grid/MaterialGridSkeleton.tsx
+++ b/src/apps/material-grid/MaterialGridSkeleton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import RecommendedMaterialSkeleton from "../recommended-material/RecommendedMaterialSkeleton";
 
-const MaterialGridAutomaticSkeleton: React.FC = () => {
+const MaterialGridSkeleton: React.FC = () => {
   return (
     <div className="material-grid">
       <div className="material-grid__title ssc-line" />
@@ -16,4 +16,4 @@ const MaterialGridAutomaticSkeleton: React.FC = () => {
   );
 };
 
-export default MaterialGridAutomaticSkeleton;
+export default MaterialGridSkeleton;

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.dev.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.dev.tsx
@@ -11,11 +11,12 @@ import MaterialGridAutomatic, {
 } from "./MaterialGridAutomatic.entry";
 
 export default {
-  title: "Apps / Material Grid Automatic",
+  title: "Apps / Material Grid / Automatic",
   component: MaterialGridAutomatic,
   argTypes: {
     title: {
       name: "Title",
+
       defaultValue: "Recommended materials",
       control: { type: "text" }
     },

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -38,7 +38,7 @@ const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
   return (
     <MaterialGrid
       title={title}
-      materialIDs={materialIDs}
+      materialIds={materialIDs}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
     />
   );

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -3,7 +3,7 @@ import { useComplexSearchWithPaginationQuery } from "../../../core/dbc-gateway/g
 import useGetCleanBranches from "../../../core/utils/branches";
 import { Work } from "../../../core/utils/types/entities";
 import MaterialGrid from "../MaterialGrid";
-import MaterialGridAutomaticSkeleton from "../MaterialGridSkeleton";
+import MaterialGridSkeleton from "../MaterialGridSkeleton";
 import { ValidSelectedIncrements } from "../materiel-grid-util";
 
 export type MaterialGridAutomaticProps = {
@@ -29,7 +29,7 @@ const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
   });
 
   if (isLoading || !data) {
-    return <MaterialGridAutomaticSkeleton />;
+    return <MaterialGridSkeleton />;
   }
 
   const resultWorks: Work[] = data.complexSearch.works as Work[];

--- a/src/apps/material-grid/manual/MaterialGridManual.dev.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.dev.tsx
@@ -1,0 +1,103 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import globalTextArgs, {
+  GlobalEntryTextProps
+} from "../../../core/storybook/globalTextArgs";
+import serviceUrlArgs from "../../../core/storybook/serviceUrlArgs";
+
+import MaterialGridManual, {
+  MaterialGridManualEntryProps
+} from "./MaterialGridManual.entry";
+
+export default {
+  title: "Apps / Material Grid / Manual",
+  component: MaterialGridManual,
+  argTypes: {
+    title: {
+      name: "Title",
+      defaultValue: "Recommended materials",
+      control: { type: "text" }
+    },
+    buttonText: {
+      name: "Button text",
+      defaultValue: "Show all",
+      control: { type: "text" }
+    },
+    materialIds: {
+      name: "Material IDs",
+      defaultValue: JSON.stringify([
+        "work-of:870970-basis:25660722",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:25932625",
+        "work-of:870970-basis:26264340",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:26856353",
+        "work-of:870970-basis:27275745",
+        "work-of:870970-basis:45363899",
+        "work-of:870970-basis:29788596",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:50689360",
+        "work-of:870970-basis:53045650",
+        "work-of:870970-basis:46510534",
+        "work-of:870970-basis:134877804",
+        "work-of:870970-basis:54129807",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:25660722",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:25932625",
+        "work-of:870970-basis:26264340",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:26856353",
+        "work-of:870970-basis:27275745",
+        "work-of:870970-basis:45363899",
+        "work-of:870970-basis:29788596",
+        "work-of:870970-basis:52646251",
+        "work-of:870970-basis:50689360",
+        "work-of:870970-basis:53045650",
+        "work-of:870970-basis:46510534",
+        "work-of:870970-basis:134877804",
+        "work-of:870970-basis:54129807",
+        "work-of:870970-basis:52646251"
+      ]),
+      control: { type: "array" }
+    },
+    materialUrl: {
+      name: "Path to the material page",
+      defaultValue: "/work/:workid",
+      control: { type: "text" }
+    },
+    etAlText: {
+      name: "Et al. Text",
+      defaultValue: "et al.",
+      control: { type: "text" }
+    },
+    ...globalTextArgs,
+    ...serviceUrlArgs,
+    blacklistedPickupBranchesConfig: {
+      name: "Blacklisted Pickup branches",
+      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      control: { type: "text" }
+    },
+    blacklistedAvailabilityBranchesConfig: {
+      name: "Blacklisted Availability branches",
+      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      control: { type: "text" }
+    },
+    blacklistedSearchBranchesConfig: {
+      name: "Blacklisted branches",
+      defaultValue: "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",
+      control: { type: "text" }
+    },
+    branchesConfig: {
+      name: "Branches",
+      defaultValue:
+        '[\n   {\n      "branchId":"DK-775120",\n      "title":"Højbjerg"\n   },\n   {\n      "branchId":"DK-775122",\n      "title":"Beder-Malling"\n   },\n   {\n      "branchId":"DK-775144",\n      "title":"Gellerup"\n   },\n   {\n      "branchId":"DK-775167",\n      "title":"Lystrup"\n   },\n   {\n      "branchId":"DK-775146",\n      "title":"Harlev"\n   },\n   {\n      "branchId":"DK-775168",\n      "title":"Skødstrup"\n   },\n   {\n      "branchId":"FBS-751010",\n      "title":"Arresten"\n   },\n   {\n      "branchId":"DK-775147",\n      "title":"Hasle"\n   },\n   {\n      "branchId":"FBS-751032",\n      "title":"Må ikke benyttes"\n   },\n   {\n      "branchId":"FBS-751031",\n      "title":"Fjernlager 1"\n   },\n   {\n      "branchId":"DK-775126",\n      "title":"Solbjerg"\n   },\n   {\n      "branchId":"FBS-751030",\n      "title":"ITK"\n   },\n   {\n      "branchId":"DK-775149",\n      "title":"Sabro"\n   },\n   {\n      "branchId":"DK-775127",\n      "title":"Tranbjerg"\n   },\n   {\n      "branchId":"DK-775160",\n      "title":"Risskov"\n   },\n   {\n      "branchId":"DK-775162",\n      "title":"Hjortshøj"\n   },\n   {\n      "branchId":"DK-775140",\n      "title":"Åby"\n   },\n   {\n      "branchId":"FBS-751009",\n      "title":"Fjernlager 2"\n   },\n   {\n      "branchId":"FBS-751029",\n      "title":"Stadsarkivet"\n   },\n   {\n      "branchId":"FBS-751027",\n      "title":"Intern"\n   },\n   {\n      "branchId":"FBS-751026",\n      "title":"Fælles undervejs"\n   },\n   {\n      "branchId":"FBS-751025",\n      "title":"Fællessekretariatet"\n   },\n   {\n      "branchId":"DK-775133",\n      "title":"Bavnehøj"\n   },\n   {\n      "branchId":"FBS-751024",\n      "title":"Fjernlånte materialer"\n   },\n   {\n      "branchId":"DK-775100",\n      "title":"Hovedbiblioteket"\n   },\n   {\n      "branchId":"DK-775170",\n      "title":"Trige"\n   },\n   {\n      "branchId":"DK-775150",\n      "title":"Tilst"\n   },\n   {\n      "branchId":"DK-775130",\n      "title":"Viby"\n   },\n   {\n      "branchId":"DK-775164",\n      "title":"Egå"\n   }\n]',
+      control: { type: "text" }
+    }
+  }
+} as ComponentMeta<typeof MaterialGridManual>;
+
+export const App: ComponentStory<typeof MaterialGridManual> = (
+  args: MaterialGridManualEntryProps & GlobalEntryTextProps
+) => <MaterialGridManual {...args} />;

--- a/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
@@ -17,17 +17,22 @@ interface MaterialGridManualEntryConfigProps {
 export interface MaterialGridManualEntryProps
   extends GlobalEntryTextProps,
     MaterialGridManualEntryConfigProps {
-  materialIds: WorkId[];
+  materialIds: string;
   title: string;
 }
 
 const MaterialGridManualEntry: React.FC<MaterialGridManualEntryProps> = ({
   materialIds,
   title
-}) => (
-  <GuardedApp app="material-grid-manual">
-    <MaterialGridManual materialIds={materialIds} title={title} />
-  </GuardedApp>
-);
+}) => {
+  const parsedMaterialIdString: WorkId[] = JSON.parse(materialIds);
+  const parsedMaterialIds = parsedMaterialIdString.map((id) => id);
+
+  return (
+    <GuardedApp app="material-grid-manual">
+      <MaterialGridManual materialIds={parsedMaterialIds} title={title} />
+    </GuardedApp>
+  );
+};
 
 export default withConfig(withUrls(withText(MaterialGridManualEntry)));

--- a/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import GuardedApp from "../../../components/guarded-app";
+import { GlobalEntryTextProps } from "../../../core/storybook/globalTextArgs";
+import { withConfig } from "../../../core/utils/config";
+import { withText } from "../../../core/utils/text";
+import { WorkId } from "../../../core/utils/types/ids";
+import { withUrls } from "../../../core/utils/url";
+import MaterialGridManual from "./MaterialGridManual";
+
+interface MaterialGridManualEntryConfigProps {
+  blacklistedAvailabilityBranchesConfig: string;
+  blacklistedPickupBranchesConfig?: string;
+  blacklistedSearchBranchesConfig?: string;
+  branchesConfig: string;
+}
+
+export interface MaterialGridManualEntryProps
+  extends GlobalEntryTextProps,
+    MaterialGridManualEntryConfigProps {
+  materialIds: WorkId[];
+  title: string;
+}
+
+const MaterialGridManualEntry: React.FC<MaterialGridManualEntryProps> = ({
+  materialIds,
+  title
+}) => (
+  <GuardedApp app="material-grid-manual">
+    <MaterialGridManual materialIds={materialIds} title={title} />
+  </GuardedApp>
+);
+
+export default withConfig(withUrls(withText(MaterialGridManualEntry)));

--- a/src/apps/material-grid/manual/MaterialGridManual.mount.ts
+++ b/src/apps/material-grid/manual/MaterialGridManual.mount.ts
@@ -1,0 +1,7 @@
+import addMount from "../../../core/addMount";
+import MaterialGridManualEntry from "./MaterialGridManual.entry";
+
+addMount({
+  appName: "material-grid-manual",
+  app: MaterialGridManualEntry
+});

--- a/src/apps/material-grid/manual/MaterialGridManual.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-import { useEffect } from "react";
 import { WorkId } from "../../../core/utils/types/ids";
 import MaterialGrid from "../MaterialGrid";
-import MaterialGridSkeleton from "../MaterialGridSkeleton";
 import { calculateAmountToDisplay } from "../materiel-grid-util";
 
 export type MaterialGridManualProps = {
@@ -14,29 +12,14 @@ const MaterialGridManual: React.FC<MaterialGridManualProps> = ({
   materialIds,
   title
 }) => {
-  const [parsedMaterialIds, setParsedMaterials] =
-    React.useState<WorkId[]>(materialIds);
-
-  useEffect(() => {
-    // Materials must be parsed from string to WorkId[] array as they are
-    // received as a string from the backend.
-    if (typeof materialIds === "string") {
-      setParsedMaterials(JSON.parse(materialIds));
-    }
-  }, [materialIds]);
-
   const selectedAmountOfMaterialsForDisplay = calculateAmountToDisplay(
-    parsedMaterialIds.length
+    materialIds.length
   );
-
-  if (!parsedMaterialIds.length || typeof parsedMaterialIds === "string") {
-    return <MaterialGridSkeleton />;
-  }
 
   return (
     <MaterialGrid
       title={title}
-      materialIds={parsedMaterialIds}
+      materialIds={materialIds}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
     />
   );

--- a/src/apps/material-grid/manual/MaterialGridManual.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { useEffect } from "react";
+import { WorkId } from "../../../core/utils/types/ids";
+import MaterialGrid from "../MaterialGrid";
+import MaterialGridSkeleton from "../MaterialGridSkeleton";
+import { calculateAmountToDisplay } from "../materiel-grid-util";
+
+export type MaterialGridManualProps = {
+  materialIds: WorkId[];
+  title: string;
+};
+
+const MaterialGridManual: React.FC<MaterialGridManualProps> = ({
+  materialIds,
+  title
+}) => {
+  const [parsedMaterialIds, setParsedMaterials] =
+    React.useState<WorkId[]>(materialIds);
+
+  useEffect(() => {
+    // Materials must be parsed from string to WorkId[] array as they are
+    // received as a string from the backend.
+    if (typeof materialIds === "string") {
+      setParsedMaterials(JSON.parse(materialIds));
+    }
+  }, [materialIds]);
+
+  const selectedAmountOfMaterialsForDisplay = calculateAmountToDisplay(
+    parsedMaterialIds.length
+  );
+
+  if (!parsedMaterialIds.length || typeof parsedMaterialIds === "string") {
+    return <MaterialGridAutomaticSkeleton />;
+  }
+
+  return (
+    <MaterialGrid
+      title={title}
+      materialIds={parsedMaterialIds}
+      selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
+    />
+  );
+};
+export default MaterialGridManual;

--- a/src/apps/material-grid/manual/MaterialGridManual.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.tsx
@@ -30,7 +30,7 @@ const MaterialGridManual: React.FC<MaterialGridManualProps> = ({
   );
 
   if (!parsedMaterialIds.length || typeof parsedMaterialIds === "string") {
-    return <MaterialGridAutomaticSkeleton />;
+    return <MaterialGridSkeleton />;
   }
 
   return (

--- a/src/apps/material-grid/materiel-grid-util.ts
+++ b/src/apps/material-grid/materiel-grid-util.ts
@@ -5,16 +5,19 @@ export const MaterialGridValidIncrements: ValidSelectedIncrements[] = [
 ];
 
 export function calculateAmountToDisplay(
-  fetchedCount: number,
-  selectedAmount: ValidSelectedIncrements
+  availableAmount: number,
+  selectedAmount?: ValidSelectedIncrements
 ): ValidSelectedIncrements {
-  if (fetchedCount >= selectedAmount) {
+  // If selectedAmount is defined and less than or equal to availableAmount, return it
+  if (selectedAmount && availableAmount >= selectedAmount) {
     return selectedAmount;
   }
 
-  const suitableIncrement = MaterialGridValidIncrements.reverse().find(
-    (increment) => increment <= fetchedCount
-  );
+  // Find the largest increment that does not exceed availableAmount
+  const suitableIncrement = [...MaterialGridValidIncrements]
+    .reverse()
+    .find((increment) => increment <= availableAmount);
 
+  // Return the found increment, or the smallest increment if none are suitable
   return suitableIncrement || MaterialGridValidIncrements[0];
 }

--- a/src/core/utils/types/ids.ts
+++ b/src/core/utils/types/ids.ts
@@ -13,7 +13,7 @@ export type GuardedAppId =
   | "inspiration-recommender"
   | "recommended-material"
   | "recommendation"
-  | "material-grid-automatic";
-
+  | "material-grid-automatic"
+  | "material-grid-manual";
 export type IssnId = DigitalArticleService["issn"];
 export type LoanId = number;


### PR DESCRIPTION
#### Link to issue

[DDFFORM-314](https://reload.atlassian.net/browse/DDFFORM-314)

#### Description

This PR adds a grid-display of recommended materials, that can be selected added by editors, by adding the workIds of the materials. 


This PR is very similar to the [MaterialGridAutomatic](https://github.com/danskernesdigitalebibliotek/dpl-react/pull/971) and depends on the CSS that was made, as part of that ticket. 


#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/13272656/4157bcea-1bc6-470b-b51f-321c0b244c48)

