### PR TITLE
Consolidate totalOwedText with totalAmountFeeText in WarningBar [DDFLSBP-461] 

### DIFF
--- a/src/apps/dashboard/dashboard-fees/dashboard-fees.tsx
+++ b/src/apps/dashboard/dashboard-fees/dashboard-fees.tsx
@@ -41,10 +41,9 @@ const DashboardFees: FC = () => {
               </div>
             </div>
             <WarningBar
-              rightText={t("totalAmountFeeText", {
+              overdueText={`${t("totalOwedText")} ${t("totalAmountFeeText", {
                 placeholders: { "@total": totalFeeAmount }
-              })}
-              overdueText={t("totalOwedText")}
+              })}`}
               rightButtonText={t("dashboardSeeMoreFeesText")}
               rightButtonAriaLabelText={t("dashboardSeeMoreFeesAriaLabelText")}
               rightLink={feesPageUrl}

--- a/src/apps/loan-list/materials/utils/warning-bar.tsx
+++ b/src/apps/loan-list/materials/utils/warning-bar.tsx
@@ -45,14 +45,16 @@ const WarningBar: FC<WarningBarProps> = ({
           </p>
         </div>
       </div>
-      {rightText && (
+      {(rightText || rightLink) && (
         <div className="warning-bar__right">
-          <p
-            className="text-body-medium-medium warning-bar__owes"
-            data-cy="warning-bar-right-text"
-          >
-            {rightText}
-          </p>
+          {rightText && (
+            <p
+              className="text-body-medium-medium warning-bar__owes"
+              data-cy="warning-bar-right-text"
+            >
+              {rightText}
+            </p>
+          )}{" "}
           <span className="hide-visually" id={labelId}>
             {rightButtonAriaLabelText}
           </span>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-461

#### Description

Consolidate totalOwedText with totalAmountFeeText in WarningBar

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/bbb4e1b9-ac38-4c59-b9c4-eb21aaf1796a)

![Skærmbillede 2024-03-13 kl  13 09 05](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/dc9e8e51-73df-4b8e-848b-b26930a85703)

#### Additional comments or questions

*