### PR TITLE
Yet another attempt at resolving issues with package install failures

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -43,18 +43,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
+          registry-url: 'https://npm.pkg.github.com'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create NPMRC
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-          echo "[@danskernesdigitalebibliotek]:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo 'registry "https://registry.yarnpkg.com"' >> ~/.yarnrc
-
-      - uses: Wandalen/wretry.action@v1.4.10
-        with:
-          command: yarn install --frozen-lockfile
-          attempt_limit: 30
-          attempt_delay: 60000
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Build artifacts
         run: yarn build

--- a/.github/workflows/create-release-on-tag.yml
+++ b/.github/workflows/create-release-on-tag.yml
@@ -28,16 +28,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
           registry-url: 'https://npm.pkg.github.com'
-          always-auth: true
-          scope: '@danskernesdigitalebibliotek'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Wandalen/wretry.action@v1.4.10
-        with:
-          command: yarn install --frozen-lockfile
-          attempt_limit: 3
-          attempt_delay: 2000
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Build artifacts
         run: yarn build


### PR DESCRIPTION
#### Description

We have repeatedly encountered problems installing new releases of the design system packages. When running yarn install we would get errors like:

```
error Error: https://npm.pkg.github.com/download/@danskernesdigitalebibliotek/dpl-design-system/2024.14.0-c34d09ae7fd2867f880dfcfd979fa295b4f9cf68/94b880305fad19177788cf3c23ac81771ba01df3: Request failed "401 Unauthorized"
```

This only occurred in GitHub Actions and only during creation of new releases based on branch or tag changes.

The changes here are yet another attempt at fixing this. They basically revert/reset the steps used to install dependencies to the ones used on all other workflows.

The assumption that this will work is based on the following observations:

- The errors only occur for the two affected workflows. All other workflows are able to download the design system without problems when running at the same time.
- This has not been a problem before the branch/tag workflow was updated in #757
- Looking at commits from the initial update of these workflows it appears as if they have been using an invalid `NODE_AUTH_TOKEN` value to begin with. We used the invalid `secrets.NPM_TOKEN` in 9338a167454f443dbcb80c2c22e1c3c5a58e298d and 9b5a2bc63e08a5606c1e53c06deadffa290576f7 when we should have used `secrets.GITHUB_TOKEN`. All other attempts at fixing this have missed this discrepancy.

#### Additional comments or questions

I do not think we can test this reliably. If accepted we will just have to merge and see.