### PR TITLE
DDFFORM 369

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -50,7 +50,7 @@ jobs:
           echo "[@danskernesdigitalebibliotek]:registry=https://npm.pkg.github.com" >> ~/.npmrc
           echo 'registry "https://registry.yarnpkg.com"' >> ~/.yarnrc
 
-      - uses: Wandalen/wretry.action@v1.4.4
+      - uses: Wandalen/wretry.action@v1.4.5
         with:
           command: yarn install --frozen-lockfile
           attempt_limit: 3

--- a/.github/workflows/create-release-on-tag.yml
+++ b/.github/workflows/create-release-on-tag.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - uses: Wandalen/wretry.action@v1.4.4
+      - uses: Wandalen/wretry.action@v1.4.5
         with:
           command: yarn install --frozen-lockfile
           attempt_limit: 3

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "caniuse-lite": "^1.0.30001588",
+    "caniuse-lite": "^1.0.30001593",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^8.2.2",
     "core-js": "^3.36.0",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "post-process-generated-graphql": "ts-node ./scripts/post-process-generated-graphql.ts"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.9",
+    "@babel/core": "^7.24.0",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-optional-chaining": "^7.21.0",
-    "@babel/preset-env": "^7.23.9",
+    "@babel/preset-env": "^7.24.0",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@csstools/postcss-sass": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-cypress": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/react-flatpickr": "^3.8.11",
     "@types/react-redux": "^7.1.24",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
-    "@typescript-eslint/parser": "^7.0.1",
+    "@typescript-eslint/parser": "^7.1.0",
     "@vitest/coverage-istanbul": "^1.3.1",
     "autoprefixer": "^10.4.17",
     "babel-loader": "^9.1.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@csstools/postcss-sass": "^5.1.1",
     "@cypress/browserify-preprocessor": "^3.0.2",
-    "@cypress/code-coverage": "^3.12.23",
+    "@cypress/code-coverage": "^3.12.26",
     "@graphql-codegen/add": "^3.1.1",
     "@graphql-codegen/cli": "^2.6.2",
     "@graphql-codegen/introspection": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@tsconfig/create-react-app": "^1.0.2",
     "@types/node": "^20.11.19",
-    "@types/react": "^18.2.58",
+    "@types/react": "^18.2.61",
     "@types/react-dom": "^18.2.19",
     "@types/react-flatpickr": "^3.8.11",
     "@types/react-redux": "^7.1.24",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-webpack-plugin": "^4.0.1",
     "glob": "^8.0.1",
-    "happy-dom": "^13.6.0",
+    "happy-dom": "^13.6.2",
     "istanbul-lib-coverage": "^3.2.2",
     "markdownlint-cli2": "^0.4.0",
     "mutationobserver-shim": "^0.3.7",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-recommended-scss": "^6.0.0",
     "stylelint-prettier": "^2.0.0",
-    "stylelint-scss": "^6.1.0",
+    "stylelint-scss": "^6.2.0",
     "stylelint-webpack-plugin": "^5.0.0",
     "svg-url-loader": "^8.0.0",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^8.2.2",
     "core-js": "^3.36.0",
-    "css-loader": "^6.9.1",
+    "css-loader": "^6.10.0",
     "cssnano": "^6.0.5",
     "cypress": "^9.6.1",
     "dotenv": "^16.4.5",

--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -8,14 +8,20 @@ import {
   ValidSelectedIncrements,
   calculateAmountToDisplay
 } from "./materiel-grid-util";
+import { DisplayMaterialType } from "../../core/utils/types/material-type";
+
+export type MaterialGridItemProps = {
+  wid: WorkId;
+  materialType?: DisplayMaterialType;
+};
 
 export type MaterialGridProps = {
-  materialIds: WorkId[];
+  materials: MaterialGridItemProps[];
   title?: string;
   selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
 };
 const MaterialGrid: React.FC<MaterialGridProps> = ({
-  materialIds,
+  materials,
   title,
   selectedAmountOfMaterialsForDisplay
 }) => {
@@ -23,7 +29,7 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
 
   const initialMaximumDisplay = MaterialGridValidIncrements[0];
   const maximumCalculatedDisplay = calculateAmountToDisplay(
-    materialIds.length,
+    materials.length,
     selectedAmountOfMaterialsForDisplay
   );
   const moreMaterialsThanInitialMaximum =
@@ -45,13 +51,20 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
     <div className="material-grid">
       {title && <h2 className="material-grid__title">{title}</h2>}
       <ul className="material-grid__items">
-        {materialIds
+        {materials
           .slice(0, currentAmountOfDisplayedMaterials)
-          .map((materialId) => (
-            <li key={materialId}>
-              <RecommendedMaterial wid={materialId} partOfGrid />
-            </li>
-          ))}
+          .map((material) => {
+            const { wid, materialType } = material;
+            return (
+              <li key={wid}>
+                <RecommendedMaterial
+                  partOfGrid
+                  wid={wid}
+                  materialType={materialType}
+                />
+              </li>
+            );
+          })}
       </ul>
       {moreMaterialsThanInitialMaximum && !showAllMaterials && (
         <button

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.entry.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.entry.tsx
@@ -28,19 +28,15 @@ const MaterialGridAutomaticEntry: React.FC<MaterialGridAutomaticEntryProps> = ({
   title,
   selectedAmountOfMaterialsForDisplay,
   buttonText
-}) => {
-  return (
-    <GuardedApp app="material-grid-automatic">
-      <MaterialGridAutomatic
-        cql={cql}
-        title={title}
-        selectedAmountOfMaterialsForDisplay={
-          selectedAmountOfMaterialsForDisplay
-        }
-        buttonText={buttonText}
-      />
-    </GuardedApp>
-  );
-};
+}) => (
+  <GuardedApp app="material-grid-automatic">
+    <MaterialGridAutomatic
+      cql={cql}
+      title={title}
+      selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
+      buttonText={buttonText}
+    />
+  </GuardedApp>
+);
 
 export default withConfig(withUrls(withText(MaterialGridAutomaticEntry)));

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -33,12 +33,16 @@ const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
   }
 
   const resultWorks: Work[] = data.complexSearch.works as Work[];
