### PR TITLE
Don't show digital material quota if not logged in home municipality

### DIFF
--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -120,7 +120,7 @@ const PatronPage: FC = () => {
             showCheckboxes
           />
         )}
-        <StatusSection />
+        {patron?.resident && <StatusSection />}
         {patron && (
           <ReservationDetailsSection
             changePatron={changePatron}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-439

#### Description
Don't show digital material loan quota on the user profile page if the user is logged in in a different municipality then their home one.

#### Screenshot of the result
-

#### Additional comments or questions
-
