### PR TITLE
Add text under login and favorites

### DIFF
--- a/src/apps/menu/menu.dev.tsx
+++ b/src/apps/menu/menu.dev.tsx
@@ -165,6 +165,14 @@ export default {
     expirationWarningDaysBeforeConfig: {
       defaultValue: "6",
       control: { type: "text" }
+    },
+    searchHeaderLoginText: {
+      defaultValue: "Login",
+      control: { type: "text" }
+    },
+    searchHeaderFavoritesText: {
+      defaultValue: "Liked",
+      control: { type: "text" }
     }
   }
 } as ComponentMeta<typeof WrappedMenu>;

--- a/src/apps/menu/menu.entry.tsx
+++ b/src/apps/menu/menu.entry.tsx
@@ -44,6 +44,8 @@ export interface MenuProps {
   menuNotAuthenticatedModalDescriptionText: string;
   physicalLoansUrl: string;
   reservationsUrl: string;
+  searchHeaderLoginText: string;
+  searchHeaderFavoritesText: string;
 }
 
 export interface MenuEntryProps

--- a/src/apps/menu/menu.tsx
+++ b/src/apps/menu/menu.tsx
@@ -60,6 +60,11 @@ const Menu: FC<MenuProps> = ({ pageSize }) => {
             <TextLineSkeleton width={50} />
           </span>
         )}
+        {!userData?.patron?.name && (
+          <span className="text-small-caption">
+            {t("searchHeaderLoginText")}
+          </span>
+        )}
         {userData?.patron?.name && (
           <span className="text-small-caption">{userData.patron.name}</span>
         )}

--- a/src/components/search-bar/story-header.dev.inc.tsx
+++ b/src/components/search-bar/story-header.dev.inc.tsx
@@ -107,11 +107,13 @@ const StoryHeader: React.FC<StoryHeaderProps> = ({ search, userProfile }) => {
             {userProfile || (
               <div className="header__menu-profile header__button">
                 <img src={profileIcon} alt="Profile" />
+                <span className="text-small-caption">Login</span>
               </div>
             )}
             <div className="header__menu-bookmarked header__button">
               <a href="/">
                 <img src={heartIcon} alt="List of bookmarks" />
+                <span className="text-small-caption">Liked</span>
               </a>
             </div>
           </nav>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-551

#### Description
This PR adds "Login" text under the user icon when user isn't logged in, and "Liked" under the heart icon in the nav menu, introducing two new text strings in the process.

#### Screenshot of the result
-

#### Additional comments or questions
[Sibling PR in the design system](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/603)
[Sibling PR in the cms](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1028)
