### PR TITLE
Add a skeleton list and list item to the Fee List Page [DDFLSBP-485]

### DIFF
--- a/src/apps/fee-list/FeeList.tsx
+++ b/src/apps/fee-list/FeeList.tsx
@@ -19,6 +19,7 @@ import ListHeader from "../../components/list-header/list-header";
 import EmptyList from "../../components/empty-list/empty-list";
 import FeePaymentButton from "./FeePaymentButton";
 import { formatCurrency } from "../../core/utils/helpers/currency";
+import FeeListSkeleton from "./FeeListSkeleton";
 
 const FeeList: FC = () => {
   const t = useText();
@@ -26,7 +27,7 @@ const FeeList: FC = () => {
   const viewFeesAndCompensationRatesUrl = u("viewFeesAndCompensationRatesUrl");
   const [feeDetailsModalId, setFeeDetailsModalId] = useState("");
   const { open } = useModalButtonHandler();
-  const { data: fbsFees = [] } = useGetFeesV2<FeeV2[]>({
+  const { data: fbsFees = [], isLoading } = useGetFeesV2<FeeV2[]>({
     includepaid: false,
     includenonpayable: true
   });
@@ -68,7 +69,10 @@ const FeeList: FC = () => {
         <div className="fee-list-body__payment-button">
           <FeePaymentButton />
         </div>
-        {!fbsFees.length && (
+
+        {isLoading && <FeeListSkeleton />}
+
+        {!isLoading && !fbsFees.length && (
           <>
             <ListHeader
               header={<>{t("unpaidFeesPayableByClientHeadlineText")}</>}

--- a/src/apps/fee-list/FeeListItemSkeleton.tsx
+++ b/src/apps/fee-list/FeeListItemSkeleton.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+const FeeListItemSkeleton: React.FC = () => {
+  return (
+    <button
+      type="button"
+      className="ssc list-reservation my-32"
+      aria-label="Fee card"
+    >
+      <div className="list-reservation__material">
+        <div>
+          <div className="ssc-square cover--size-small" />
+        </div>
+        <div className="list-reservation__information">
+          <div className="ssc-head-line w-30 mb-24" />
+          <div className="ssc-head-line w-100 mb-4" />
+          <div className="ssc-line w-70 mb-4" />
+          <div className="ssc-line w-60 mb-4" />
+        </div>
+      </div>
+      <div className="list-reservation__status">
+        <div>
+          <div className="list-reservation__deadline">
+            <div className="ssc-head-line w-30" />
+            <div className="ssc-line w-80 mb-4" />
+          </div>
+        </div>
+        <div className="list-reservation__fee flex justify-end">
+          <div className="ssc-head-line w-30" />
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default FeeListItemSkeleton;

--- a/src/apps/fee-list/FeeListSkeleton.tsx
+++ b/src/apps/fee-list/FeeListSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import FeeListItemSkeleton from "./FeeListItemSkeleton";
+
+const FeeListSkeleton: React.FC = () => {
+  return (
+    <section className="ssc fee-list">
+      <h2 className="dpl-list-buttons__header" aria-label="Fee payment info">
+        <div className="ssc-head-line w-20 mt-10" />
+      </h2>
+      <FeeListItemSkeleton />
+      <FeeListItemSkeleton />
+      <div className="ssc-head-line w-20 mt-48" />
+      <FeeListItemSkeleton />
+      <FeeListItemSkeleton />
+    </section>
+  );
+};
+
+export default FeeListSkeleton;

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -110,6 +110,7 @@ describe("Fee list", () => {
 
     cy.visit("/iframe.html?path=/story/apps-fee-list--fee-list-entry");
     cy.wait(["@work"]);
+    cy.wait(["@work"]);
   });
 
   it("Fee list basics (physical loans)", () => {

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -109,11 +109,13 @@ describe("Fee list", () => {
     }).as("work");
 
     cy.visit("/iframe.html?path=/story/apps-fee-list--fee-list-entry");
-    cy.wait(["@work"]);
-    cy.wait(["@work"]);
+    cy.wait(["@fees"]);
   });
 
   it("Fee list basics (physical loans)", () => {
+    // Wait for element not in skeleton screen to prevent testing prematurely.
+    cy.get(".status-label").should("be.visible");
+
     // 2. System shows:
     // 2.a. Headline "Fees & Replacement costs"
     cy.getBySel("fee-list-page")

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -109,13 +109,10 @@ describe("Fee list", () => {
     }).as("work");
 
     cy.visit("/iframe.html?path=/story/apps-fee-list--fee-list-entry");
-    cy.wait(["@fees"]);
+    cy.wait(["@work"]);
   });
 
   it("Fee list basics (physical loans)", () => {
-    // Wait for the full page to load, ensuring we don't test on the skeleton screen, by waiting for an element that isn't present in the skeleton.
-    cy.getBySel("list-reservation__about").should("be.visible");
-
     // 2. System shows:
     // 2.a. Headline "Fees & Replacement costs"
     cy.getBySel("fee-list-page")

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -113,6 +113,9 @@ describe("Fee list", () => {
   });
 
   it("Fee list basics (physical loans)", () => {
+    // Wait for the full page to load, ensuring we don't test on the skeleton screen, by waiting for an element that isn't present in the skeleton.
+    cy.getBySel("list-reservation__about").should("be.visible");
+
     // 2. System shows:
     // 2.a. Headline "Fees & Replacement costs"
     cy.getBySel("fee-list-page")

--- a/src/apps/fee-list/stackable-fees/stackable-fees.tsx
+++ b/src/apps/fee-list/stackable-fees/stackable-fees.tsx
@@ -9,6 +9,7 @@ import FeeStatus from "./fee-status";
 import { useText } from "../../../core/utils/text";
 import { BasicDetailsType } from "../../../core/utils/types/basic-details-type";
 import { formatCurrency } from "../../../core/utils/helpers/currency";
+import FeeListItemSkeleton from "../FeeListItemSkeleton";
 
 export interface StackableFeeProps {
   amountOfMaterialsWithDueDate: number;
@@ -75,4 +76,4 @@ const StackableFees: FC<StackableFeeProps & MaterialProps> = ({
   );
 };
 
-export default fetchMaterial(StackableFees);
+export default fetchMaterial(StackableFees, FeeListItemSkeleton);


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-485

#### Description

A skeleton list view has been added while awaiting a response from FBS, and individual list items are shown as skeletons while waiting for a response from FBI.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/b91f3be1-12cf-40a0-b9da-d10ee209ba47

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/e367ed13-6e37-44f7-9074-4edde1804753

Det bemærkes at der opleves et "hop" i indholdet, dette skyldes at skrifttypen loades ind "sent"

#### Additional comments or questions
 
*