### PR TITLE
Differenciate between blacklistBranchesInstantLoan & pickupBlacklist

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -92,12 +92,18 @@ export const ReservationModalBody = ({
   const branches = config<AgencyBranch[]>("branchesConfig", {
     transformer: "jsonParse"
   });
-  const blacklistBranches = config("blacklistedInstantLoanBranchesConfig", {
+  const blacklistBranchesInstantLoan = config(
+    "blacklistedInstantLoanBranchesConfig",
+    {
+      transformer: "stringToArray"
+    }
+  );
+  const blacklistPickupBranches = config("blacklistedPickupBranchesConfig", {
     transformer: "stringToArray"
   });
   const whitelistBranches = excludeBlacklistedBranches(
     branches,
-    blacklistBranches
+    blacklistBranchesInstantLoan.concat(blacklistPickupBranches)
   );
 
   const mainManifestationType = getManifestationType(selectedManifestations);


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-491

#### Description
In the reservation modal - when changing between pickup branches, we didn't ask for the correct configuration - forgetting blacklistedPickupBranchesConfig branches. Now we add those on top of already used instant loan blacklisted branches, and as a result when an administrator changes this config in the backend, the changes take effect in the reservation modal as well.

#### Screenshot of the result
-
#### Additional comments or questions
-