### PR TITLE
DDFLSBP-474 - Added data-cy props on create and cancel buttons

### DIFF
--- a/src/apps/create-patron-user-info/UserInfo.tsx
+++ b/src/apps/create-patron-user-info/UserInfo.tsx
@@ -101,10 +101,18 @@ const UserInfo: FC<UserInfoProps> = ({ cpr }) => {
             />
           </div>
           <div className="patron-buttons">
-            <button type="submit" className="btn-primary btn-filled btn-small">
+            <button
+              type="submit"
+              className="btn-primary btn-filled btn-small"
+              data-cy="complete-user-registration"
+            >
               {t("createPatronConfirmButtonText")}
             </button>
-            <Link href={logoutUrl} className="link-tag mx-16 mt-8">
+            <Link
+              href={logoutUrl}
+              className="link-tag mx-16 mt-8"
+              dataCy="cancel-user-registration"
+            >
               {t("createPatronCancelButtonText")}
             </Link>
           </div>

--- a/src/apps/create-patron-user-info/UserInfo.tsx
+++ b/src/apps/create-patron-user-info/UserInfo.tsx
@@ -104,14 +104,14 @@ const UserInfo: FC<UserInfoProps> = ({ cpr }) => {
             <button
               type="submit"
               className="btn-primary btn-filled btn-small"
-              data-cy="complete-user-registration"
+              data-cy="complete-user-registration-button"
             >
               {t("createPatronConfirmButtonText")}
             </button>
             <Link
               href={logoutUrl}
               className="link-tag mx-16 mt-8"
-              dataCy="cancel-user-registration"
+              dataCy="cancel-user-registration-button"
             >
               {t("createPatronCancelButtonText")}
             </Link>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-474

#### Description

This PR adds cypress-data props to the two buttons on the user registration page. It adds it on the confirm and cancel buttons.

#### Additional comments or questions

This PR will have a sister PR on dpl-cms: https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1030#issue-2188414530 