-  const materialIDs = resultWorks.map((work) => work.workId);
+  const materials = resultWorks.map((work) => {
+    return {
+      wid: work.workId
+    };
+  });
 
   return (
     <MaterialGrid
       title={title}
-      materialIds={materialIDs}
+      materials={materials}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
     />
   );

--- a/src/apps/material-grid/manual/MaterialGridManual.dev.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.dev.tsx
@@ -10,6 +10,41 @@ import MaterialGridManual, {
   MaterialGridManualEntryProps
 } from "./MaterialGridManual.entry";
 
+// 31 materials. Intentionally not using 32 in order to demonstrate the
+// logic for only displaying intervals of 4 materials.
+const materials = [
+  { wid: "work-of:870970-basis:25660722", materialType: "bog" },
+  { wid: "work-of:870970-basis:22383590", materialType: "e-bog" },
+  { wid: "work-of:870970-basis:25932625", materialType: "film" },
+  { wid: "work-of:870970-basis:26264340", materialType: "musik (online)" },
+  { wid: "work-of:870970-basis:52646251", materialType: "lydbog" },
+  { wid: "work-of:870970-basis:26856353", materialType: "artikel" },
+  { wid: "work-of:870970-basis:27275745", materialType: "tegneserie (online)" },
+  { wid: "work-of:870970-basis:22383590", materialType: "tidsskrift" },
+  { wid: "work-of:870970-basis:29788596", materialType: "cd" },
+  { wid: "work-of:870970-basis:52646251", materialType: "podcast" },
+  { wid: "work-of:870970-basis:50689360", materialType: "film (online)" },
+  { wid: "work-of:870970-basis:22383590", materialType: "lydbog (cd-mp3)" },
+  { wid: "work-of:870970-basis:46510534", materialType: "artikel (online)" },
+  { wid: "work-of:870970-basis:134877804", materialType: "tegneserie" },
+  { wid: "work-of:870970-basis:54129807", materialType: "tidsskrift (online)" },
+  { wid: "work-of:870970-basis:52646251", materialType: "billedbog" },
+  { wid: "work-of:870970-basis:25660722", materialType: "billedbog (online)" },
+  { wid: "work-of:870970-basis:25932625", materialType: "lydbog (online)" },
+  { wid: "work-of:870970-basis:26264340", materialType: "musik (online)" },
+  { wid: "work-of:870970-basis:22383590", materialType: "artikel" },
+  { wid: "work-of:870970-basis:26856353", materialType: "film" },
+  { wid: "work-of:870970-basis:27275745", materialType: "e-bog" },
+  { wid: "work-of:870970-basis:45363899", materialType: "cd" },
+  { wid: "work-of:870970-basis:29788596", materialType: "podcast" },
+  { wid: "work-of:870970-basis:52646251", materialType: "film (online)" },
+  { wid: "work-of:870970-basis:50689360", materialType: "lydbog" },
+  { wid: "work-of:870970-basis:53045650", materialType: "tegneserie (online)" },
+  { wid: "work-of:870970-basis:46510534", materialType: "tidsskrift" },
+  { wid: "work-of:870970-basis:134877804", materialType: "cd" },
+  { wid: "work-of:870970-basis:54129807", materialType: "podcast" },
+  { wid: "work-of:870970-basis:52646251", materialType: "film (online)" }
+];
 export default {
   title: "Apps / Material Grid / Manual",
   component: MaterialGridManual,
@@ -24,42 +59,9 @@ export default {
       defaultValue: "Show all",
       control: { type: "text" }
     },
-    materialIds: {
-      name: "Material IDs",
-      defaultValue: JSON.stringify([
-        "work-of:870970-basis:25660722",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:25932625",
-        "work-of:870970-basis:26264340",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:26856353",
-        "work-of:870970-basis:27275745",
-        "work-of:870970-basis:45363899",
-        "work-of:870970-basis:29788596",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:50689360",
-        "work-of:870970-basis:53045650",
-        "work-of:870970-basis:46510534",
-        "work-of:870970-basis:134877804",
-        "work-of:870970-basis:54129807",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:25660722",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:25932625",
-        "work-of:870970-basis:26264340",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:26856353",
-        "work-of:870970-basis:27275745",
-        "work-of:870970-basis:45363899",
-        "work-of:870970-basis:29788596",
-        "work-of:870970-basis:52646251",
-        "work-of:870970-basis:50689360",
-        "work-of:870970-basis:53045650",
-        "work-of:870970-basis:46510534",
-        "work-of:870970-basis:134877804",
-        "work-of:870970-basis:54129807",
-        "work-of:870970-basis:52646251"
-      ]),
+    materials: {
+      name: "Materials",
+      defaultValue: JSON.stringify(materials),
       control: { type: "array" }
     },
     materialUrl: {

--- a/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
@@ -3,8 +3,8 @@ import GuardedApp from "../../../components/guarded-app";
 import { GlobalEntryTextProps } from "../../../core/storybook/globalTextArgs";
 import { withConfig } from "../../../core/utils/config";
 import { withText } from "../../../core/utils/text";
-import { WorkId } from "../../../core/utils/types/ids";
 import { withUrls } from "../../../core/utils/url";
+import { MaterialGridItemProps } from "../MaterialGrid";
 import MaterialGridManual from "./MaterialGridManual";
 
 interface MaterialGridManualEntryConfigProps {
@@ -17,20 +17,23 @@ interface MaterialGridManualEntryConfigProps {
 export interface MaterialGridManualEntryProps
   extends GlobalEntryTextProps,
     MaterialGridManualEntryConfigProps {
-  materialIds: string;
+  materials: string;
   title?: string;
 }
 
 const MaterialGridManualEntry: React.FC<MaterialGridManualEntryProps> = ({
-  materialIds,
+  materials,
   title
 }) => {
-  const parsedMaterialIdString: WorkId[] = JSON.parse(materialIds);
-  const parsedMaterialIds = parsedMaterialIdString.map((id) => id);
+  const parsedMaterialsString: MaterialGridItemProps[] = JSON.parse(materials);
+  const parsedMaterials = parsedMaterialsString.map((work) => ({
+    wid: work.wid,
+    materialType: work.materialType
+  }));
 
   return (
     <GuardedApp app="material-grid-manual">
-      <MaterialGridManual materialIds={parsedMaterialIds} title={title} />
+      <MaterialGridManual materials={parsedMaterials} title={title} />
     </GuardedApp>
   );
 };

--- a/src/apps/material-grid/manual/MaterialGridManual.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.tsx
@@ -1,25 +1,24 @@
 import * as React from "react";
-import { WorkId } from "../../../core/utils/types/ids";
-import MaterialGrid from "../MaterialGrid";
+import MaterialGrid, { MaterialGridItemProps } from "../MaterialGrid";
 import { calculateAmountToDisplay } from "../materiel-grid-util";
 
 export type MaterialGridManualProps = {
-  materialIds: WorkId[];
+  materials: MaterialGridItemProps[];
   title?: string;
 };
 
 const MaterialGridManual: React.FC<MaterialGridManualProps> = ({
-  materialIds,
+  materials,
   title
 }) => {
   const selectedAmountOfMaterialsForDisplay = calculateAmountToDisplay(
-    materialIds.length
+    materials.length
   );
 
   return (
     <MaterialGrid
       title={title}
-      materialIds={materialIds}
+      materials={materials}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
     />
   );

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,4 +1,4 @@
-import { compact, groupBy, uniqBy, uniq, head } from "lodash";
+import { compact, groupBy, uniqBy, uniq, head, first } from "lodash";
 import { UseQueryOptions } from "react-query";
 import {
   getManifestationType,
@@ -14,7 +14,10 @@ import {
 import { UseTextFunction } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import { FaustId } from "../../core/utils/types/ids";
-import { ManifestationMaterialType } from "../../core/utils/types/material-type";
+import {
+  DisplayMaterialType,
+  ManifestationMaterialType
+} from "../../core/utils/types/material-type";
 import {
   AccessTypeCode,
   WorkType
@@ -454,6 +457,36 @@ export const useGetHoldings = ({
   return { data, isLoading, isError };
 };
 
+export const getManifestationBasedOnType = (
+  work: Work,
+  materialType: DisplayMaterialType
+): Manifestation => {
+  const { bestRepresentation, all } = work.manifestations;
+
+  const bestRepresentationMaterialType =
+    getManifestationMaterialTypes(bestRepresentation);
+
+  if (materialType === bestRepresentationMaterialType) {
+    return bestRepresentation;
+  }
+
+  // Filters and sorts the manifestations if the best representation does not match.
+  const filteredAndSortedManifestations = filterManifestationsByType(
+    materialType,
+    all
+  );
+  const newestFilteredAndSortedManifestation = first(
+    filteredAndSortedManifestations
+  );
+
+  if (newestFilteredAndSortedManifestation) {
+    return newestFilteredAndSortedManifestation;
+  }
+  // Fallback returning best representation.
+  return bestRepresentation;
+};
+
+// ************** VITEST ***************
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
 

--- a/src/apps/recommendation/recommendation.dev.tsx
+++ b/src/apps/recommendation/recommendation.dev.tsx
@@ -1,21 +1,27 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import Recommendation, {
-  RecommendationEntryProps
-} from "./recommendation.entry";
 import globalTextArgs, {
   GlobalEntryTextProps
 } from "../../core/storybook/globalTextArgs";
 import serviceUrlArgs from "../../core/storybook/serviceUrlArgs";
+
+import DisplayMaterialTypeOptions from "../recommended-material/recommendedMaterialDisplayTypeData";
 import RecommendationSkeleton from "./RecommendationSkeleton";
+import Recommendation, {
+  RecommendationEntryProps
+} from "./recommendation.entry";
 
 export default {
   title: "Apps / Recommendation",
   component: Recommendation,
   argTypes: {
     wid: {
-      defaultValue: "work-of:870970-basis:136336282",
+      defaultValue: "work-of:870970-basis:22383590",
       control: { type: "text" }
+    },
+    materialType: {
+      defaultValue: "bog",
+      control: { type: "select", options: DisplayMaterialTypeOptions }
     },
     positionImageRight: {
       defaultValue: false,

--- a/src/apps/recommendation/recommendation.entry.tsx
+++ b/src/apps/recommendation/recommendation.entry.tsx
@@ -1,23 +1,30 @@
 import React from "react";
-import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
-import { withText } from "../../core/utils/text";
-import Recommendation from "./recommendation";
-import { withConfig } from "../../core/utils/config";
-import { withUrls } from "../../core/utils/url";
-import { WorkId } from "../../core/utils/types/ids";
 import GuardedApp from "../../components/guarded-app";
+import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
+import { withConfig } from "../../core/utils/config";
+import { withText } from "../../core/utils/text";
+import { WorkId } from "../../core/utils/types/ids";
+import { DisplayMaterialType } from "../../core/utils/types/material-type";
+import { withUrls } from "../../core/utils/url";
+import Recommendation from "./recommendation";
 
 export interface RecommendationEntryProps extends GlobalEntryTextProps {
   wid: WorkId;
+  materialType?: DisplayMaterialType;
   positionImageRight?: boolean;
 }
 
 const RecommendationEntry: React.FC<RecommendationEntryProps> = ({
   wid,
+  materialType,
   positionImageRight
 }) => (
   <GuardedApp app="recommendation">
-    <Recommendation wid={wid} positionImageRight={positionImageRight} />
+    <Recommendation
+      wid={wid}
+      materialType={materialType}
+      positionImageRight={positionImageRight}
+    />
   </GuardedApp>
 );
 

--- a/src/apps/recommendation/recommendation.tsx
+++ b/src/apps/recommendation/recommendation.tsx
@@ -5,20 +5,24 @@ import Link from "../../components/atoms/links/Link";
 import { useGetMaterialQuery } from "../../core/dbc-gateway/generated/graphql";
 import { constructMaterialUrl } from "../../core/utils/helpers/url";
 import { WorkId } from "../../core/utils/types/ids";
+import { DisplayMaterialType } from "../../core/utils/types/material-type";
 import { useUrls } from "../../core/utils/url";
 import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
 import RecommendationMaterialSkeleton from "./RecommendationSkeleton";
 
 export type RecommendationProps = {
-  positionImageRight?: boolean;
   wid: WorkId;
+  materialType?: DisplayMaterialType;
+  positionImageRight?: boolean;
 };
 
 const Recommendation: React.FC<RecommendationProps> = ({
-  positionImageRight,
-  wid
+  wid,
+  materialType,
+  positionImageRight
 }) => {
   const u = useUrls();
+
   const materialUrl = u("materialUrl");
 
   const { data, isLoading } = useGetMaterialQuery({
@@ -36,7 +40,7 @@ const Recommendation: React.FC<RecommendationProps> = ({
     }
   } = data;
 
-  const materialFullUrl = constructMaterialUrl(materialUrl, wid);
+  const materialFullUrl = constructMaterialUrl(materialUrl, wid, materialType);
   const materialDescription = abstract?.[0];
 
   return (
@@ -47,7 +51,7 @@ const Recommendation: React.FC<RecommendationProps> = ({
       )}
       data-cy="recommendation"
     >
-      <RecommendedMaterial wid={wid} />
+      <RecommendedMaterial wid={wid} materialType={materialType} />
       <Link
         href={materialFullUrl}
         className="recommendation__texts arrow__hover--right-small"

--- a/src/apps/recommended-material/RecommendedMaterial.dev.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.dev.tsx
@@ -8,14 +8,19 @@ import RecommendedMaterial, {
   RecommendedMaterialEntryProps
 } from "./RecommendedMaterial.entry";
 import RecommendedMaterialSkeleton from "./RecommendedMaterialSkeleton";
+import DisplayMaterialTypeOptions from "./recommendedMaterialDisplayTypeData";
 
 export default {
   title: "Apps / Recommended Material",
   component: RecommendedMaterial,
   argTypes: {
     wid: {
-      defaultValue: "work-of:870970-basis:136336282",
+      defaultValue: "work-of:870970-basis:22383590",
       control: { type: "text" }
+    },
+    materialType: {
+      defaultValue: "bog",
+      control: { type: "select", options: DisplayMaterialTypeOptions }
     },
     materialUrl: {
       defaultValue: "/work/:workid",
@@ -35,9 +40,16 @@ export const Default: ComponentStory<typeof RecommendedMaterial> = (
   args: RecommendedMaterialEntryProps & GlobalEntryTextProps
 ) => <RecommendedMaterial {...args} />;
 
+export const materialWithoutType = Default.bind({});
+
+materialWithoutType.args = {
+  materialType: undefined
+};
+
 const SkeletonTemplate: ComponentStory<
   typeof RecommendedMaterialSkeleton
 > = () => {
   return <RecommendedMaterialSkeleton />;
 };
+
 export const Skeleton = SkeletonTemplate.bind({});

--- a/src/apps/recommended-material/RecommendedMaterial.entry.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.entry.tsx
@@ -4,18 +4,20 @@ import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
 import { withConfig } from "../../core/utils/config";
 import { withText } from "../../core/utils/text";
 import { WorkId } from "../../core/utils/types/ids";
+import { DisplayMaterialType } from "../../core/utils/types/material-type";
 import { withUrls } from "../../core/utils/url";
 import RecommendedMaterial from "./RecommendedMaterial";
 
 export interface RecommendedMaterialEntryProps {
   wid: WorkId;
+  materialType?: DisplayMaterialType;
 }
 
 const RecommendedMaterialEntry: React.FC<
   RecommendedMaterialEntryProps & GlobalEntryTextProps
-> = ({ wid }) => (
+> = ({ wid, materialType }) => (
   <GuardedApp app="recommended-material">
-    <RecommendedMaterial wid={wid} />
+    <RecommendedMaterial wid={wid} materialType={materialType} />
   </GuardedApp>
 );
 

--- a/src/apps/recommended-material/RecommendedMaterial.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.tsx
@@ -13,23 +13,30 @@ import {
 } from "../../core/utils/helpers/general";
 import { constructMaterialUrl } from "../../core/utils/helpers/url";
 import { useText } from "../../core/utils/text";
+import { Work } from "../../core/utils/types/entities";
+
 import { WorkId } from "../../core/utils/types/ids";
+import { DisplayMaterialType } from "../../core/utils/types/material-type";
 import { useUrls } from "../../core/utils/url";
+import { getManifestationBasedOnType } from "../material/helper";
 import RecommendedMaterialSkeleton from "./RecommendedMaterialSkeleton";
 
 export type RecommendedMaterialProps = {
   wid: WorkId;
+  materialType?: DisplayMaterialType;
   partOfGrid?: boolean;
 };
 
 const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({
   wid,
+  materialType,
   partOfGrid = false
 }) => {
   const t = useText();
   const u = useUrls();
   const materialUrl = u("materialUrl");
   const dispatch = useDispatch<TypedDispatch>();
+
   const { data, isLoading } = useGetMaterialQuery({
     wid
   });
@@ -41,15 +48,22 @@ const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({
   const {
     work: {
       titles: { full: fullTitle },
-      manifestations: { bestRepresentation: manifestations },
+      manifestations: { bestRepresentation },
       creators
     }
   } = data;
 
-  const { pid } = manifestations;
+  const work = data.work as Work;
+
+  const materialManifestationForDisplay = materialType
+    ? getManifestationBasedOnType(work, materialType)
+    : bestRepresentation;
+
+  const { pid } = materialManifestationForDisplay;
 
   const author = creatorsToString(flattenCreators(creators), t);
-  const materialFullUrl = constructMaterialUrl(materialUrl, wid);
+
+  const materialFullUrl = constructMaterialUrl(materialUrl, wid, materialType);
   const addToListRequest = (id: ButtonFavouriteId) => {
     dispatch(
       guardedRequest({

--- a/src/apps/recommended-material/recommendedMaterialDisplayTypeData.ts
+++ b/src/apps/recommended-material/recommendedMaterialDisplayTypeData.ts
@@ -1,0 +1,23 @@
+const DisplayMaterialTypeOptions = {
+  None: "",
+  Bog: "bog",
+  Billedbog: "billedbog",
+  "Billedbog (Online)": "billedbog (online)",
+  "E-bog": "e-bog",
+  CD: "cd",
+  Podcast: "podcast",
+  "Musik (Online)": "musik (online)",
+  Film: "film",
+  "Film (Online)": "film (online)",
+  Lydbog: "lydbog",
+  "Lydbog (Online)": "lydbog (online)",
+  "Lydbog (CD-MP3)": "lydbog (cd-mp3)",
+  Artikel: "artikel",
+  "Artikel (Online)": "artikel (online)",
+  Tegneserie: "tegneserie",
+  "Tegneserie (Online)": "tegneserie (online)",
+  Tidsskrift: "tidsskrift",
+  "Tidsskrift (Online)": "tidsskrift (online)"
+};
+
+export default DisplayMaterialTypeOptions;

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -33,3 +33,23 @@ export type AutosuggestCategoryList = {
 };
 
 export default {};
+
+export type DisplayMaterialType =
+  | "bog"
+  | "billedbog"
+  | "billedbog (online)"
+  | "e-bog"
+  | "cd"
+  | "podcast"
+  | "musik (online)"
+  | "film"
+  | "film (online)"
+  | "lydbog"
+  | "lydbog (online)"
+  | "lydbog (cd-mp3)"
+  | "artikel"
+  | "artikel (online)"
+  | "tegneserie"
+  | "tegneserie (online)"
+  | "tidsskrift"
+  | "tidsskrift (online)";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@
     through2 "^2.0.0"
     watchify "^4.0.0"
 
-"@cypress/code-coverage@^3.12.23":
-  version "3.12.23"
-  resolved "https://registry.yarnpkg.com/@cypress/code-coverage/-/code-coverage-3.12.23.tgz#80e8020e800f11ae9be2f38c3401aebd45a1f136"
-  integrity sha512-zdqLkiQOLll1tCw9TSHvhIobVTG6tsRUTN9HwDf3WvV1T+kPwmL5DU+1TkoWOEYyUyo04ZHd3PKDjUkQWxfg5A==
+"@cypress/code-coverage@^3.12.26":
+  version "3.12.26"
+  resolved "https://registry.yarnpkg.com/@cypress/code-coverage/-/code-coverage-3.12.26.tgz#c9ae218c8e637b90dad37400d166c050c0435105"
+  integrity sha512-fJDELN3BNOPKm8JRZxHN/FrNebXpjX/PAsJYUbqp7SIn7Rk7MlDhKR5T0gFOzhrfvOpKmJ7t0dQf7kqRjb/LOQ==
   dependencies:
     "@cypress/webpack-preprocessor" "^6.0.0"
     chalk "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6931,15 +6931,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580, caniuse-lite@^1.0.30001588:
-  version "1.0.30001588"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz#07f16b65a7f95dba82377096923947fb25bce6e3"
-  integrity sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==
-
-caniuse-lite@^1.0.30001587:
-  version "1.0.30001589"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz#7ad6dba4c9bf6561aec8291976402339dc157dfb"
-  integrity sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001593:
+  version "1.0.30001593"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz#7cda1d9e5b0cad6ebab4133b1f239d4ea44fe659"
+  integrity sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==
 
 capital-case@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7911,10 +7911,10 @@ css-loader@^5.0.1:
     schema-utils "^3.0.0"
     semver "^7.3.5"
 
-css-loader@^6.9.1:
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.9.1.tgz#9ec9a434368f2bdfeffbf8f6901a1ce773586c6b"
-  integrity sha512-OzABOh0+26JKFdMzlK6PY1u5Zx8+Ck7CVRlcGNZoY9qwJjdfu2VWFuprTIpPW+Av5TZTVViYWcFQaEEQURLknQ==
+css-loader@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.10.0.tgz#7c172b270ec7b833951b52c348861206b184a4b7"
+  integrity sha512-LTSA/jWbwdMlk+rhmElbDR2vbtQoTBPr7fkJE+mxrHj+7ru0hUmHafDRzWIjIHTwpitWVaqY2/UWGRca3yUgRw==
   dependencies:
     icss-utils "^5.1.0"
     postcss "^8.4.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4679,10 +4679,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.58":
-  version "18.2.58"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.58.tgz#22082d12898d11806f4a1aefb5583116a047493d"
-  integrity sha512-TaGvMNhxvG2Q0K0aYxiKfNDS5m5ZsoIBBbtfUorxdH4NGSXIlYvZxLJI+9Dd3KjeB3780bciLyAb7ylO8pLhPw==
+"@types/react@*", "@types/react@^18.2.61":
+  version "18.2.61"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.61.tgz#5607308495037436779939ec0348a5816c08799d"
+  integrity sha512-NURTN0qNnJa7O/k4XUkEW2yfygA+NxS0V5h1+kp9jPwhzZy95q3ADoGMP0+JypMhrZBTTgjKAUlTctde1zzeQA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9314,10 +9314,10 @@ eslint-config-airbnb-base@^15.0.0:
     object.entries "^1.1.5"
     semver "^6.3.0"
 
-eslint-config-airbnb-typescript@^17.1.0:
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.1.0.tgz#fda960eee4a510f092a9a1c139035ac588937ddc"
-  integrity sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==
+eslint-config-airbnb-typescript@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-18.0.0.tgz#b1646db4134858d704b1d2bee47e1d72c180315f"
+  integrity sha512-oc+Lxzgzsu8FQyFVa4QFaVKiitTYiiW3frB9KYW5OWdPrqFc7FzxgB20hP4cHMlr+MBzGcLl3jnCOVOydL9mIg==
   dependencies:
     eslint-config-airbnb-base "^15.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18183,10 +18183,10 @@ stylelint-scss@^4.0.0:
     postcss-selector-parser "^6.0.6"
     postcss-value-parser "^4.1.0"
 
-stylelint-scss@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-6.1.0.tgz#b7ef162c417132e8df2b69d1759ae07395d54fb5"
-  integrity sha512-kCfK8TQzthGwb4vaZniZgxRsVbCM4ZckmT1b/H5m4FU3I8Dz0id9llKsy1NMp3XXqC8+OPD4rVKtUbSxXlJb5g==
+stylelint-scss@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-6.2.0.tgz#039c6c10cda0862734cb3591cf3d1f1dcfd15c1c"
+  integrity sha512-ktYsWKNN+zh4VlpdNMajYCOREwaPI9xZLVue/H5vX4f4v7Kg+ej9Bj0b7fG41J2UboNujZNU9qi0yM/KK3KhOQ==
   dependencies:
     known-css-properties "^0.29.0"
     postcss-media-query-parser "^0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10941,10 +10941,10 @@ handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-happy-dom@^13.6.0:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-13.6.0.tgz#a50bac9ca5515ecb7f7e4d3684c4d8ad187bbd56"
-  integrity sha512-4sVRENyxCSqAiOzAfPiohU56/D5bcLJmyT3WGoqjVX1IXq+ScTsrLR98RUODHz0nVvSLNW86CJzRXdPoSdw/yg==
+happy-dom@^13.6.2:
+  version "13.6.2"
+  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-13.6.2.tgz#791db32921fd6322c6bb3fb5bc47b25ad2e0d21a"
+  integrity sha512-Ku+wDqcF/KwFA0dI+xIMZd9Jn020RXjuSil/Vz7gu2yhDC3FsDYZ55qqV9k+SGC4opwb4acisXqVSRxUJMlPbQ==
   dependencies:
     entities "^4.5.0"
     webidl-conversions "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@
     "@babel/highlight" "^7.23.4"
     chalk "^2.4.2"
 
-"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.17.0", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.23.3", "@babel/compat-data@^7.23.5":
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.17.0", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
@@ -87,21 +87,21 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.16.0", "@babel/core@^7.23.9", "@babel/core@^7.7.5":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
-  integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
+"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.16.0", "@babel/core@^7.24.0", "@babel/core@^7.7.5":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.0.tgz#56cbda6b185ae9d9bed369816a8f4423c5f2ff1b"
+  integrity sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.23.5"
     "@babel/generator" "^7.23.6"
     "@babel/helper-compilation-targets" "^7.23.6"
     "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.23.9"
-    "@babel/parser" "^7.23.9"
-    "@babel/template" "^7.23.9"
-    "@babel/traverse" "^7.23.9"
-    "@babel/types" "^7.23.9"
+    "@babel/helpers" "^7.24.0"
+    "@babel/parser" "^7.24.0"
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -305,10 +305,10 @@
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.16.7", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
-  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.16.7", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.24.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz#945681931a52f15ce879fd5b86ce2dae6d3d7f2a"
+  integrity sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==
 
 "@babel/helper-remap-async-to-generator@^7.22.20":
   version "7.22.20"
@@ -384,14 +384,14 @@
     "@babel/template" "^7.22.15"
     "@babel/types" "^7.22.19"
 
-"@babel/helpers@^7.12.5", "@babel/helpers@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.9.tgz#c3e20bbe7f7a7e10cb9b178384b4affdf5995c7d"
-  integrity sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==
+"@babel/helpers@^7.12.5", "@babel/helpers@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.0.tgz#a3dd462b41769c95db8091e49cfe019389a9409b"
+  integrity sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==
   dependencies:
-    "@babel/template" "^7.23.9"
-    "@babel/traverse" "^7.23.9"
-    "@babel/types" "^7.23.9"
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
 
 "@babel/highlight@^7.23.4":
   version "7.23.4"
@@ -402,10 +402,10 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.8", "@babel/parser@^7.23.6", "@babel/parser@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
-  integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.8", "@babel/parser@^7.23.6", "@babel/parser@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.0.tgz#26a3d1ff49031c53a97d03b604375f028746a9ac"
+  integrity sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.23.3":
   version "7.23.3"
@@ -933,14 +933,14 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-transform-object-rest-spread@^7.23.4":
-  version "7.23.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz#2b9c2d26bf62710460bdc0d1730d4f1048361b83"
-  integrity sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==
+"@babel/plugin-transform-object-rest-spread@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.0.tgz#7b836ad0088fdded2420ce96d4e1d3ed78b71df1"
+  integrity sha512-y/yKMm7buHpFFXfxVFS4Vk1ToRJDilIa6fKRioB9Vjichv58TDGXTvqV0dN7plobAmTW5eSEGXDngE+Mm+uO+w==
   dependencies:
-    "@babel/compat-data" "^7.23.3"
-    "@babel/helper-compilation-targets" "^7.22.15"
-    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/compat-data" "^7.23.5"
+    "@babel/helper-compilation-targets" "^7.23.6"
+    "@babel/helper-plugin-utils" "^7.24.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
     "@babel/plugin-transform-parameters" "^7.23.3"
 
@@ -1138,14 +1138,14 @@
     "@babel/helper-create-regexp-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/preset-env@^7.12.11", "@babel/preset-env@^7.16.0", "@babel/preset-env@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.9.tgz#beace3b7994560ed6bf78e4ae2073dff45387669"
-  integrity sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==
+"@babel/preset-env@^7.12.11", "@babel/preset-env@^7.16.0", "@babel/preset-env@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.24.0.tgz#11536a7f4b977294f0bdfad780f01a8ac8e183fc"
+  integrity sha512-ZxPEzV9IgvGn73iK0E6VB9/95Nd7aMFpbE0l8KQFDG70cOV9IxRP7Y2FUPmlK0v6ImlLqYX50iuZ3ZTVhOF2lA==
   dependencies:
     "@babel/compat-data" "^7.23.5"
     "@babel/helper-compilation-targets" "^7.23.6"
-    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-plugin-utils" "^7.24.0"
     "@babel/helper-validator-option" "^7.23.5"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.23.3"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.23.3"
@@ -1198,7 +1198,7 @@
     "@babel/plugin-transform-new-target" "^7.23.3"
     "@babel/plugin-transform-nullish-coalescing-operator" "^7.23.4"
     "@babel/plugin-transform-numeric-separator" "^7.23.4"
-    "@babel/plugin-transform-object-rest-spread" "^7.23.4"
+    "@babel/plugin-transform-object-rest-spread" "^7.24.0"
     "@babel/plugin-transform-object-super" "^7.23.3"
     "@babel/plugin-transform-optional-catch-binding" "^7.23.4"
     "@babel/plugin-transform-optional-chaining" "^7.23.4"
@@ -1296,19 +1296,19 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.12.7", "@babel/template@^7.22.15", "@babel/template@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.23.9.tgz#f881d0487cba2828d3259dcb9ef5005a9731011a"
-  integrity sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==
+"@babel/template@^7.12.7", "@babel/template@^7.22.15", "@babel/template@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.0.tgz#c6a524aa93a4a05d66aaf31654258fae69d87d50"
+  integrity sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==
   dependencies:
     "@babel/code-frame" "^7.23.5"
-    "@babel/parser" "^7.23.9"
-    "@babel/types" "^7.23.9"
+    "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
 
-"@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
-  integrity sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==
+"@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.0.tgz#4a408fbf364ff73135c714a2ab46a5eab2831b1e"
+  integrity sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==
   dependencies:
     "@babel/code-frame" "^7.23.5"
     "@babel/generator" "^7.23.6"
@@ -1316,15 +1316,15 @@
     "@babel/helper-function-name" "^7.23.0"
     "@babel/helper-hoist-variables" "^7.22.5"
     "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.9"
-    "@babel/types" "^7.23.9"
+    "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.18.6", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.3.0", "@babel/types@^7.4.4":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
-  integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.18.6", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.6", "@babel/types@^7.24.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
+  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
   dependencies:
     "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4826,15 +4826,15 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.0.1.tgz#e9c61d9a5e32242477d92756d36086dc40322eed"
-  integrity sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==
+"@typescript-eslint/parser@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.1.0.tgz#b89dab90840f7d2a926bf4c23b519576e8c31970"
+  integrity sha512-V1EknKUubZ1gWFjiOZhDSNToOjs63/9O0puCgGS8aDOgpZY326fzFu15QAUjwaXzRZjf/qdsdBrckYdv9YxB8w==
   dependencies:
-    "@typescript-eslint/scope-manager" "7.0.1"
-    "@typescript-eslint/types" "7.0.1"
-    "@typescript-eslint/typescript-estree" "7.0.1"
-    "@typescript-eslint/visitor-keys" "7.0.1"
+    "@typescript-eslint/scope-manager" "7.1.0"
+    "@typescript-eslint/types" "7.1.0"
+    "@typescript-eslint/typescript-estree" "7.1.0"
+    "@typescript-eslint/visitor-keys" "7.1.0"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.23.0":
@@ -4845,13 +4845,13 @@
     "@typescript-eslint/types" "5.23.0"
     "@typescript-eslint/visitor-keys" "5.23.0"
 
-"@typescript-eslint/scope-manager@7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz#611ec8e78c70439b152a805e1b10aaac36de7c00"
-  integrity sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==
+"@typescript-eslint/scope-manager@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.1.0.tgz#e4babaa39a3d612eff0e3559f3e99c720a2b4a54"
+  integrity sha512-6TmN4OJiohHfoOdGZ3huuLhpiUgOGTpgXNUPJgeZOZR3DnIpdSgtt83RS35OYNNXxM4TScVlpVKC9jyQSETR1A==
   dependencies:
-    "@typescript-eslint/types" "7.0.1"
-    "@typescript-eslint/visitor-keys" "7.0.1"
+    "@typescript-eslint/types" "7.1.0"
+    "@typescript-eslint/visitor-keys" "7.1.0"
 
 "@typescript-eslint/type-utils@5.23.0":
   version "5.23.0"
@@ -4867,10 +4867,10 @@
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.23.0.tgz"
   integrity sha512-NfBsV/h4dir/8mJwdZz7JFibaKC3E/QdeMEDJhiAE3/eMkoniZ7MjbEMCGXw6MZnZDMN3G9S0mH/6WUIj91dmw==
 
-"@typescript-eslint/types@7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.0.1.tgz#dcfabce192db5b8bf77ea3c82cfaabe6e6a3c901"
-  integrity sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==
+"@typescript-eslint/types@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.1.0.tgz#52a86d6236fda646e7e5fe61154991dc0dc433ef"
+  integrity sha512-qTWjWieJ1tRJkxgZYXx6WUYtWlBc48YRxgY2JN1aGeVpkhmnopq+SUC8UEVGNXIvWH7XyuTjwALfG6bFEgCkQA==
 
 "@typescript-eslint/typescript-estree@5.23.0":
   version "5.23.0"
@@ -4885,13 +4885,13 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz#1d52ac03da541693fa5bcdc13ad655def5046faf"
-  integrity sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==
+"@typescript-eslint/typescript-estree@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.0.tgz#419b1310f061feee6df676c5bed460537310c593"
+  integrity sha512-k7MyrbD6E463CBbSpcOnwa8oXRdHzH1WiVzOipK3L5KSML92ZKgUBrTlehdi7PEIMT8k0bQixHUGXggPAlKnOQ==
   dependencies:
-    "@typescript-eslint/types" "7.0.1"
-    "@typescript-eslint/visitor-keys" "7.0.1"
+    "@typescript-eslint/types" "7.1.0"
+    "@typescript-eslint/visitor-keys" "7.1.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -4919,12 +4919,12 @@
     "@typescript-eslint/types" "5.23.0"
     eslint-visitor-keys "^3.0.0"
 
-"@typescript-eslint/visitor-keys@7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz#864680ac5a8010ec4814f8a818e57595f79f464e"
-  integrity sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==
+"@typescript-eslint/visitor-keys@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.0.tgz#576c4ad462ca1378135a55e2857d7aced96ce0a0"
+  integrity sha512-FhUqNWluiGNzlvnDZiXad4mZRhtghdoKW6e98GoEOYSu5cND+E39rG5KwJMUzeENwm1ztYBRqof8wMLP+wNPIA==
   dependencies:
-    "@typescript-eslint/types" "7.0.1"
+    "@typescript-eslint/types" "7.1.0"
     eslint-visitor-keys "^3.4.1"
 
 "@ungap/structured-clone@^1.2.0":


### PR DESCRIPTION
#### Link to issue

[DDFFORM-369](https://reload.atlassian.net/browse/DDFFORM-369)

This is connected to [CMS PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/867)

#### Description

This PR adds an optional materialType field to all components currently using the recommendedMaterial for displaying materials. 

Remember to read the commit messages and consider any question specified there. 

#### Additional comments or questions

_Current styling for the material Grids are only in develop, which is not merged onto form-sprint-8_

Consider the used type casting. I was not sure what alternative to this there was. 

Consider wether the combined type in materialGrid `MaterialGridItemProps`should be a general type and used for all components using recommendedMaterial, or if the current implmenetation is better. I am still unsure about this, but i decided to initiately use this as i found it "cleaner". 


