### PR TITLE
Fix fees and compensations modals

### DIFF
--- a/src/apps/fee-list/FeeList.tsx
+++ b/src/apps/fee-list/FeeList.tsx
@@ -12,7 +12,7 @@ import FeeDetailsContent from "./stackable-fees/fee-details-content";
 import modalIdsConf from "../../core/configuration/modal-ids.json";
 import {
   calculateFeeAmount,
-  getFeeObjectByFaustId,
+  getFeeObjectByFeeId,
   getFeesBasedOnPayableByClient
 } from "./utils/helper";
 import ListHeader from "../../components/list-header/list-header";
@@ -32,13 +32,13 @@ const FeeList: FC = () => {
   });
   const [feeDetailsData, setFeeDetailsData] = useState<FeeV2[]>();
   const openDetailsModalClickEvent = useCallback(
-    (faustId: string) => {
-      if (faustId) {
+    (feeId: number) => {
+      if (feeId) {
         if (fbsFees.length > 0) {
-          setFeeDetailsData(getFeeObjectByFaustId(fbsFees, faustId));
+          setFeeDetailsData(getFeeObjectByFeeId(fbsFees, feeId));
         }
-        setFeeDetailsModalId(modalIdsConf.feeDetails + faustId);
-        open(modalIdsConf.feeDetails + faustId || "");
+        setFeeDetailsModalId(modalIdsConf.feeDetails + feeId);
+        open(modalIdsConf.feeDetails + feeId || "");
       }
     },
     [fbsFees, open]

--- a/src/apps/fee-list/list.tsx
+++ b/src/apps/fee-list/list.tsx
@@ -5,7 +5,7 @@ import StackableFees from "./stackable-fees/stackable-fees";
 import { FaustId } from "../../core/utils/types/ids";
 
 interface ListProps {
-  openDetailsModalClickEvent: (faustId: string) => void;
+  openDetailsModalClickEvent: (feeId: number) => void;
   fees: FeeV2[] | null;
   dataCy: string;
   listHeader: ReactNode;
@@ -31,7 +31,6 @@ const List: FC<ListProps> = ({
             <StackableFees
               amountOfMaterialsWithDueDate={itemData.materials.length}
               item={{ faust: itemData.materials[0].recordId as FaustId }}
-              faust={itemData.materials[0].recordId as FaustId}
               materialItemNumber={itemData.materials[0].materialItemNumber}
               feeData={itemData}
               openDetailsModalClickEvent={openDetailsModalClickEvent}

--- a/src/apps/fee-list/stackable-fees/stackable-fees.tsx
+++ b/src/apps/fee-list/stackable-fees/stackable-fees.tsx
@@ -8,21 +8,18 @@ import fetchMaterial, {
 import FeeStatus from "./fee-status";
 import { useText } from "../../../core/utils/text";
 import { BasicDetailsType } from "../../../core/utils/types/basic-details-type";
-import { FaustId } from "../../../core/utils/types/ids";
 import { formatCurrency } from "../../../core/utils/helpers/currency";
 
 export interface StackableFeeProps {
   amountOfMaterialsWithDueDate: number;
   material?: BasicDetailsType;
-  faust: FaustId;
   feeData: FeeV2;
   materialItemNumber: string;
-  openDetailsModalClickEvent: (faustId: FaustId) => void;
+  openDetailsModalClickEvent: (feeId: number) => void;
 }
 
 const StackableFees: FC<StackableFeeProps & MaterialProps> = ({
   amountOfMaterialsWithDueDate,
-  faust,
   material = {},
   feeData,
   materialItemNumber,
@@ -34,31 +31,34 @@ const StackableFees: FC<StackableFeeProps & MaterialProps> = ({
   const listReservationClass = clsx(["list-reservation", "my-32"], {
     "list-reservation--stacked": stackSize > 0
   });
+
+  if (!feeData) {
+    return null;
+  }
+
   return (
     <button
       type="button"
-      onClick={() => openDetailsModalClickEvent(faust)}
+      onClick={() => openDetailsModalClickEvent(feeData.feeId)}
       onKeyUp={(e) => {
         if (e.key === "Enter" || e.key === "Space") {
-          openDetailsModalClickEvent(faust);
+          openDetailsModalClickEvent(feeData.feeId);
         }
       }}
       className={listReservationClass}
     >
-      {feeData && (
-        <FeeInfo materialItemNumber={materialItemNumber} material={material}>
-          {stackSize > 0 && (
-            <p
-              className="text-small-caption color-secondary-gray mt-8"
-              data-cy="stack-size"
-            >
-              {t("plusXOtherMaterialsText", {
-                placeholders: { "@amount": stackSize }
-              })}
-            </p>
-          )}
-        </FeeInfo>
-      )}
+      <FeeInfo materialItemNumber={materialItemNumber} material={material}>
+        {stackSize > 0 && (
+          <p
+            className="text-small-caption color-secondary-gray mt-8"
+            data-cy="stack-size"
+          >
+            {t("plusXOtherMaterialsText", {
+              placeholders: { "@amount": stackSize }
+            })}
+          </p>
+        )}
+      </FeeInfo>
       <div className="list-reservation__status">
         <FeeStatus dueDate={creationDate} reasonMessage={reasonMessage} />
         <div className="list-reservation__fee">

--- a/src/apps/fee-list/utils/helper.ts
+++ b/src/apps/fee-list/utils/helper.ts
@@ -1,8 +1,8 @@
 import { FeeV2 } from "../../../core/fbs/model";
 
-export const getFeeObjectByFaustId = (feeObj: FeeV2[], faustId: string) => {
+export const getFeeObjectByFeeId = (feeObj: FeeV2[], feeId: number) => {
   return feeObj.filter((item) => {
-    return item.materials[0].recordId === faustId;
+    return item.feeId === feeId;
   });
 };
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-411

#### Description
In this PR we start to distinguish between fees and compensations when creating fee modals.

Before, if there ever were materials that had both fees and compensations on them, clicking on either one of them would result in opening the same modal. The other item would then have incorrect items inside the modal. Creating separate modal IDs for each fee/compensation fixes this problem.

#### Screenshot of the result
-

#### Additional comments or questions
-