### PR TITLE
DDFFORM 497

### DIFF
--- a/src/apps/recommended-material/RecommendedMaterial.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.tsx
@@ -21,6 +21,7 @@ import { DisplayMaterialType } from "../../core/utils/types/material-type";
 import { useUrls } from "../../core/utils/url";
 import { getManifestationBasedOnType } from "../material/helper";
 import RecommendedMaterialSkeleton from "./RecommendedMaterialSkeleton";
+import Link from "../../components/atoms/links/Link";
 
 export type RecommendedMaterialProps = {
   wid: WorkId;
@@ -98,18 +99,20 @@ const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({
         shadow="medium"
       />
       <div className="recommended-material__texts">
-        <p
+        <Link
+          href={materialFullUrl}
           className="recommended-material__description"
-          data-cy="recommended-description"
+          dataCy="recommended-description"
         >
           {fullTitle}
-        </p>
-        <p
+        </Link>
+        <Link
+          href={materialFullUrl}
           className="recommended-material__author"
-          data-cy="recommended-author"
+          dataCy="recommended-author"
         >
-          {author}{" "}
-        </p>
+          {author}
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
#### Link to issue

jira : [DDFFORM-497](https://reload.atlassian.net/browse/DDFFORM-497)
#### Description

Before it was not possible to click the description text / author text in a recommended-material component. This makes it possible to click in the same way as the cover. 

[Design system  PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/579)


[DDFFORM-497]: https://reload.atlassian.net/browse/DDFFORM-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