### PR TITLE
Add grid modifier CSS class to `MaterialGridSkeleton`

### DIFF
--- a/src/apps/material-grid/MaterialGridSkeleton.tsx
+++ b/src/apps/material-grid/MaterialGridSkeleton.tsx
@@ -1,14 +1,18 @@
-import React from "react";
+import React, { FC } from "react";
 import RecommendedMaterialSkeleton from "../recommended-material/RecommendedMaterialSkeleton";
 
-const MaterialGridSkeleton: React.FC = () => {
+type MaterialGridSkeletonType = {
+  title?: string;
+};
+
+const MaterialGridSkeleton: FC<MaterialGridSkeletonType> = ({ title }) => {
   return (
     <div className="material-grid">
-      <div className="material-grid__title ssc-line" />
+      {title && <div className="material-grid__title">{title}</div>}
       <div className="material-grid__items">
         {[...Array(4)].map(() => (
           <div className="material-grid__item">
-            <RecommendedMaterialSkeleton />
+            <RecommendedMaterialSkeleton partOfGrid />
           </div>
         ))}
       </div>

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -29,7 +29,7 @@ const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
   });
 
   if (isLoading || !data) {
-    return <MaterialGridSkeleton />;
+    return <MaterialGridSkeleton title={title} />;
   }
 
   const resultWorks: Work[] = data.complexSearch.works as Work[];

--- a/src/apps/recommended-material/RecommendedMaterial.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.tsx
@@ -45,7 +45,7 @@ const RecommendedMaterial: React.FC<RecommendedMaterialProps> = ({
   });
 
   if (isLoading || !data?.work) {
-    return <RecommendedMaterialSkeleton />;
+    return <RecommendedMaterialSkeleton partOfGrid={partOfGrid} />;
   }
 
   const {

--- a/src/apps/recommended-material/RecommendedMaterialSkeleton.tsx
+++ b/src/apps/recommended-material/RecommendedMaterialSkeleton.tsx
@@ -1,9 +1,20 @@
-import React from "react";
+import clsx from "clsx";
+import React, { FC } from "react";
 
-const RecommendedMaterialSkeleton = () => {
+type RecommendedMaterialSkeletonType = {
+  partOfGrid?: boolean;
+};
+
+const RecommendedMaterialSkeleton: FC<RecommendedMaterialSkeletonType> = ({
+  partOfGrid
+}) => {
   return (
-    <div className="recommended-material">
-      <div className="ssc-square w-30" />
+    <div
+      className={clsx("recommended-material", {
+        "recommended-material--in-grid": partOfGrid
+      })}
+    >
+      <div className="ssc-square w-30 recommended-material__icon" />
       <div className="ssc-square image-square" />
       <div className="ssc-text-wrapper">
         <div className="ssc-line" />


### PR DESCRIPTION
#### Depend on:
https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/596

#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-490

#### Description
This pull request ensures the correct sizes for skeletons and prevents content jumping during loading. Additionally, logic has been added to not display the skeleton for the title in the grid if it is not present.

#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/0f38cf0e-32bf-4bf1-bdad-0504cc6f7a5a



https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/ac15f7aa-abad-4a44-8c17-354e83c27301

