### PR TITLE
Cleanup query map naming

### DIFF
--- a/src/core/dbc-gateway/helper.ts
+++ b/src/core/dbc-gateway/helper.ts
@@ -39,8 +39,8 @@ if (import.meta.vitest) {
       vi.mock("../utils/reduxMiddleware/extractServiceBaseUrls", async () => {
         const urls = {
           fbiBaseUrl: "i-am-fbi-url",
-          fbiSearchBaseUrl: "i-am-fbi-search-url",
-          fbiMaterialBaseUrl: "i-am-fbi-material-url"
+          fbiLocalBaseUrl: "i-am-fbi-local-url",
+          fbiGlobalBaseUrl: "i-am-fbi-global-url"
         } as const;
 
         const actual = await vi.importActual(
@@ -58,40 +58,38 @@ if (import.meta.vitest) {
 
     it("should resolve baseurl based on query name", () => {
       expect(resolveBaseUrl("complexSearchWithPagination")).toEqual(
-        "i-am-fbi-search-url"
+        "i-am-fbi-local-url"
       );
       expect(resolveBaseUrl("complexSearchWithPaginationWorkAccess")).toEqual(
-        "i-am-fbi-search-url"
+        "i-am-fbi-local-url"
       );
-      expect(resolveBaseUrl("intelligentFacets")).toEqual(
-        "i-am-fbi-search-url"
-      );
+      expect(resolveBaseUrl("intelligentFacets")).toEqual("i-am-fbi-local-url");
       expect(resolveBaseUrl("recommendFromFaust")).toEqual(
-        "i-am-fbi-search-url"
+        "i-am-fbi-local-url"
       );
-      expect(resolveBaseUrl("searchFacet")).toEqual("i-am-fbi-search-url");
+      expect(resolveBaseUrl("searchFacet")).toEqual("i-am-fbi-local-url");
       expect(resolveBaseUrl("searchWithPagination")).toEqual(
-        "i-am-fbi-search-url"
+        "i-am-fbi-local-url"
       );
       expect(resolveBaseUrl("suggestionsFromQueryString")).toEqual(
-        "i-am-fbi-search-url"
+        "i-am-fbi-local-url"
       );
-      expect(resolveBaseUrl("getInfomedia")).toEqual("i-am-fbi-material-url");
+      expect(resolveBaseUrl("getInfomedia")).toEqual("i-am-fbi-global-url");
       expect(
         resolveBaseUrl("getManifestationViaBestRepresentationByFaust")
-      ).toEqual("i-am-fbi-material-url");
+      ).toEqual("i-am-fbi-global-url");
       expect(resolveBaseUrl("getManifestationViaMaterialByFaust")).toEqual(
-        "i-am-fbi-material-url"
+        "i-am-fbi-global-url"
       );
-      expect(resolveBaseUrl("getMaterial")).toEqual("i-am-fbi-search-url");
+      expect(resolveBaseUrl("getMaterial")).toEqual("i-am-fbi-local-url");
       expect(resolveBaseUrl("getMaterialGlobally")).toEqual(
-        "i-am-fbi-material-url"
+        "i-am-fbi-global-url"
       );
       expect(resolveBaseUrl("getReviewManifestations")).toEqual(
-        "i-am-fbi-material-url"
+        "i-am-fbi-global-url"
       );
-      expect(resolveBaseUrl("getSmallWork")).toEqual("i-am-fbi-material-url");
-      expect(resolveBaseUrl("openOrder")).toEqual("i-am-fbi-material-url");
+      expect(resolveBaseUrl("getSmallWork")).toEqual("i-am-fbi-global-url");
+      expect(resolveBaseUrl("openOrder")).toEqual("i-am-fbi-global-url");
     });
 
     it("should resolve default to the fbi base url if the query is unknown", () => {

--- a/src/core/dbc-gateway/queryMap.ts
+++ b/src/core/dbc-gateway/queryMap.ts
@@ -2,23 +2,23 @@ import { serviceUrlKeys } from "../utils/reduxMiddleware/extractServiceBaseUrls"
 
 // This map is for mapping query names to FBI service base urls.
 export default {
-  // Search requests.
-  complexSearchWithPagination: serviceUrlKeys.fbiSearch,
-  complexSearchWithPaginationWorkAccess: serviceUrlKeys.fbiSearch,
-  getMaterial: serviceUrlKeys.fbiSearch,
-  intelligentFacets: serviceUrlKeys.fbiSearch,
-  recommendFromFaust: serviceUrlKeys.fbiSearch,
-  searchFacet: serviceUrlKeys.fbiSearch,
-  searchWithPagination: serviceUrlKeys.fbiSearch,
-  suggestionsFromQueryString: serviceUrlKeys.fbiSearch,
-  // Material requests.
-  getInfomedia: serviceUrlKeys.fbiMaterial,
-  getManifestationViaBestRepresentationByFaust: serviceUrlKeys.fbiMaterial,
-  getManifestationViaMaterialByFaust: serviceUrlKeys.fbiMaterial,
-  getMaterialGlobally: serviceUrlKeys.fbiMaterial,
-  getReviewManifestations: serviceUrlKeys.fbiMaterial,
-  getSmallWork: serviceUrlKeys.fbiMaterial,
-  openOrder: serviceUrlKeys.fbiMaterial,
+  // Local requests.
+  complexSearchWithPagination: serviceUrlKeys.fbiLocal,
+  complexSearchWithPaginationWorkAccess: serviceUrlKeys.fbiLocal,
+  getMaterial: serviceUrlKeys.fbiLocal,
+  intelligentFacets: serviceUrlKeys.fbiLocal,
+  recommendFromFaust: serviceUrlKeys.fbiLocal,
+  searchFacet: serviceUrlKeys.fbiLocal,
+  searchWithPagination: serviceUrlKeys.fbiLocal,
+  suggestionsFromQueryString: serviceUrlKeys.fbiLocal,
+  // Global requests.
+  getInfomedia: serviceUrlKeys.fbiGlobal,
+  getManifestationViaBestRepresentationByFaust: serviceUrlKeys.fbiGlobal,
+  getManifestationViaMaterialByFaust: serviceUrlKeys.fbiGlobal,
+  getMaterialGlobally: serviceUrlKeys.fbiGlobal,
+  getReviewManifestations: serviceUrlKeys.fbiGlobal,
+  getSmallWork: serviceUrlKeys.fbiGlobal,
+  openOrder: serviceUrlKeys.fbiGlobal,
   // All other requests.
   default: serviceUrlKeys.fbi
 } as const;

--- a/src/core/storybook/serviceUrlArgs.ts
+++ b/src/core/storybook/serviceUrlArgs.ts
@@ -32,13 +32,13 @@ export default {
     defaultValue: "https://fbi-api.dbc.dk/next-present/graphql",
     control: { type: "text" }
   },
-  [serviceUrlKeys.fbiSearch]: {
-    name: "Base url for the FBI API (search)",
+  [serviceUrlKeys.fbiLocal]: {
+    name: "Base url for the FBI API (local inventory)",
     defaultValue: "https://fbi-api.dbc.dk/next/graphql",
     control: { type: "text" }
   },
-  [serviceUrlKeys.fbiMaterial]: {
-    name: "Base url for the FBI API (material)",
+  [serviceUrlKeys.fbiGlobal]: {
+    name: "Base url for the FBI API (global inventory)",
     defaultValue: "https://fbi-api.dbc.dk/next-present/graphql",
     control: { type: "text" }
   }

--- a/src/core/utils/reduxMiddleware/extractServiceBaseUrls.ts
+++ b/src/core/utils/reduxMiddleware/extractServiceBaseUrls.ts
@@ -8,8 +8,8 @@ type Api =
   | "cover"
   | "materialList"
   | "fbi"
-  | "fbiSearch"
-  | "fbiMaterial";
+  | "fbiLocal"
+  | "fbiGlobal";
 
 export type ApiBaseUrlKey = `${Api}BaseUrl`;
 
@@ -26,8 +26,8 @@ export const serviceUrlKeys = {
   cover: "coverBaseUrl",
   materialList: "materialListBaseUrl",
   fbi: "fbiBaseUrl",
-  fbiSearch: "fbiSearchBaseUrl",
-  fbiMaterial: "fbiMaterialBaseUrl"
+  fbiLocal: "fbiLocalBaseUrl",
+  fbiGlobal: "fbiGlobalBaseUrl"
 } as const;
 
 // ServiceBaseUrls "store". We use this to store the base urls for the different services.

--- a/src/core/utils/types/global-url-props.ts
+++ b/src/core/utils/types/global-url-props.ts
@@ -10,8 +10,8 @@ interface GlobalUrlEntryPropsInterface {
   coverBaseUrl: string;
   materialBaseUrl: string;
   fbiBaseUrl: string;
-  fbiSearchBaseUrl: string;
-  fbiMaterialBaseUrl: string;
+  fbiLocalBaseUrl: string;
+  fbiGlobalBaseUrl: string;
   authUrl: string;
   ereolenHomepageUrl: string;
 }


### PR DESCRIPTION
It makes more sense to call the scopes local/global instead of search/material because local/global illustrates if the material comes from the local library inventory or the cross library inventory.

NB!!: [This](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/919) should be merged first.