### PR TITLE
Show renewable loans grouped first, then non-renewable

### DIFF
--- a/src/components/GroupModal/GroupModalLoansList.tsx
+++ b/src/components/GroupModal/GroupModalLoansList.tsx
@@ -24,16 +24,20 @@ const GroupModalLoansList: FC<GroupModalLoansListProps> = ({
   selectMaterials,
   pageSize
 }) => {
+  // Show renewable materials first, then non-renewable
+  const groupedMaterials = materials.sort(
+    (a, b) => Number(!!b.isRenewable) - Number(!!a.isRenewable)
+  );
   const t = useText();
   const [displayedMaterials, setDisplayedMaterials] = useState<LoanType[]>([]);
   const { itemsShown, PagerComponent, firstInNewPage } = usePager({
-    hitcount: materials.length,
+    hitcount: groupedMaterials.length,
     pageSize
   });
 
   useEffect(() => {
-    setDisplayedMaterials([...materials].splice(0, itemsShown));
-  }, [itemsShown, materials]);
+    setDisplayedMaterials([...groupedMaterials].splice(0, itemsShown));
+  }, [itemsShown, groupedMaterials]);
 
   const onMaterialChecked = (item: ListType) => {
     const selectedMaterialsCopy = [...selectedMaterials];


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-480

#### Description
This PR groups loans in group loan modal by renewability and shows the renewable ones on top.

#### Screenshot of the result
-

#### Additional comments or questions
-
