### PR TITLE
Use the URL API for more accurate parameter handling [DDFLSBP-516]

### DIFF
--- a/src/core/modal.slice.ts
+++ b/src/core/modal.slice.ts
@@ -31,12 +31,19 @@ const returnFocusElement = () => {
   return element;
 };
 
+// Removes the 'modal' parameter from the browser's address bar.
+// If state.modalIds is not empty, adds the last modal ID as the 'modal' parameter.
 const removeModalIdFromUrl = (state: StateProps) => {
-  let newModalParam = "?";
-  if (state.modalIds?.toString() !== "") {
-    newModalParam = `?modal=${state.modalIds.toString()}`;
+  const currentUrl = new URL(window.location.href);
+
+  if (state.modalIds && state.modalIds.length > 0) {
+    const lastModalId = state.modalIds[state.modalIds.length - 1];
+    currentUrl.searchParams.set("modal", lastModalId);
+  } else {
+    currentUrl.searchParams.delete("modal");
   }
-  window.history.pushState("", "", newModalParam);
+
+  window.history.pushState({}, "", currentUrl);
 };
 
 const modalSlice = createSlice({
@@ -75,6 +82,7 @@ const modalSlice = createSlice({
     },
     closeModal(state: StateProps, action: PayloadProps) {
       const modalId = state.modalIds.pop();
+      // Check if the modalId from action payload exists in state.modalIds; if so, remove it:
       if (state.modalIds.indexOf(action.payload.modalId) > -1) {
         state.modalIds.splice(
           state.modalIds.indexOf(action.payload.modalId),


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-516

#### Description

Updates the removeModalIdFromUrl function to accurately manage the 'modal' parameter using the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL). This refactoring corrects an issue where previously the entire query string was discarded when modifying the 'modal' parameter.

#### Screenshot of the result

This demonstrates that on the search page, one can open a modal, close it again, and subsequently press F5, with the search term remaining preserved in the URL.

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/d33a1179-cce9-448b-97d5-5ae49ed20287


