### PR TITLE
Provide a unique key to each autosuggest category item so it rerenders

### DIFF
--- a/src/components/autosuggest-category/autosuggest-category.tsx
+++ b/src/components/autosuggest-category/autosuggest-category.tsx
@@ -40,7 +40,7 @@ const AutosuggestCategory: FC<AutosuggestCategoryProps> = ({
                 "autosuggest__text-item--highlight": highlightedIndex === index
               }
             )}
-            key={item.term + (item.work?.workId || "")}
+            key={`${item.term}-${index}`}
             {...getItemProps({ item, index })}
             data-cy={dataCy}
           >


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-489

#### Description
This PR fixes an issue where autosuggest category items from previous searches would pop up on top of the autosuggest item list. This was happening because the used React keys weren't unique, and so React was confused which items to rerender and which not to.

#### Screenshot of the result
-

#### Additional comments or questions
-