### PR TITLE
Insert retry delay in installs in branch release workflow

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           command: yarn install --frozen-lockfile
           attempt_limit: 3
-          attempt_delay: 2000
+          attempt_delay: 360000
 
       - name: Build artifacts
         run: yarn build

--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -53,8 +53,8 @@ jobs:
       - uses: Wandalen/wretry.action@v1.4.5
         with:
           command: yarn install --frozen-lockfile
-          attempt_limit: 3
-          attempt_delay: 360000
+          attempt_limit: 30
+          attempt_delay: 60000
 
       - name: Build artifacts
         run: yarn build


### PR DESCRIPTION
We have the suspicion that the design system npm packages takes time in being ready. Let's wait a bit more for them to be available...
