### PR TITLE
Fix/availability blacklisting

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -411,7 +411,7 @@ export const isParallelReservation = (manifestations: Manifestation[]) =>
   hasCorrectAccessType(AccessTypeCode.Physical, manifestations) &&
   !isArticle(manifestations);
 
-// Because we  need to exclude the branches that are blacklisted, we need to
+// Because we need to exclude the branches that are blacklisted, we need to
 // use a custom hook to prevent duplicate code
 export const getBlacklistedQueryArgs = (
   faustIds: FaustId[],

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -411,19 +411,29 @@ export const isParallelReservation = (manifestations: Manifestation[]) =>
   hasCorrectAccessType(AccessTypeCode.Physical, manifestations) &&
   !isArticle(manifestations);
 
-// Because we  need to exclude the branches that are blacklisted, we need to use a custom hook to prevent duplicate code
+// Because we  need to exclude the branches that are blacklisted, we need to
+// use a custom hook to prevent duplicate code
 export const getBlacklistedQueryArgs = (
   faustIds: FaustId[],
   config: UseConfigFunction,
-  blacklist: "availability" | "pickup"
+  blacklist: "availability" | "pickup" | "both"
 ) => {
-  const configKey =
-    blacklist === "availability"
-      ? "blacklistedAvailabilityBranchesConfig"
-      : "blacklistedPickupBranchesConfig";
-  const blacklistBranches = config(configKey, {
+  const configKey = {
+    availability: "blacklistedAvailabilityBranchesConfig",
+    pickup: "blacklistedPickupBranchesConfig",
+    both: "blacklistedAvailabilityBranchesConfig"
+  };
+  let blacklistBranches = config(configKey[blacklist], {
     transformer: "stringToArray"
   });
+  // If we want to blacklist both availability and pickup branches we now add the
+  // complimentary blacklist
+  if (blacklist === "both") {
+    const additionalBlacklistBranches = config(configKey.pickup, {
+      transformer: "stringToArray"
+    });
+    blacklistBranches = blacklistBranches.concat(additionalBlacklistBranches);
+  }
   return {
     recordid: faustIds,
     ...(blacklistBranches ? { exclude: blacklistBranches } : {})
@@ -442,16 +452,19 @@ export const getAvailability = async ({
 export const useGetHoldings = ({
   faustIds,
   config,
+  useAvailabilityBlacklist = false,
   options
 }: {
   faustIds: FaustId[];
   config: UseConfigFunction;
+  useAvailabilityBlacklist?: boolean;
   options?: {
     query?: UseQueryOptions<Awaited<ReturnType<typeof getHoldingsV3>>>;
   };
 }) => {
+  const blacklistedBranches = useAvailabilityBlacklist ? "both" : "pickup";
   const { data, isLoading, isError } = useGetHoldingsV3(
-    getBlacklistedQueryArgs(faustIds, config, "pickup"),
+    getBlacklistedQueryArgs(faustIds, config, blacklistedBranches),
     options
   );
   return { data, isLoading, isError };

--- a/src/apps/search-header/search-header.entry.tsx
+++ b/src/apps/search-header/search-header.entry.tsx
@@ -4,6 +4,7 @@ import { withUrls } from "../../core/utils/url";
 import SearchHeader from "./search-header";
 import GlobalUrlEntryPropsInterface from "../../core/utils/types/global-url-props";
 import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
+import { GlobalConfigProps } from "../../core/storybook/globalConfigArgs";
 
 export interface SearchHeaderTextProps {
   searchHeaderIconAltText?: string;
@@ -30,6 +31,7 @@ export interface SearchHeaderTextProps {
 export interface SearchHeaderEntryProps
   extends SearchHeaderTextProps,
     GlobalEntryTextProps,
+    GlobalConfigProps,
     GlobalUrlEntryPropsInterface {}
 
 const SearchHeaderEntry: React.FC<SearchHeaderEntryProps> = () => {

--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -65,12 +65,12 @@ const SearchHeader: React.FC = () => {
     {
       render: t("autosuggestBookCategoryText"),
       term: AutosuggestCategory.book,
-      facet: "materialTypes"
+      facet: "materialTypesSpecific"
     },
     {
       render: t("autosuggestEbookCategoryText"),
       term: AutosuggestCategory.ebook,
-      facet: "materialTypes"
+      facet: "materialTypesSpecific"
     },
     {
       render: t("autosuggestFilmCategoryText"),
@@ -80,7 +80,7 @@ const SearchHeader: React.FC = () => {
     {
       render: t("autosuggestAudioBookCategoryText"),
       term: AutosuggestCategory.audioBook,
-      facet: "materialTypes"
+      facet: "materialTypesSpecific"
     },
     {
       render: t("autosuggestMusicCategoryText"),
@@ -95,7 +95,7 @@ const SearchHeader: React.FC = () => {
     {
       render: t("autosuggestAnimatedSeriesCategoryText"),
       term: AutosuggestCategory.animatedSeries,
-      facet: "materialTypes"
+      facet: "materialTypesSpecific"
     }
   ];
   // Once we register the item select event the original highlighted index is

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -90,9 +90,7 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
   useEffect(() => {
     addFilterFromUrlParamListener(FacetField.MaterialTypesSpecific);
     addFilterFromUrlParamListener(FacetField.WorkTypes);
-    // We only want to do this once, so we need the dependency array empty
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [addFilterFromUrlParamListener]);
 
   const { data, isLoading } = useSearchWithPaginationQuery({
     q: { all: q },

--- a/src/components/find-on-shelf/FindOnShelfModalBody.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModalBody.tsx
@@ -145,7 +145,7 @@ const FindOnShelfModalBody: FC<FindOnShelfModalBodyProps> = ({
         }
       )
     );
-  // "00" is the ending of beanchIds for branches that are considered main & should
+  // "00" is the ending of branchIds for branches that are considered main & should
   // be shown first independent of whether they're available.
   const finalDataMainBranchFirst = finalDataAlphabetical.sort(
     (manifestationHolding: ManifestationHoldings) => {

--- a/src/components/find-on-shelf/FindOnShelfModalBody.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModalBody.tsx
@@ -51,6 +51,7 @@ const FindOnShelfModalBody: FC<FindOnShelfModalBodyProps> = ({
   );
   const { data, isLoading } = useGetHoldings({
     faustIds: faustIdArray,
+    useAvailabilityBlacklist: true,
     config
   });
   const author = creatorsToString(flattenCreators(authors), t);
@@ -154,7 +155,24 @@ const FindOnShelfModalBody: FC<FindOnShelfModalBodyProps> = ({
         : 1;
     }
   );
-  const finalDataToShow: ManifestationHoldings[] = finalDataMainBranchFirst;
+  // Due to the way the data is structured and that we need to assemble it from
+  // two different sources, we need to filter out branches that are blacklisted
+  // even though this already happened once when fetching one half of the data.
+  const finalDataFilterOutBlacklistedBranches = finalDataMainBranchFirst.filter(
+    (libraryBranch: ManifestationHoldings) => {
+      const blacklistedBranches = config(
+        "blacklistedAvailabilityBranchesConfig",
+        {
+          transformer: "stringToArray"
+        }
+      );
+      return !blacklistedBranches.includes(
+        libraryBranch[0].holding.branch.branchId
+      );
+    }
+  );
+  const finalDataToShow: ManifestationHoldings[] =
+    finalDataFilterOutBlacklistedBranches;
 
   return (
     <>

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -142,7 +142,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
             />
           )}
         </div>
-        {/* The CTA nuttons apperently only makes sense on a global work */}
+        {/* The CTA buttons apparently only make sense on a global work */}
         {!isGlobalMaterial && showItem && (
           <>
             {isPeriodical && (

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -24,7 +24,7 @@ export const enum AutosuggestCategory {
   animatedSeries = "tegneserie"
 }
 
-export type AutosuggestCategoryFacet = "materialTypes" | "workTypes";
+export type AutosuggestCategoryFacet = "materialTypesSpecific" | "workTypes";
 
 export type AutosuggestCategoryList = {
   render: string;

--- a/src/core/utils/useReservableFromAnotherLibrary.tsx
+++ b/src/core/utils/useReservableFromAnotherLibrary.tsx
@@ -10,6 +10,7 @@ const useReservableFromAnotherLibrary = (
   const config = useConfig();
   const { data: holdingsData } = useGetHoldings({
     faustIds: getAllFaustIds(manifestations),
+    useAvailabilityBlacklist: true,
     config
   });
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-493

#### Description
This PR makes changes to fetching availability data for works - for find on shelf modal, and the reserve button on material page for materials that can be loaned from another library (overbygningsmaterialer). We forgot to take the Drupal config blacklisted availability branches into account before. 

#### Screenshot of the result
-

#### Additional comments or questions
-
