### PR TITLE
Adding metadata to material page details and editions/details [DDFLSBP-543]

### DIFF
--- a/cypress/fixtures/advanced-search/fbi-api.json
+++ b/cypress/fixtures/advanced-search/fbi-api.json
@@ -4,1029 +4,626 @@
       "hitcount": 2,
       "works": [
         {
-          "workId": "work-of:870970-basis:54129807",
+          "workId": "work-of:870970-basis:135229989",
           "titles": {
-            "full": ["Harry : samtaler med prinsen"],
-            "original": ["Harry (engelsk)"]
+            "full": ["Reserven"],
+            "original": ["Spare"]
           },
           "abstract": [
-            "Gennem samtaler gives et portræt af den engelske prins Harry. Der åbnes med forlovelsen mellem Harry (f. 1984) og Meghan Markle (f. 1981). Samtalerne kredser om de store emner i Harrys liv, bl.a. prinsesse Dianas alt for tidlige død"
+            "Prins Harry fortæller om konflikten med sin far, sin bror og det engelske kongehus i bestræbelsen på at værne om sig selv og sin familie. Til alle, som interesserer sig for de europæiske kongehuse og ønsker et nuanceret syn på monarkiet som styreform."
           ],
-          "creators": [{ "display": "Angela Levin", "__typename": "Person" }],
+          "creators": [
+            {
+              "display": "Harry (prins, hertug af Sussex)",
+              "__typename": "Person"
+            }
+          ],
           "series": [],
           "seriesMembers": [],
           "workYear": null,
-          "genreAndForm": ["biografier"],
+          "genreAndForm": ["erindringer", "biografier"],
           "manifestations": {
             "all": [
               {
-                "pid": "870970-basis:54129793",
-                "genreAndForm": ["biografier"],
-                "source": ["eReolen"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "e-bog" } }
-                ],
-                "creators": [
-                  { "display": "Angela Levin", "__typename": "Person" }
-                ],
-                "publisher": ["Memoris"],
-                "identifiers": [
-                  { "value": "9788793681095" },
-                  { "value": "9788793681095" }
-                ],
-                "contributors": [{ "display": "Birgitte Brix" }],
-                "edition": {
-                  "summary": "1. udgave, 2018",
-                  "publicationYear": { "display": "2018" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 301, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "ONLINE" }],
-                "access": [
-                  {
-                    "__typename": "Ereol",
-                    "origin": "eReolen",
-                    "url": "https://ereolen.dk/ting/object/870970-basis:54129793",
-                    "canAlwaysBeLoaned": false
-                  }
-                ],
-                "shelfmark": { "postfix": "Levin", "shelfmark": "99.4 Henry" },
-                "workYear": null
-              },
-              {
-                "pid": "870970-basis:54129807",
-                "genreAndForm": ["biografier"],
+                "pid": "870970-basis:135229989",
+                "genreAndForm": ["erindringer", "biografier"],
                 "source": ["Bibliotekskatalog"],
                 "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
+                  "main": [
+                    {
+                      "display": "dansk",
+                      "isoCode": "dan"
+                    }
+                  ],
+                  "notes": []
                 },
                 "titles": {
-                  "main": ["Harry"],
-                  "original": ["Harry (engelsk)"]
+                  "main": ["Reserven"],
+                  "original": ["Spare"]
                 },
                 "fictionNonfiction": {
                   "display": "faglitteratur",
                   "code": "NONFICTION"
                 },
                 "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Angela Levin", "__typename": "Person" }
-                ],
-                "publisher": ["Memoris"],
-                "identifiers": [{ "value": "9788793681088" }],
-                "contributors": [{ "display": "Birgitte Brix" }],
-                "edition": {
-                  "summary": "1. udgave, 2018",
-                  "publicationYear": { "display": "2018" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 301, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": { "postfix": "Levin", "shelfmark": "99.4 Henry" },
-                "workYear": null
-              },
-              {
-                "pid": "870970-basis:54168446",
-                "genreAndForm": [],
-                "source": ["Netlydbog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "lydbog (online)" } }
-                ],
-                "creators": [
-                  { "display": "Angela Levin", "__typename": "Person" }
-                ],
-                "publisher": ["Memoris"],
-                "identifiers": [
-                  { "value": "9788793681132" },
-                  { "value": "9788793681132" }
-                ],
-                "contributors": [
-                  { "display": "Randi Winther" },
-                  { "display": "Birgitte Brix" }
-                ],
-                "edition": {
-                  "summary": "2018",
-                  "publicationYear": { "display": "2018" }
-                },
-                "dateFirstEdition": { "display": "2018", "year": 2018 },
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": "8 t., 37 min." }
-                ],
-                "accessTypes": [{ "code": "ONLINE" }],
-                "access": [
                   {
-                    "__typename": "Ereol",
-                    "origin": "eReolen",
-                    "url": "https://ereolen.dk/ting/object/870970-basis:54168446",
-                    "canAlwaysBeLoaned": false
+                    "materialTypeSpecific": {
+                      "display": "bog"
+                    }
                   }
                 ],
-                "shelfmark": { "postfix": "Levin", "shelfmark": "99.4 Henry" },
-                "workYear": null
-              },
-              {
-                "pid": "870970-basis:54175183",
-                "genreAndForm": [],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry (mp3)"],
-                  "original": ["Harry (engelsk)"]
-                },
-                "fictionNonfiction": {
-                  "display": "faglitteratur",
-                  "code": "NONFICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } }
-                ],
                 "creators": [
-                  { "display": "Angela Levin", "__typename": "Person" }
+                  {
+                    "display": "Harry (prins, hertug af Sussex)",
+                    "__typename": "Person"
+                  }
                 ],
-                "publisher": ["Memoris"],
-                "identifiers": [{ "value": "9788793681231" }],
+                "publisher": ["Politiken"],
+                "identifiers": [
+                  {
+                    "value": "9788740075212"
+                  }
+                ],
                 "contributors": [
-                  { "display": "Randi Winther" },
-                  { "display": "Birgitte Brix" }
+                  {
+                    "display": "Didde Gaardsted",
+                    "roles": [
+                      {
+                        "function": {
+                          "singular": "oversætter"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "display": "Carsten Norton",
+                    "roles": [
+                      {
+                        "function": {
+                          "singular": "oversætter"
+                        }
+                      }
+                    ]
+                  }
                 ],
                 "edition": {
-                  "summary": "2018",
-                  "publicationYear": { "display": "2018" }
+                  "summary": "1. udgave, 2023",
+                  "publicationYear": {
+                    "display": "2023"
+                  }
                 },
-                "dateFirstEdition": { "display": "2018", "year": 2018 },
-                "audience": { "generalAudience": [] },
+                "dateFirstEdition": null,
+                "audience": {
+                  "generalAudience": [],
+                  "ages": []
+                },
+                "notes": [],
                 "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": "8 t., 37 min." }
+                  {
+                    "summary": "576 sider",
+                    "numberOfPages": 576,
+                    "playingTime": null
+                  }
                 ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
+                "hostPublication": null,
+                "manifestationParts": null,
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
                 "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
                 ],
-                "shelfmark": { "postfix": "Levin", "shelfmark": "99.4 Henry" },
-                "workYear": null
+                "shelfmark": {
+                  "postfix": "Harry",
+                  "shelfmark": "99.4 Harry"
+                },
+                "workYear": null,
+                "catalogueCodes": {
+                  "nationalBibliography": ["DBF202305"],
+                  "otherCatalogues": [
+                    "ACF202250",
+                    "ACC202302",
+                    "BKM202305",
+                    "BKX202304"
+                  ]
+                }
               }
             ],
             "latest": {
-              "pid": "870970-basis:54175183",
-              "genreAndForm": [],
+              "pid": "870970-basis:135229989",
+              "genreAndForm": ["erindringer", "biografier"],
               "source": ["Bibliotekskatalog"],
               "languages": {
-                "main": [{ "display": "dansk", "isoCode": "dan" }]
+                "main": [
+                  {
+                    "display": "dansk",
+                    "isoCode": "dan"
+                  }
+                ],
+                "notes": []
               },
               "titles": {
-                "main": ["Harry (mp3)"],
-                "original": ["Harry (engelsk)"]
+                "main": ["Reserven"],
+                "original": ["Spare"]
               },
               "fictionNonfiction": {
                 "display": "faglitteratur",
                 "code": "NONFICTION"
               },
               "materialTypes": [
-                { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } }
+                {
+                  "materialTypeSpecific": {
+                    "display": "bog"
+                  }
+                }
               ],
               "creators": [
-                { "display": "Angela Levin", "__typename": "Person" }
+                {
+                  "display": "Harry (prins, hertug af Sussex)",
+                  "__typename": "Person"
+                }
               ],
-              "publisher": ["Memoris"],
-              "identifiers": [{ "value": "9788793681231" }],
+              "publisher": ["Politiken"],
+              "identifiers": [
+                {
+                  "value": "9788740075212"
+                }
+              ],
               "contributors": [
-                { "display": "Randi Winther" },
-                { "display": "Birgitte Brix" }
+                {
+                  "display": "Didde Gaardsted",
+                  "roles": [
+                    {
+                      "function": {
+                        "singular": "oversætter"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "display": "Carsten Norton",
+                  "roles": [
+                    {
+                      "function": {
+                        "singular": "oversætter"
+                      }
+                    }
+                  ]
+                }
               ],
               "edition": {
-                "summary": "2018",
-                "publicationYear": { "display": "2018" }
-              },
-              "dateFirstEdition": { "display": "2018", "year": 2018 },
-              "audience": { "generalAudience": [] },
-              "physicalDescriptions": [
-                { "numberOfPages": null, "playingTime": "8 t., 37 min." }
-              ],
-              "accessTypes": [{ "code": "PHYSICAL" }],
-              "access": [
-                { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-              ],
-              "shelfmark": { "postfix": "Levin", "shelfmark": "99.4 Henry" },
-              "workYear": null
-            },
-            "bestRepresentation": {
-              "pid": "870970-basis:54129807",
-              "genreAndForm": ["biografier"],
-              "source": ["Bibliotekskatalog"],
-              "languages": {
-                "main": [{ "display": "dansk", "isoCode": "dan" }]
-              },
-              "titles": { "main": ["Harry"], "original": ["Harry (engelsk)"] },
-              "fictionNonfiction": {
-                "display": "faglitteratur",
-                "code": "NONFICTION"
-              },
-              "materialTypes": [
-                { "materialTypeSpecific": { "display": "bog" } }
-              ],
-              "creators": [
-                { "display": "Angela Levin", "__typename": "Person" }
-              ],
-              "publisher": ["Memoris"],
-              "identifiers": [{ "value": "9788793681088" }],
-              "contributors": [{ "display": "Birgitte Brix" }],
-              "edition": {
-                "summary": "1. udgave, 2018",
-                "publicationYear": { "display": "2018" }
+                "summary": "1. udgave, 2023",
+                "publicationYear": {
+                  "display": "2023"
+                }
               },
               "dateFirstEdition": null,
-              "audience": { "generalAudience": [] },
+              "audience": {
+                "generalAudience": [],
+                "ages": []
+              },
+              "notes": [],
               "physicalDescriptions": [
-                { "numberOfPages": 301, "playingTime": null }
+                {
+                  "summary": "576 sider",
+                  "numberOfPages": 576,
+                  "playingTime": null
+                }
               ],
-              "accessTypes": [{ "code": "PHYSICAL" }],
+              "hostPublication": null,
+              "manifestationParts": null,
+              "accessTypes": [
+                {
+                  "code": "PHYSICAL"
+                }
+              ],
               "access": [
-                { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+                {
+                  "__typename": "InterLibraryLoan",
+                  "loanIsPossible": true
+                }
               ],
-              "shelfmark": { "postfix": "Levin", "shelfmark": "99.4 Henry" },
-              "workYear": null
+              "shelfmark": {
+                "postfix": "Harry",
+                "shelfmark": "99.4 Harry"
+              },
+              "workYear": null,
+              "catalogueCodes": {
+                "nationalBibliography": ["DBF202305"],
+                "otherCatalogues": [
+                  "ACF202250",
+                  "ACC202302",
+                  "BKM202305",
+                  "BKX202304"
+                ]
+              }
+            },
+            "bestRepresentation": {
+              "pid": "870970-basis:135229989",
+              "genreAndForm": ["erindringer", "biografier"],
+              "source": ["Bibliotekskatalog"],
+              "languages": {
+                "main": [
+                  {
+                    "display": "dansk",
+                    "isoCode": "dan"
+                  }
+                ],
+                "notes": []
+              },
+              "titles": {
+                "main": ["Reserven"],
+                "original": ["Spare"]
+              },
+              "fictionNonfiction": {
+                "display": "faglitteratur",
+                "code": "NONFICTION"
+              },
+              "materialTypes": [
+                {
+                  "materialTypeSpecific": {
+                    "display": "bog"
+                  }
+                }
+              ],
+              "creators": [
+                {
+                  "display": "Harry (prins, hertug af Sussex)",
+                  "__typename": "Person"
+                }
+              ],
+              "publisher": ["Politiken"],
+              "identifiers": [
+                {
+                  "value": "9788740075212"
+                }
+              ],
+              "contributors": [
+                {
+                  "display": "Didde Gaardsted",
+                  "roles": [
+                    {
+                      "function": {
+                        "singular": "oversætter"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "display": "Carsten Norton",
+                  "roles": [
+                    {
+                      "function": {
+                        "singular": "oversætter"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "edition": {
+                "summary": "1. udgave, 2023",
+                "publicationYear": {
+                  "display": "2023"
+                }
+              },
+              "dateFirstEdition": null,
+              "audience": {
+                "generalAudience": [],
+                "ages": []
+              },
+              "notes": [],
+              "physicalDescriptions": [
+                {
+                  "summary": "576 sider",
+                  "numberOfPages": 576,
+                  "playingTime": null
+                }
+              ],
+              "hostPublication": null,
+              "manifestationParts": null,
+              "accessTypes": [
+                {
+                  "code": "PHYSICAL"
+                }
+              ],
+              "access": [
+                {
+                  "__typename": "InterLibraryLoan",
+                  "loanIsPossible": true
+                }
+              ],
+              "shelfmark": {
+                "postfix": "Harry",
+                "shelfmark": "99.4 Harry"
+              },
+              "workYear": null,
+              "catalogueCodes": {
+                "nationalBibliography": ["DBF202305"],
+                "otherCatalogues": [
+                  "ACF202250",
+                  "ACC202302",
+                  "BKM202305",
+                  "BKX202304"
+                ]
+              }
             }
           }
         },
         {
-          "workId": "work-of:870970-basis:25245784",
+          "workId": "work-of:870970-basis:134991119",
           "titles": {
-            "full": ["Harry Potter og Fønixordenen"],
-            "original": ["Harry Potter and the Order of the Phoenix"]
+            "full": ["Spare"],
+            "original": []
           },
           "abstract": [
-            "Stor, flot og gennemillustreret udgave af bind 5 i \"Harry Potter\"-serien. Harry går stadig på kostskolen Hogwarts, men det bliver ikke et let år.  Bogen er meget velegnet til oplæsning for børn fra 8 år - og kan selvlæses fra 12 år"
+            "Before losing his mother, Diana, Princess of Wales, Prince Harry was known as the happy-to-lucky Spare to the more serious Heir. Grief changed everything. Because he blamed the press for his mother's death, he struggled to accept life in the spotlight. From the beginning, his romance with Meghan was preyed upon by the press, subjected to waves of abuse, racism, and lies. Here Prince Harry tells his own story."
           ],
           "creators": [
-            { "display": "Joanne K. Rowling", "__typename": "Person" }
-          ],
-          "series": [
             {
-              "title": "Harry Potter (bøger)",
-              "isPopular": true,
-              "numberInSeries": { "display": "5", "number": [5] },
-              "readThisFirst": null,
-              "readThisWhenever": null
+              "display": "Harry (prins, hertug af Sussex)",
+              "__typename": "Person"
             }
           ],
-          "seriesMembers": [
-            {
-              "workId": "work-of:870970-basis:22629344",
-              "titles": {
-                "main": ["Harry Potter og de vises sten"],
-                "full": ["Harry Potter og de vises sten"],
-                "original": ["Harry Potter and the philosopher's stone"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22677780",
-              "titles": {
-                "main": ["Harry Potter og Hemmelighedernes Kammer"],
-                "full": ["Harry Potter og Hemmelighedernes Kammer"],
-                "original": ["Harry Potter and the Chamber of Secrets"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:22995154",
-              "titles": {
-                "main": ["Harry Potter og fangen fra Azkaban"],
-                "full": ["Harry Potter og fangen fra Azkaban"],
-                "original": ["Harry Potter and the prisoner of Azkaban"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:23540703",
-              "titles": {
-                "main": ["Harry Potter og Flammernes Pokal"],
-                "full": ["Harry Potter og Flammernes Pokal"],
-                "original": ["Harry Potter and the goblet of fire"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25245784",
-              "titles": {
-                "main": ["Harry Potter og Fønixordenen"],
-                "full": ["Harry Potter og Fønixordenen"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:25807995",
-              "titles": {
-                "main": ["Harry Potter og halvblodsprinsen"],
-                "full": ["Harry Potter og halvblodsprinsen"],
-                "original": ["Harry Potter and the half-blood prince"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:27267912",
-              "titles": {
-                "main": ["Harry Potter og dødsregalierne"],
-                "full": ["Harry Potter og dødsregalierne"],
-                "original": ["Harry Potter and the deathly hallows"]
-              }
-            },
-            {
-              "workId": "work-of:870970-basis:52646251",
-              "titles": {
-                "main": ["Harry Potter og det forbandede barn"],
-                "full": ["Harry Potter og det forbandede barn : del et & to"],
-                "original": ["Harry Potter and the cursed child"]
-              }
-            }
-          ],
-          "workYear": { "year": 2003 },
-          "genreAndForm": [
-            "roman",
-            "fantasy",
-            "eventyrlige fortællinger",
-            "romaner"
-          ],
+          "series": [],
+          "seriesMembers": [],
+          "workYear": null,
+          "genreAndForm": ["erindringer", "biografier"],
           "manifestations": {
             "all": [
               {
-                "pid": "870970-basis:134693959",
-                "genreAndForm": ["roman", "fantasy", "romaner"],
+                "pid": "870970-basis:134991119",
+                "genreAndForm": ["erindringer", "biografier"],
                 "source": ["Bibliotekskatalog"],
                 "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
+                  "main": [
+                    {
+                      "display": "engelsk",
+                      "isoCode": "eng"
+                    }
+                  ],
+                  "notes": []
                 },
                 "titles": {
-                  "main": ["Harry Potter og Fønixordenen (Ill. Jim Kay)"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
+                  "main": ["Spare"],
+                  "original": []
                 },
                 "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
+                  "display": "faglitteratur",
+                  "code": "NONFICTION"
                 },
                 "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal"],
-                "identifiers": [{ "value": "9788702307566" }],
-                "contributors": [
-                  { "display": "Jim Kay" },
-                  { "display": "Neil Packer" },
-                  { "display": "Hanna Lützen" }
-                ],
-                "edition": {
-                  "summary": "Illustreret udgave, 7. udgave, 2022",
-                  "publicationYear": { "display": "2022" }
-                },
-                "dateFirstEdition": null,
-                "audience": {
-                  "generalAudience": [
-                    "Højtlæsning fra 8 år. Selvlæsning fra 12 år",
-                    "for højtlæsning"
-                  ]
-                },
-                "physicalDescriptions": [
-                  { "numberOfPages": 565, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:24880605",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal"],
-                "identifiers": [{ "value": "87-02-02222-2" }],
-                "contributors": [],
-                "edition": {
-                  "summary": "2003",
-                  "publicationYear": { "display": "2003" }
-                },
-                "dateFirstEdition": { "display": "2003", "year": 2003 },
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 923, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:24973670",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "lydbog (bånd)" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" },
-                  { "display": "Mikkel Schou", "__typename": "Person" }
-                ],
-                "publisher": ["Danmarks Blindebibliotek"],
-                "identifiers": [{ "value": "Best.nr. 14948" }],
-                "contributors": [{ "display": "Mikkel Schou" }],
-                "edition": {
-                  "summary": "2003",
-                  "publicationYear": { "display": "2003" }
-                },
-                "dateFirstEdition": { "display": "2003", "year": 2003 },
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": "27 t., 58 min." }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:25040007",
-                "genreAndForm": ["roman", "eventyrlige fortællinger"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "diskette" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Danmarks Blindebibliotek"],
-                "identifiers": [
-                  { "value": "Best.nr. ascii 503142" },
-                  { "value": "Best.nr. html 603142" }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2003",
-                  "publicationYear": { "display": "2003" }
-                },
-                "dateFirstEdition": { "display": "2003", "year": 2003 },
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:25082427",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendals Bogklubber"],
-                "identifiers": [{ "value": "87-03-00004-4" }],
-                "contributors": [],
-                "edition": {
-                  "summary": "1. bogklubudgave, 2004",
-                  "publicationYear": { "display": "2004" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 923, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": null
-              },
-              {
-                "pid": "870970-basis:25096517",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "punktskrift" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Danmarks Blindebibliotek"],
-                "identifiers": [{ "value": "Best.nr. 103081" }],
-                "contributors": [],
-                "edition": {
-                  "summary": "2003",
-                  "publicationYear": { "display": "2003" }
-                },
-                "dateFirstEdition": { "display": "2003", "year": 2003 },
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
                   {
-                    "__typename": "AccessUrl",
-                    "origin": "nota.dk",
-                    "url": "https://nota.dk/bibliotek/bogid/103081",
-                    "loginRequired": false
-                  },
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:25245784",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
+                    "materialTypeSpecific": {
+                      "display": "bog"
+                    }
+                  }
                 ],
                 "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal"],
-                "identifiers": [
-                  { "value": "9788702029444" },
-                  { "value": "87-02-02944-8" }
-                ],
-                "contributors": [],
-                "edition": {
-                  "summary": "2. udgave, 2004",
-                  "publicationYear": { "display": "2004" }
-                },
-                "dateFirstEdition": { "display": "2003", "year": 2003 },
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 923, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:26167663",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "lydbog (cd)" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" },
                   {
-                    "display": "Jesper Christensen (f. 1948)",
+                    "display": "Harry (prins, hertug af Sussex)",
                     "__typename": "Person"
                   }
                 ],
-                "publisher": ["Gyldendal Lyd"],
-                "identifiers": [{ "value": "87-02-04746-2" }],
-                "contributors": [],
-                "edition": {
-                  "summary": "2006",
-                  "publicationYear": { "display": "2006" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": "29 t., 33 min." }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:26470498",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendals Bogklubber"],
+                "publisher": ["Random House"],
                 "identifiers": [
-                  { "value": "9788703014807" },
-                  { "value": "87-03-01480-0" }
+                  {
+                    "value": "9780593593806"
+                  }
                 ],
                 "contributors": [],
                 "edition": {
-                  "summary": "2. bogklubudgave, 2006",
-                  "publicationYear": { "display": "2006" }
+                  "summary": "1. US edition, 2023",
+                  "publicationYear": {
+                    "display": "2023"
+                  }
                 },
                 "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
+                "audience": {
+                  "generalAudience": [],
+                  "ages": []
+                },
+                "notes": [],
                 "physicalDescriptions": [
-                  { "numberOfPages": 923, "playingTime": null }
+                  {
+                    "summary": "410 sider: ill.",
+                    "numberOfPages": 410,
+                    "playingTime": null
+                  }
                 ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
+                "hostPublication": null,
+                "manifestationParts": null,
+                "accessTypes": [
+                  {
+                    "code": "PHYSICAL"
+                  }
+                ],
                 "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+                  {
+                    "__typename": "InterLibraryLoan",
+                    "loanIsPossible": true
+                  }
                 ],
-                "shelfmark": null,
-                "workYear": null
-              },
-              {
-                "pid": "870970-basis:27639534",
-                "genreAndForm": ["roman"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
+                "shelfmark": {
+                  "postfix": "Harry",
+                  "shelfmark": "99.4 Harry"
                 },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen (mp3)"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal Lyd"],
-                "identifiers": [{ "value": "9788702075427" }],
-                "contributors": [{ "display": "Jesper Christensen (f. 1948)" }],
-                "edition": {
-                  "summary": "2009",
-                  "publicationYear": { "display": "2009" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": null, "playingTime": "29 t., 34 min." }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:29368872",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal"],
-                "identifiers": [{ "value": "9788702114393" }],
-                "contributors": [{ "display": "Hanna Lützen" }],
-                "edition": {
-                  "summary": "4. udgave, 2012",
-                  "publicationYear": { "display": "2012" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 923, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:51980204",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal"],
-                "identifiers": [{ "value": "9788702173260" }],
-                "contributors": [{ "display": "Hanna Lützen" }],
-                "edition": {
-                  "summary": "5. udgave, 2015",
-                  "publicationYear": { "display": "2015" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 841, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
-              },
-              {
-                "pid": "870970-basis:54871996",
-                "genreAndForm": ["roman", "fantasy"],
-                "source": ["Bibliotekskatalog"],
-                "languages": {
-                  "main": [{ "display": "dansk", "isoCode": "dan" }]
-                },
-                "titles": {
-                  "main": ["Harry Potter og Fønixordenen"],
-                  "original": ["Harry Potter and the Order of the Phoenix"]
-                },
-                "fictionNonfiction": {
-                  "display": "skønlitteratur",
-                  "code": "FICTION"
-                },
-                "materialTypes": [
-                  { "materialTypeSpecific": { "display": "bog" } }
-                ],
-                "creators": [
-                  { "display": "Joanne K. Rowling", "__typename": "Person" }
-                ],
-                "publisher": ["Gyldendal"],
-                "identifiers": [{ "value": "9788702272482" }],
-                "contributors": [{ "display": "Hanna Lützen" }],
-                "edition": {
-                  "summary": "6. udgave, 2018",
-                  "publicationYear": { "display": "2018" }
-                },
-                "dateFirstEdition": null,
-                "audience": { "generalAudience": [] },
-                "physicalDescriptions": [
-                  { "numberOfPages": 841, "playingTime": null }
-                ],
-                "accessTypes": [{ "code": "PHYSICAL" }],
-                "access": [
-                  { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-                ],
-                "shelfmark": null,
-                "workYear": { "year": 2003 }
+                "workYear": null,
+                "catalogueCodes": {
+                  "nationalBibliography": [],
+                  "otherCatalogues": ["OVE999999"]
+                }
               }
             ],
             "latest": {
-              "pid": "870970-basis:134693959",
-              "genreAndForm": ["roman", "fantasy", "romaner"],
+              "pid": "870970-basis:134991119",
+              "genreAndForm": ["erindringer", "biografier"],
               "source": ["Bibliotekskatalog"],
               "languages": {
-                "main": [{ "display": "dansk", "isoCode": "dan" }]
+                "main": [
+                  {
+                    "display": "engelsk",
+                    "isoCode": "eng"
+                  }
+                ],
+                "notes": []
               },
               "titles": {
-                "main": ["Harry Potter og Fønixordenen (Ill. Jim Kay)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
+                "main": ["Spare"],
+                "original": []
               },
               "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
+                "display": "faglitteratur",
+                "code": "NONFICTION"
               },
               "materialTypes": [
-                { "materialTypeSpecific": { "display": "bog" } }
+                {
+                  "materialTypeSpecific": {
+                    "display": "bog"
+                  }
+                }
               ],
               "creators": [
-                { "display": "Joanne K. Rowling", "__typename": "Person" }
+                {
+                  "display": "Harry (prins, hertug af Sussex)",
+                  "__typename": "Person"
+                }
               ],
-              "publisher": ["Gyldendal"],
-              "identifiers": [{ "value": "9788702307566" }],
-              "contributors": [
-                { "display": "Jim Kay" },
-                { "display": "Neil Packer" },
-                { "display": "Hanna Lützen" }
+              "publisher": ["Random House"],
+              "identifiers": [
+                {
+                  "value": "9780593593806"
+                }
               ],
+              "contributors": [],
               "edition": {
-                "summary": "Illustreret udgave, 7. udgave, 2022",
-                "publicationYear": { "display": "2022" }
+                "summary": "1. US edition, 2023",
+                "publicationYear": {
+                  "display": "2023"
+                }
               },
               "dateFirstEdition": null,
               "audience": {
-                "generalAudience": [
-                  "Højtlæsning fra 8 år. Selvlæsning fra 12 år",
-                  "for højtlæsning"
-                ]
+                "generalAudience": [],
+                "ages": []
               },
+              "notes": [],
               "physicalDescriptions": [
-                { "numberOfPages": 565, "playingTime": null }
+                {
+                  "summary": "410 sider: ill.",
+                  "numberOfPages": 410,
+                  "playingTime": null
+                }
               ],
-              "accessTypes": [{ "code": "PHYSICAL" }],
+              "hostPublication": null,
+              "manifestationParts": null,
+              "accessTypes": [
+                {
+                  "code": "PHYSICAL"
+                }
+              ],
               "access": [
-                { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+                {
+                  "__typename": "InterLibraryLoan",
+                  "loanIsPossible": true
+                }
               ],
-              "shelfmark": null,
-              "workYear": { "year": 2003 }
+              "shelfmark": {
+                "postfix": "Harry",
+                "shelfmark": "99.4 Harry"
+              },
+              "workYear": null,
+              "catalogueCodes": {
+                "nationalBibliography": [],
+                "otherCatalogues": ["OVE999999"]
+              }
             },
             "bestRepresentation": {
-              "pid": "870970-basis:134693959",
-              "genreAndForm": ["roman", "fantasy", "romaner"],
+              "pid": "870970-basis:134991119",
+              "genreAndForm": ["erindringer", "biografier"],
               "source": ["Bibliotekskatalog"],
               "languages": {
-                "main": [{ "display": "dansk", "isoCode": "dan" }]
+                "main": [
+                  {
+                    "display": "engelsk",
+                    "isoCode": "eng"
+                  }
+                ],
+                "notes": []
               },
               "titles": {
-                "main": ["Harry Potter og Fønixordenen (Ill. Jim Kay)"],
-                "original": ["Harry Potter and the Order of the Phoenix"]
+                "main": ["Spare"],
+                "original": []
               },
               "fictionNonfiction": {
-                "display": "skønlitteratur",
-                "code": "FICTION"
+                "display": "faglitteratur",
+                "code": "NONFICTION"
               },
               "materialTypes": [
-                { "materialTypeSpecific": { "display": "bog" } }
+                {
+                  "materialTypeSpecific": {
+                    "display": "bog"
+                  }
+                }
               ],
               "creators": [
-                { "display": "Joanne K. Rowling", "__typename": "Person" }
+                {
+                  "display": "Harry (prins, hertug af Sussex)",
+                  "__typename": "Person"
+                }
               ],
-              "publisher": ["Gyldendal"],
-              "identifiers": [{ "value": "9788702307566" }],
-              "contributors": [
-                { "display": "Jim Kay" },
-                { "display": "Neil Packer" },
-                { "display": "Hanna Lützen" }
+              "publisher": ["Random House"],
+              "identifiers": [
+                {
+                  "value": "9780593593806"
+                }
               ],
+              "contributors": [],
               "edition": {
-                "summary": "Illustreret udgave, 7. udgave, 2022",
-                "publicationYear": { "display": "2022" }
+                "summary": "1. US edition, 2023",
+                "publicationYear": {
+                  "display": "2023"
+                }
               },
               "dateFirstEdition": null,
               "audience": {
-                "generalAudience": [
-                  "Højtlæsning fra 8 år. Selvlæsning fra 12 år",
-                  "for højtlæsning"
-                ]
+                "generalAudience": [],
+                "ages": []
               },
+              "notes": [],
               "physicalDescriptions": [
-                { "numberOfPages": 565, "playingTime": null }
+                {
+                  "summary": "410 sider: ill.",
+                  "numberOfPages": 410,
+                  "playingTime": null
+                }
               ],
-              "accessTypes": [{ "code": "PHYSICAL" }],
+              "hostPublication": null,
+              "manifestationParts": null,
+              "accessTypes": [
+                {
+                  "code": "PHYSICAL"
+                }
+              ],
               "access": [
-                { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+                {
+                  "__typename": "InterLibraryLoan",
+                  "loanIsPossible": true
+                }
               ],
-              "shelfmark": null,
-              "workYear": { "year": 2003 }
+              "shelfmark": {
+                "postfix": "Harry",
+                "shelfmark": "99.4 Harry"
+              },
+              "workYear": null,
+              "catalogueCodes": {
+                "nationalBibliography": [],
+                "otherCatalogues": ["OVE999999"]
+              }
             }
           }
         }

--- a/cypress/fixtures/favorites-list/work.json
+++ b/cypress/fixtures/favorites-list/work.json
@@ -1,362 +1,7672 @@
 {
   "data": {
     "work": {
-      "workId": "work-of:870970-basis:51363035",
-      "titles": { "full": ["Mimbo Jimbo og den lange vinter"], "original": [] },
+      "workId": "work-of:870970-basis:20636866",
+      "titles": {
+        "full": ["Turen går til Rom"],
+        "original": []
+      },
       "abstract": [
-        "Billedbog. Den lille, blå elefant Mimbo Jimbo undrer sig over, at det er snevejr, nu hvor foråret burde komme. Sammen med sine venner undersøger han, hvorfor vejret opfører sig så mystisk. Det bliver en spændende rejse ud i snelandskabet"
+        "Turen Går Til Rom dækker alle de centrale kvarterer i Den Evige Stad. I det sidste kapitel er der også forslag til ture ud af byen. Den kendte dansk-italienske journalist Alfredo Tesio tager kyndigt sine læsere med på en tidsrejse gennem Roms forunderlige historie. Byen er dog meget mere end romerske søjler og barok-facader. Rom er fuld af indtryk, og bogen har derfor også mange gode bud på spisesteder, cafeer og shopping-muligheder, ligesom Alfredo Tesio viser vej til grønne parker, smukke torve og andre romantiske hjørner. TUREN GÅR TIL har eksisteret siden 1952 og er blandt verdens hyppigst opdaterede rejsebogsserier. Serien dækker hele verden fra Nordatlanten til Australien. Bøgerne skrives på dansk af forfattere og journalister med et særligt indgående kendskab til de enkelte destinationer. Med nøje udvalgte attraktioner, herunder spisesteder, viser vi vej til de største oplevelser."
       ],
-      "creators": [{ "display": "Jakob Martin Strid", "__typename": "Person" }],
+      "creators": [
+        {
+          "display": "Alfredo Tesio",
+          "__typename": "Person"
+        }
+      ],
       "series": [],
       "seriesMembers": [],
-      "workYear": { "year": 2014 },
-      "genreAndForm": ["dyrefortællinger", "sjove bøger"],
+      "workYear": null,
+      "genreAndForm": ["rejseguides", "rejseførere"],
       "manifestations": {
         "all": [
           {
-            "pid": "870970-basis:51363035",
-            "genreAndForm": ["dyrefortællinger", "sjove bøger"],
+            "pid": "300101-katalog:20636866",
+            "genreAndForm": ["rejseguides", "rejseførere"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
-              "main": ["Mimbo Jimbo og den lange vinter"],
+              "main": ["Turen går til Rom"],
               "original": []
             },
             "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
+              "display": "faglitteratur",
+              "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "billedbog" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Jakob Martin Strid", "__typename": "Person" }
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
             ],
-            "publisher": ["Gyldendal"],
-            "identifiers": [{ "value": "9788702165708" }],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
             "contributors": [],
             "edition": {
-              "summary": "1. udgave, 2014",
-              "publicationYear": { "display": "2014" }
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
             },
-            "dateFirstEdition": { "display": "2014", "year": 2014 },
-            "audience": { "generalAudience": ["for højtlæsning"] },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": 100, "playingTime": null }
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
-            "shelfmark": null,
-            "workYear": { "year": 2014 }
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
           },
           {
-            "pid": "870970-basis:51374975",
-            "genreAndForm": [],
-            "source": ["Netlydbog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "pid": "300101-katalog:22223623",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
-              "main": ["Mimbo Jimbo og den lange vinter"],
+              "main": ["Turen går til Rom"],
               "original": []
             },
             "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
+              "display": "faglitteratur",
+              "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (online)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Jakob Martin Strid", "__typename": "Person" }
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
             ],
-            "publisher": ["Gyldendal"],
+            "publisher": ["Politiken"],
             "identifiers": [
-              { "value": "9788702173475" },
-              { "value": "9788702173475" }
+              {
+                "value": "87-567-5973-8"
+              }
             ],
-            "contributors": [{ "display": "Lars Junker Thiesgaard" }],
+            "contributors": [],
             "edition": {
-              "summary": "2014",
-              "publicationYear": { "display": "2014" }
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
             },
-            "dateFirstEdition": { "display": "2014", "year": 2014 },
-            "audience": { "generalAudience": [] },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "26 min." }
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "ONLINE" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
               {
-                "__typename": "Ereol",
-                "origin": "eReolen Go",
-                "url": "https://ereolengo.dk/ting/object/870970-basis:51374975",
-                "canAlwaysBeLoaned": false
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199930"],
+              "otherCatalogues": ["SFD199930", "LIU199930"]
+            }
+          },
+          {
+            "pid": "300101-katalog:23445158",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6313-1"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2001",
+              "publicationYear": {
+                "display": "2001"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2001",
+              "year": 2001
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200224"],
+              "otherCatalogues": [
+                "ACC200115",
+                "SFD200224",
+                "DAT200118",
+                "ACC200220",
+                "DAT991149",
+                "LIU200224"
+              ]
+            }
+          },
+          {
+            "pid": "300101-katalog:28477074",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756795036"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marita Hoydal",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
               },
               {
-                "__typename": "Ereol",
-                "origin": "eReolen",
-                "url": "https://ereolen.dk/ting/object/870970-basis:51374975",
-                "canAlwaysBeLoaned": false
+                "display": "Pipaluk Balslev Fabricius",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Søren Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "25. udgave, 2010",
+              "publicationYear": {
+                "display": "2010"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201211"],
+              "otherCatalogues": ["ACC201041", "BKM201211", "DAT991605"]
+            }
+          },
+          {
+            "pid": "300151-katalog:23445158",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6313-1"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2001",
+              "publicationYear": {
+                "display": "2001"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2001",
+              "year": 2001
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200224"],
+              "otherCatalogues": [
+                "ACC200115",
+                "SFD200224",
+                "DAT200118",
+                "ACC200220",
+                "DAT991149"
+              ]
+            }
+          },
+          {
+            "pid": "300155-katalog:20636866",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "300157-katalog:20636866",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543", "DBF9543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "300175-katalog:20636866",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "300201-katalog:21417890",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835"],
+              "otherCatalogues": ["SFD199835", "DAT199635"]
+            }
+          },
+          {
+            "pid": "300250-katalog:21417890",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835", "DBF199637"],
+              "otherCatalogues": [
+                "SFD199835",
+                "DAT199635",
+                "SFD199637",
+                "DAT199635"
+              ]
+            }
+          },
+          {
+            "pid": "300316-katalog:20636866",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom. - 18. rev. udgave."],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543", "DBF9543"],
+              "otherCatalogues": ["SFD199543", "SFD9543", "BØK9404", "TKO9543"]
+            }
+          },
+          {
+            "pid": "300316-katalog:21417890",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835", "DBF9835"],
+              "otherCatalogues": [
+                "SFD199835",
+                "DAT199635",
+                "SFD9835",
+                "TKO9835",
+                "DAT9635",
+                "SKO9703",
+                "BØK9701"
+              ]
+            }
+          },
+          {
+            "pid": "300316-katalog:22223623",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5973-8"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199930", "DBF9930"],
+              "otherCatalogues": ["SFD199930", "TKO9930", "SFD9930"]
+            }
+          },
+          {
+            "pid": "300360-katalog:105536585",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
               }
             ],
             "shelfmark": null,
-            "workYear": { "year": 2014 }
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
           },
           {
-            "pid": "870970-basis:51514386",
-            "genreAndForm": [],
+            "pid": "300360-katalog:22223623",
+            "genreAndForm": ["rejseguides"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
-              "main": ["Mimbo Jimbo og den lange vinter"],
+              "main": ["Turen går til Rom"],
               "original": []
             },
             "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
+              "display": "faglitteratur",
+              "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (cd)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Jakob Martin Strid", "__typename": "Person" }
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
             ],
-            "publisher": ["Gyldendal  Lyd"],
-            "identifiers": [{ "value": "9788702174823" }],
-            "contributors": [{ "display": "Lars Junker Thiesgaard" }],
-            "edition": {
-              "summary": "2014",
-              "publicationYear": { "display": "2014" }
-            },
-            "dateFirstEdition": { "display": "2014", "year": 2014 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "26 min." }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": { "year": 2014 }
-          },
-          {
-            "pid": "870970-basis:51515951",
-            "genreAndForm": [],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["Mimbo Jimbo og den lange vinter"],
-              "original": []
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "billedbog" } }
-            ],
-            "creators": [
-              { "display": "Jakob Martin Strid", "__typename": "Person" }
-            ],
-            "publisher": ["Gyldendals Bogklubber"],
-            "identifiers": [{ "value": "9788703068077" }],
-            "contributors": [],
-            "edition": {
-              "summary": "1. bogklubudgave, 2014",
-              "publicationYear": { "display": "2014" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 100, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:53063403",
-            "genreAndForm": ["dyrefortællinger", "sjove bøger"],
-            "source": ["eReolen"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["Mimbo Jimbo og den lange vinter"],
-              "original": []
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "billedbog (online)" } }
-            ],
-            "creators": [
-              { "display": "Jakob Martin Strid", "__typename": "Person" }
-            ],
-            "publisher": ["Gyldendal"],
+            "publisher": ["Politiken"],
             "identifiers": [
-              { "value": "9788702165715" },
-              { "value": "9788702165715" }
+              {
+                "value": "87-567-5973-8"
+              }
             ],
             "contributors": [],
             "edition": {
-              "summary": "2014",
-              "publicationYear": { "display": "2014" }
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": ["for højtlæsning"] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": 100, "playingTime": null }
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "ONLINE" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
               {
-                "__typename": "Ereol",
-                "origin": "eReolen",
-                "url": "https://ereolen.dk/ting/object/870970-basis:53063403",
-                "canAlwaysBeLoaned": false
-              },
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199930"],
+              "otherCatalogues": ["SFD199930"]
+            }
+          },
+          {
+            "pid": "300360-katalog:24922197",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
               {
-                "__typename": "Ereol",
-                "origin": "eReolen Go",
-                "url": "https://ereolengo.dk/ting/object/870970-basis:53063403",
-                "canAlwaysBeLoaned": false
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2003",
+              "year": 2003
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200512"],
+              "otherCatalogues": [
+                "ACC200344",
+                "SFD200512",
+                "DAT200346",
+                "DAT200534",
+                "DAT991149"
+              ]
+            }
+          },
+          {
+            "pid": "300370-katalog:21417890",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835", "DBF9835"],
+              "otherCatalogues": [
+                "SFD199835",
+                "DAT199635",
+                "SKO9703",
+                "BØK9701"
+              ]
+            }
+          },
+          {
+            "pid": "300370-katalog:22223623",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5973-8"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199930", "DBF199930"],
+              "otherCatalogues": [
+                "SFD199930",
+                "SFD199930",
+                "SFDO199930",
+                "SFDO199930"
+              ]
+            }
+          },
+          {
+            "pid": "300430-katalog:20636866",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "300607-katalog:20636866",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1995",
+              "publicationYear": {
+                "display": "1995"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [
+                "DBF199543",
+                "DBF9427",
+                "TKO9427",
+                "BØK9404"
+              ],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "300630-katalog:22223623",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5973-8"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199930", "DBF199930"],
+              "otherCatalogues": [
+                "SFD199930",
+                "SFD199930",
+                "SFDO199930",
+                "SFDO199930"
+              ]
+            }
+          },
+          {
+            "pid": "300630-katalog:23445158",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6313-1"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2001",
+              "publicationYear": {
+                "display": "2001"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2001",
+              "year": 2001
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200224", "DBF200224"],
+              "otherCatalogues": [
+                "ACC200115",
+                "SFD200224",
+                "DAT200118",
+                "ACC200220",
+                "DAT991149",
+                "SFD200224",
+                "DAT200118",
+                "SFDO200224"
+              ]
+            }
+          },
+          {
+            "pid": "300630-katalog:24922197",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2003",
+              "year": 2003
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200512", "DBF200512"],
+              "otherCatalogues": [
+                "ACC200344",
+                "SFD200512",
+                "DAT200346",
+                "DAT200534",
+                "DAT991149",
+                "SFD200512",
+                "DAT200346",
+                "DAT200534",
+                "SFDO200512"
+              ]
+            }
+          },
+          {
+            "pid": "300657-katalog:21417890",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835"],
+              "otherCatalogues": ["SFD199835", "DAT199635"]
+            }
+          },
+          {
+            "pid": "300751-katalog:24922197",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2003",
+              "year": 2003
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200512"],
+              "otherCatalogues": [
+                "ACC200344",
+                "SFD200512",
+                "DAT200346",
+                "DAT200534",
+                "DAT991149"
+              ]
+            }
+          },
+          {
+            "pid": "300760-katalog:20636866",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "300779-katalog:21417890",
+            "genreAndForm": ["rejseguides", "rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835"],
+              "otherCatalogues": ["SFD199835", "DAT199635"]
+            }
+          },
+          {
+            "pid": "300791-katalog:20636866",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "800010-katalog:99121947434805763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756763131"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ;redaktør: Jytte Flamsholt Christensen. 1. oplag, 2001",
+              "publicationYear": {
+                "display": "2001"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens turen går til Rom",
+                  "Tidligere: 20. udgave uden seriebetegnelsen \"Politikens rejsebøger\". 1998",
+                  "Uindb"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99121986092105763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756759738"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ;redaktør: Anette Stoffersen. 2. oplag, 1999",
+              "publicationYear": {
+                "display": "1999"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Rygtitel: Rom", "Tidligere: 19. udgave. 1996"]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
               }
             ],
             "shelfmark": null,
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122013216905763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio (1945-)",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756759738"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ;redaktør: Anette Stoffersen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill., kort",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122046064205763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756773126"
+              },
+              {
+                "value": "8756773129"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "23. udgave / af Alfredo Tesio ;redaktør: Karen Lise Søndergaard og Inge-Lise Paulsen. 2. oplag, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Tidligere: 22. udgave. 2003",
+                  "1. oplag, 1. oplag",
+                  "2. oplag, 2006"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122053418405763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756781107"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "24. udgave / af Alfredo Tesio ;redaktør: Inge-Lise Paulsen. 2. oplag, 2008",
+              "publicationYear": {
+                "display": "2008"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Tidligere: 23. udgave. 2005",
+                  "1. oplag, 1. oplag"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122063844605763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756753527"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. reviderede udgave / af Alfredo Tesio ;redaktion: Lone Burmeister. 2. oplag, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Rom",
+                  "Tidligere: 17. udgave uden seriebetegnelse / af Ole Høeg og Alfredo Tesio. 1991. 144 sider"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122082120605763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756768745"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ;redaktør: Jytte Flamsholt Christensen. 1. oplag, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Tidligere: 21. udgave. 2001. 156 sider",
+                  "Uindb"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122141658205763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756781107"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "24. udgave / af Alfredo Tesio ;redaktør: Inge-Lise Paulsen. 1. oplag, 2008",
+              "publicationYear": {
+                "display": "2008"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Tidligere: 23. udgave. 2005"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122240159205763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756773126"
+              },
+              {
+                "value": "8756773129"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "23. udgave / af Alfredo Tesio ;redaktør: Karen Lise Søndergaard og Inge-Lise Paulsen. 1. oplag, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Tidligere: 22. udgave. 2003"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122335328805763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756768745"
+              },
+              {
+                "value": "8756773129"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ;redaktør: Jytte Flamsholt Christensen. 2. oplag, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Tidligere: 22. udgave. 2003. - 21. udgave. 2001. 156 sider"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver, kort",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122350081705763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politikens Forlag"],
+            "identifiers": [
+              {
+                "value": "8756756739"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 s.: ill.",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122387248205763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740025323"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "28. udgave. 1. oplag, 2018",
+              "publicationYear": {
+                "display": "2018"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              },
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122458994005763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756753527"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. reviderede udgave / af Alfredo Tesio ;redaktion: Lone Burmeister. 1. oplag, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Rom",
+                  "Tidligere: 17. udgave uden seriebetegnelse / af Ole Høeg og Alfredo Tesio. 1991. 144 sider"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122462619805763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756768745"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ;redaktør: Jytte Flamsholt Christensen. 3. oplag, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Tidligere: 21. udgave. 2001. 156 sider",
+                  "Tidligere: 22. udgave, 1. oplag, 2003"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122580786305763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756756739"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ;kort: Ulla Britze. 1. oplag, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Rom",
+                  "Tidligere: 18. udgave. 1994. 128 sider"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122715510005763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756756739"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ;kort: Ulla Britze. 2. oplag, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Rygtitel: Rom"]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122737769905763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740013115"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "27. udgave. 1. oplag, 2015",
+              "publicationYear": {
+                "display": "2015"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              },
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122887315305763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756795036"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marita Hoydal",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Pipaluk Balslev Fabricius",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Søren Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "fotograf"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "25. udgave, 2010",
+              "publicationYear": {
+                "display": "2010"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag",
+                  "Rygtitel:Politikens Turen går til Rom"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122898944205763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740003437"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Alfredo Tesio",
+                "roles": []
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Monty",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave. 1. oplag, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Rygtitel Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99122982249205763",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756759738"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ;redaktør: Anette Stoffersen. 1. oplag, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Rygtitel: Rom", "Tidligere: 19. udgave. 1996"]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "800010-katalog:99124010864505763",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740063585"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marine Gastineau",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Martin Thomas",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Thomas Linder Thomsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Trine Blak Kosteljanetz",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "29. udgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Turen",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "820050-katalog:9920592847605762",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756795036"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marita Hoydal",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Pipaluk Balslev Fabricius",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Søren Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "fotograf"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "25. udgave, 2010",
+              "publicationYear": {
+                "display": "2010"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag",
+                  "Rygtitel:Politikens Turen går til Rom"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "820050-katalog:9920603662305762",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "8756773129"
+              },
+              {
+                "value": "9788756773126"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "23. udgave / af Alfredo Tesio ;redaktør: Karen Lise Søndergaard og Inge-Lise Paulsen. 1. oplag, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "820050-katalog:9920684422705762",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740003437"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Alfredo Tesio",
+                "roles": []
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Monty",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave. 1. oplag, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "Rygtitel Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "820120-katalog:990007303440305765",
+            "genreAndForm": ["rejseførere"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740013115"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "27. udgave. 1. oplag, 2015",
+              "publicationYear": {
+                "display": "2015"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              },
+              {
+                "display": [
+                  "Rygtitel: Politikens Turen går til Rom",
+                  "1. oplag, 1. oplag"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": [],
+              "otherCatalogues": []
+            }
+          },
+          {
+            "pid": "870970-basis:138130479",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740088588"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Thomas Linder Thomsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Marine Gastineau",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Martin Thomas",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "30. udgave, 2024",
+              "publicationYear": {
+                "display": "2024"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202415"],
+              "otherCatalogues": ["ACC202412", "BKM202415", "BKX202413"]
+            }
+          },
+          {
+            "pid": "870970-basis:20636866",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5352-7"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
+              "publicationYear": {
+                "display": "1994"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "128 sider, tavler: ill. (nogle i farver)",
+                "numberOfPages": 128,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199543"],
+              "otherCatalogues": ["SFD199543"]
+            }
+          },
+          {
+            "pid": "870970-basis:21417890",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5673-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
+              "publicationYear": {
+                "display": "1996"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199835"],
+              "otherCatalogues": ["SFD199835", "DAT199635"]
+            }
+          },
+          {
+            "pid": "870970-basis:22223623",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-5973-8"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
+              "publicationYear": {
+                "display": "1998"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF199930"],
+              "otherCatalogues": ["SFD199930"]
+            }
+          },
+          {
+            "pid": "870970-basis:23445158",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6313-1"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2001",
+              "publicationYear": {
+                "display": "2001"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2001",
+              "year": 2001
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200224"],
+              "otherCatalogues": [
+                "ACC200115",
+                "SFD200224",
+                "DAT200118",
+                "ACC200220",
+                "DAT991149"
+              ]
+            }
+          },
+          {
+            "pid": "870970-basis:24922197",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2003",
+              "year": 2003
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200512"],
+              "otherCatalogues": [
+                "ACC200344",
+                "SFD200512",
+                "DAT200346",
+                "DAT200534",
+                "DAT991149"
+              ]
+            }
+          },
+          {
+            "pid": "870970-basis:26019109",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756773126"
+              },
+              {
+                "value": "87-567-7312-9"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "23. udgave / af Alfredo Tesio ; redaktør: Karen Lise Søndergaard og Inge-Lise Paulsen ; kort: Ulla Britze, 2005",
+              "publicationYear": {
+                "display": "2005"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200709"],
+              "otherCatalogues": [
+                "ACC200547",
+                "SFD200709",
+                "DAT200748",
+                "DAT991149"
+              ]
+            }
+          },
+          {
+            "pid": "870970-basis:27173640",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756781107"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "24. udgave / af Alfredo Tesio ; redaktør: Inge-Lise Paulsen ; kort: Britze, 2008",
+              "publicationYear": {
+                "display": "2008"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201008"],
+              "otherCatalogues": ["BKM201008", "ACC200810", "DAT201029"]
+            }
+          },
+          {
+            "pid": "870970-basis:28477074",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756795036"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marita Hoydal",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Pipaluk Balslev Fabricius",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Søren Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "25. udgave, 2010",
+              "publicationYear": {
+                "display": "2010"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201211"],
+              "otherCatalogues": ["ACC201041", "BKM201211", "DAT991605"]
+            }
+          },
+          {
+            "pid": "870970-basis:29798079",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740003437"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Monty",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201427"],
+              "otherCatalogues": ["ACC201305", "BKM201427"]
+            }
+          },
+          {
+            "pid": "870970-basis:47077435",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "lydbog (online)"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740059311"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Karen Abrahamsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "indlæser"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "2019",
+              "publicationYear": {
+                "display": "2019"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Delvis gengivelse af bogen",
+                  "Indlæst efter 28. udgave. 2018. ISBN: 9788740025323"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "80 min.",
+                "numberOfPages": null,
+                "playingTime": "80 min."
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DLF201940"],
+              "otherCatalogues": ["ACC201936", "BKM201940"]
+            }
+          },
+          {
+            "pid": "870970-basis:50690601",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "e-bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740010671"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Monty",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201401"],
+              "otherCatalogues": [
+                "ACC201350",
+                "BKM201401",
+                "DAT201405",
+                "DAT201505",
+                "DAT991505",
+                "DAT201512",
+                "DAT201513",
+                "DAT201525",
+                "DAT991608"
+              ]
+            }
+          },
+          {
+            "pid": "870970-basis:51634764",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740013115"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "27. udgave, 2015",
+              "publicationYear": {
+                "display": "2015"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201636"],
+              "otherCatalogues": ["ACC201511", "BKM201636", "BKX201512"]
+            }
+          },
+          {
+            "pid": "870970-basis:51658256",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "e-bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740018493"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "1. e-bogsudgave, 2015",
+              "publicationYear": {
+                "display": "2015"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201523"],
+              "otherCatalogues": [
+                "ACC201521",
+                "BKM201523",
+                "DAT201617",
+                "DAT991608"
+              ]
+            }
+          },
+          {
+            "pid": "870970-basis:53787495",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "e-bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740025316"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Monty",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "Ny e-bogsudgave, 2017",
+              "publicationYear": {
+                "display": "2017"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              }
+            ],
+            "physicalDescriptions": [],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201806"],
+              "otherCatalogues": ["BKM201806", "ACC201750"]
+            }
+          },
+          {
+            "pid": "870970-basis:53976018",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740025323"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "28. udgave, 2018",
+              "publicationYear": {
+                "display": "2018"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201810"],
+              "otherCatalogues": ["ACC201807", "BKX201809", "BKM201810"]
+            }
+          },
+          {
+            "pid": "870970-basis:61809988",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "e-bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740067156"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Trine Blak Kosteljanetz",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "4. e-bogsudgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202207"],
+              "otherCatalogues": ["ACC202148", "BKM202207"]
+            }
+          },
+          {
+            "pid": "870970-basis:61991484",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740063585"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marine Gastineau",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Martin Thomas",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Thomas Linder Thomsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Trine Blak Kosteljanetz",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "29. udgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202207"],
+              "otherCatalogues": ["ACF202202", "ACC202203", "BKM202207"]
+            }
+          },
+          {
+            "pid": "870970-basis:62820586",
+            "genreAndForm": [],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "lydbog (online)"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740067163"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Paul Becker",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "indlæser"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Trine Blak Kosteljanetz",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "2022",
+              "publicationYear": {
+                "display": "2022"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Gengivelse af bogen",
+                  "Indlæst efter 29. udgave. 2021. ISBN: 9788740063585"
+                ]
+              }
+            ],
+            "physicalDescriptions": [
+              {
+                "summary": "80 min.",
+                "numberOfPages": null,
+                "playingTime": "80 min."
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
+            "access": [],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DLF202236"],
+              "otherCatalogues": ["ACC202224", "BKM202236"]
+            }
+          },
+          {
+            "pid": "876040-katalog:23445158",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6313-1"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2001",
+              "publicationYear": {
+                "display": "2001"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2001",
+              "year": 2001
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "156 sider: ill. i farver",
+                "numberOfPages": 156,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200224", "DBF200119"],
+              "otherCatalogues": [
+                "ACC200115",
+                "SFD200224",
+                "DAT200118",
+                "ACC200220",
+                "DAT991149",
+                "SFD200119",
+                "DAT200118"
+              ]
+            }
+          },
+          {
+            "pid": "876040-katalog:27173640",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788756781107"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "24. udgave / af Alfredo Tesio ; redaktør: Inge-Lise Paulsen ; kort: Britze, 2008",
+              "publicationYear": {
+                "display": "2008"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201008", "DBF200922"],
+              "otherCatalogues": [
+                "BKM201008",
+                "ACC200810",
+                "DAT201029",
+                "BKM200922"
+              ]
+            }
+          },
+          {
+            "pid": "876040-katalog:29798079",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740003437"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Monty",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "26. udgave, 2013",
+              "publicationYear": {
+                "display": "2013"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201427", "DBF201307"],
+              "otherCatalogues": [
+                "ACC201305",
+                "BKM201427",
+                "BKM201307",
+                "BKX201306"
+              ]
+            }
+          },
+          {
+            "pid": "911116-katalog:61991484",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "9788740063585"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Marine Gastineau",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Martin Thomas",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Thomas Linder Thomsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Trine Blak Kosteljanetz",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "29. udgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202207"],
+              "otherCatalogues": ["ACF202202", "ACC202203", "BKM202207"]
+            }
+          },
+          {
+            "pid": "911130-katalog:24922197",
+            "genreAndForm": ["rejseguides"],
+            "source": ["Bibliotekskatalog"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
+            "fictionNonfiction": {
+              "display": "faglitteratur",
+              "code": "NONFICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Politiken"],
+            "identifiers": [
+              {
+                "value": "87-567-6874-5"
+              }
+            ],
+            "contributors": [],
+            "edition": {
+              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2003",
+              "publicationYear": {
+                "display": "2003"
+              }
+            },
+            "dateFirstEdition": {
+              "display": "2003",
+              "year": 2003
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF200512"],
+              "otherCatalogues": [
+                "ACC200344",
+                "SFD200512",
+                "DAT200346",
+                "DAT200534",
+                "DAT991149",
+                "dgl89"
+              ]
+            }
           }
         ],
         "latest": {
-          "pid": "870970-basis:53063403",
-          "genreAndForm": ["dyrefortællinger", "sjove bøger"],
-          "source": ["eReolen"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "pid": "870970-basis:138130479",
+          "genreAndForm": ["rejseguides"],
+          "source": ["Bibliotekskatalog"],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
-            "main": ["Mimbo Jimbo og den lange vinter"],
+            "main": ["Turen går til Rom"],
             "original": []
           },
           "fictionNonfiction": {
-            "display": "skønlitteratur",
-            "code": "FICTION"
+            "display": "faglitteratur",
+            "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "billedbog (online)" } }
-          ],
-          "creators": [
-            { "display": "Jakob Martin Strid", "__typename": "Person" }
-          ],
-          "publisher": ["Gyldendal"],
-          "identifiers": [
-            { "value": "9788702165715" },
-            { "value": "9788702165715" }
-          ],
-          "contributors": [],
-          "edition": {
-            "summary": "2014",
-            "publicationYear": { "display": "2014" }
-          },
-          "dateFirstEdition": null,
-          "audience": { "generalAudience": ["for højtlæsning"] },
-          "physicalDescriptions": [
-            { "numberOfPages": 100, "playingTime": null }
-          ],
-          "accessTypes": [{ "code": "ONLINE" }],
-          "access": [
             {
-              "__typename": "Ereol",
-              "origin": "eReolen",
-              "url": "https://ereolen.dk/ting/object/870970-basis:53063403",
-              "canAlwaysBeLoaned": false
-            },
-            {
-              "__typename": "Ereol",
-              "origin": "eReolen Go",
-              "url": "https://ereolengo.dk/ting/object/870970-basis:53063403",
-              "canAlwaysBeLoaned": false
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
             }
           ],
-          "shelfmark": null,
-          "workYear": null
+          "creators": [
+            {
+              "display": "Alfredo Tesio",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": ["Politiken"],
+          "identifiers": [
+            {
+              "value": "9788740088588"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Thomas Linder Thomsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Marine Gastineau",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Martin Thomas",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Britze",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Susan Bergqvist",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            }
+          ],
+          "edition": {
+            "summary": "30. udgave, 2024",
+            "publicationYear": {
+              "display": "2024"
+            }
+          },
+          "dateFirstEdition": null,
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
+          "physicalDescriptions": [
+            {
+              "summary": "168 sider: ill. i farver",
+              "numberOfPages": 168,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Tesio",
+            "shelfmark": "47.57 Rom"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DBF202415"],
+            "otherCatalogues": ["ACC202412", "BKM202415", "BKX202413"]
+          }
         },
         "bestRepresentation": {
-          "pid": "870970-basis:51363035",
-          "genreAndForm": ["dyrefortællinger", "sjove bøger"],
+          "pid": "870970-basis:138130479",
+          "genreAndForm": ["rejseguides"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
-            "main": ["Mimbo Jimbo og den lange vinter"],
+            "main": ["Turen går til Rom"],
             "original": []
           },
           "fictionNonfiction": {
-            "display": "skønlitteratur",
-            "code": "FICTION"
+            "display": "faglitteratur",
+            "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "billedbog" } }
+            {
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
+            }
           ],
           "creators": [
-            { "display": "Jakob Martin Strid", "__typename": "Person" }
+            {
+              "display": "Alfredo Tesio",
+              "__typename": "Person"
+            }
           ],
-          "publisher": ["Gyldendal"],
-          "identifiers": [{ "value": "9788702165708" }],
-          "contributors": [],
+          "publisher": ["Politiken"],
+          "identifiers": [
+            {
+              "value": "9788740088588"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Thomas Linder Thomsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Marine Gastineau",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Martin Thomas",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Britze",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Susan Bergqvist",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            }
+          ],
           "edition": {
-            "summary": "1. udgave, 2014",
-            "publicationYear": { "display": "2014" }
+            "summary": "30. udgave, 2024",
+            "publicationYear": {
+              "display": "2024"
+            }
           },
-          "dateFirstEdition": { "display": "2014", "year": 2014 },
-          "audience": { "generalAudience": ["for højtlæsning"] },
+          "dateFirstEdition": null,
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
           "physicalDescriptions": [
-            { "numberOfPages": 100, "playingTime": null }
+            {
+              "summary": "168 sider: ill. i farver",
+              "numberOfPages": 168,
+              "playingTime": null
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
-          "shelfmark": null,
-          "workYear": { "year": 2014 }
+          "shelfmark": {
+            "postfix": "Tesio",
+            "shelfmark": "47.57 Rom"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DBF202415"],
+            "otherCatalogues": ["ACC202412", "BKM202415", "BKX202413"]
+          }
         }
-      },
-      "materialTypes": [
-        { "materialTypeSpecific": { "display": "lydbog (cd)" } },
-        { "materialTypeSpecific": { "display": "billedbog" } },
-        { "materialTypeSpecific": { "display": "billedbog (online)" } },
-        { "materialTypeSpecific": { "display": "lydbog (online)" } }
-      ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
-      "subjects": {
-        "all": [
-          { "display": "venner" },
-          { "display": "vejret" },
-          { "display": "årstider" },
-          { "display": "dyrefortællinger" },
-          { "display": "sjove bøger" },
-          { "display": "Børnebøger" }
-        ],
-        "dbcVerified": [
-          { "display": "venner" },
-          { "display": "vejret" },
-          { "display": "årstider" },
-          { "display": "dyrefortællinger" },
-          { "display": "sjove bøger" }
-        ]
-      },
-      "fictionNonfiction": { "display": "skønlitteratur", "code": "FICTION" },
-      "dk5MainEntry": { "display": "Skønlitteratur" },
-      "relations": {
-        "hasReview": [
-          { "pid": "150005-anmeld:79708" },
-          { "pid": "870976-anmeld:129442158" },
-          { "pid": "870971-anmeld:36617012" },
-          { "pid": "870971-anmeld:36278676" }
-        ],
-        "hasAdaptation": []
       }
     }
   }

--- a/cypress/fixtures/material-buttons/material-buttons-fbi-api.json
+++ b/cypress/fixtures/material-buttons/material-buttons-fbi-api.json
@@ -7,14 +7,22 @@
         "original": ["The seven sisters"]
       },
       "abstract": [
-        "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav"
+        "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav."
       ],
-      "creators": [{ "display": "Lucinda Riley", "__typename": "Person" }],
+      "creators": [
+        {
+          "display": "Lucinda Riley",
+          "__typename": "Person"
+        }
+      ],
       "series": [
         {
           "title": "De syv søstre-serien",
           "isPopular": true,
-          "numberInSeries": { "display": "1", "number": [1] },
+          "numberInSeries": {
+            "display": "1",
+            "number": [1]
+          },
           "readThisFirst": true,
           "readThisWhenever": null
         }
@@ -90,82 +98,18 @@
       "manifestations": {
         "all": [
           {
-            "pid": "870970-basis:46615743",
-            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Cicero"],
-            "identifiers": [{ "value": "9788763863285" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "3. udgave, 2019",
-              "publicationYear": { "display": "2019" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
             "pid": "870970-basis:52557240",
             "genreAndForm": ["roman", "slægtsromaner"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
             },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Cicero"],
-            "identifiers": [{ "value": "9788763844116" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "1. udgave, 2016",
-              "publicationYear": { "display": "2016" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:52590302",
-            "genreAndForm": ["roman", "slægtsromaner"],
-            "source": ["eReolen"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
             "titles": {
               "main": ["De syv søstre"],
               "original": ["The seven sisters"]
@@ -175,25 +119,150 @@
               "code": "FICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Cicero"],
             "identifiers": [
-              { "value": "9788763844123" },
-              { "value": "9788763844123" }
+              {
+                "value": "9788763844116"
+              }
             ],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "oversætter"
+                    }
+                  }
+                ]
+              }
+            ],
             "edition": {
-              "summary": "1. eBogsudgave, 2016",
-              "publicationYear": { "display": "2016" }
+              "summary": "1. udgave, 2016",
+              "publicationYear": {
+                "display": "2016"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "523 sider",
+                "numberOfPages": 523,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201835"],
+              "otherCatalogues": ["ACC201634", "BKM201835"]
+            }
+          },
+          {
+            "pid": "870970-basis:52590302",
+            "genreAndForm": ["roman", "slægtsromaner"],
+            "source": ["eReolen"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
+            },
+            "fictionNonfiction": {
+              "display": "skønlitteratur",
+              "code": "FICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "e-bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Cicero"],
+            "identifiers": [
+              {
+                "value": "9788763844123"
+              },
+              {
+                "value": "9788763844123"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "oversætter"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "1. eBogsudgave, 2016",
+              "publicationYear": {
+                "display": "2016"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [],
-            "accessTypes": [{ "code": "ONLINE" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
             "access": [
               {
                 "__typename": "Ereol",
@@ -203,13 +272,30 @@
               }
             ],
             "shelfmark": null,
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201639"],
+              "otherCatalogues": [
+                "ACC201636",
+                "BKM201639",
+                "ERE202235",
+                "DAT201713"
+              ]
+            }
           },
           {
             "pid": "870970-basis:52643414",
             "genreAndForm": ["roman"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
               "main": ["De syv søstre (mp3)"],
               "original": ["The seven sisters"]
@@ -219,242 +305,390 @@
               "code": "FICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "lydbog (cd-mp3)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Rosinante"],
-            "identifiers": [{ "value": "9788763850636" }],
+            "identifiers": [
+              {
+                "value": "9788763850636"
+              }
+            ],
             "contributors": [
-              { "display": "Maria Stokholm" },
-              { "display": "Ulla Lauridsen" }
+              {
+                "display": "Maria Stokholm",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "indlæser"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "oversætter"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
               "summary": "1. lydbogsudgave, 2016",
-              "publicationYear": { "display": "2016" }
+              "publicationYear": {
+                "display": "2016"
+              }
             },
-            "dateFirstEdition": { "display": "2016", "year": 2016 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "16 t., 30 min." }
+            "dateFirstEdition": {
+              "display": "2016",
+              "year": 2016
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Gengivelse af bogen",
+                  "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+                ]
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "physicalDescriptions": [
+              {
+                "summary": "1 cd i 1 mappe (mp3) 16 t., 30 min.",
+                "numberOfPages": null,
+                "playingTime": "16 t., 30 min."
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
             "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:52643503",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (online)" } }
-            ],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Rosinante"],
-            "identifiers": [{ "value": "9788763847995" }],
-            "contributors": [
-              { "display": "Maria Stokholm" },
-              { "display": "Ulla Lauridsen" }
-            ],
-            "edition": {
-              "summary": "2016",
-              "publicationYear": { "display": "2016" }
-            },
-            "dateFirstEdition": { "display": "2016", "year": 2016 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "16 t., 30 min." }
-            ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:53200346",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Gyldendals Bogklubber"],
-            "identifiers": [{ "value": "9788703079875" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "1. bogklubudgave, 2017",
-              "publicationYear": { "display": "2017" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:53292968",
-            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Cicero"],
-            "identifiers": [{ "value": "9788763849630" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "2. udgave, 2017",
-              "publicationYear": { "display": "2017" }
-            },
-            "dateFirstEdition": { "display": "2016", "year": 2016 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DLF201642"],
+              "otherCatalogues": ["BKM201642", "DAT201713"]
+            }
           }
         ],
         "latest": {
-          "pid": "870970-basis:46615743",
-          "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+          "pid": "870970-basis:52643414",
+          "genreAndForm": ["roman"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
-            "main": ["De syv søstre"],
+            "main": ["De syv søstre (mp3)"],
             "original": ["The seven sisters"]
           },
           "fictionNonfiction": {
             "display": "skønlitteratur",
             "code": "FICTION"
           },
-          "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-          "creators": [{ "display": "Lucinda Riley", "__typename": "Person" }],
-          "publisher": ["Cicero"],
-          "identifiers": [{ "value": "9788763863285" }],
-          "contributors": [{ "display": "Ulla Lauridsen" }],
-          "edition": {
-            "summary": "3. udgave, 2019",
-            "publicationYear": { "display": "2019" }
-          },
-          "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [
-            { "numberOfPages": 523, "playingTime": null }
+          "materialTypes": [
+            {
+              "materialTypeSpecific": {
+                "display": "lydbog (cd-mp3)"
+              }
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "creators": [
+            {
+              "display": "Lucinda Riley",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": ["Rosinante"],
+          "identifiers": [
+            {
+              "value": "9788763850636"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Maria Stokholm",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "indlæser"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Lauridsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "oversætter"
+                  }
+                }
+              ]
+            }
+          ],
+          "edition": {
+            "summary": "1. lydbogsudgave, 2016",
+            "publicationYear": {
+              "display": "2016"
+            }
+          },
+          "dateFirstEdition": {
+            "display": "2016",
+            "year": 2016
+          },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": [
+                "Gengivelse af bogen",
+                "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+              ]
+            }
+          ],
+          "physicalDescriptions": [
+            {
+              "summary": "1 cd i 1 mappe (mp3) 16 t., 30 min.",
+              "numberOfPages": null,
+              "playingTime": "16 t., 30 min."
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
           "shelfmark": null,
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DLF201642"],
+            "otherCatalogues": ["BKM201642", "DAT201713"]
+          }
         },
         "bestRepresentation": {
-          "pid": "870970-basis:46615743",
-          "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+          "pid": "870970-basis:52643414",
+          "genreAndForm": ["roman"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
-            "main": ["De syv søstre"],
+            "main": ["De syv søstre (mp3)"],
             "original": ["The seven sisters"]
           },
           "fictionNonfiction": {
             "display": "skønlitteratur",
             "code": "FICTION"
           },
-          "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-          "creators": [{ "display": "Lucinda Riley", "__typename": "Person" }],
-          "publisher": ["Cicero"],
-          "identifiers": [{ "value": "9788763863285" }],
-          "contributors": [{ "display": "Ulla Lauridsen" }],
-          "edition": {
-            "summary": "3. udgave, 2019",
-            "publicationYear": { "display": "2019" }
-          },
-          "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [
-            { "numberOfPages": 523, "playingTime": null }
+          "materialTypes": [
+            {
+              "materialTypeSpecific": {
+                "display": "lydbog (cd-mp3)"
+              }
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "creators": [
+            {
+              "display": "Lucinda Riley",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": ["Rosinante"],
+          "identifiers": [
+            {
+              "value": "9788763850636"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Maria Stokholm",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "indlæser"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Lauridsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "oversætter"
+                  }
+                }
+              ]
+            }
+          ],
+          "edition": {
+            "summary": "1. lydbogsudgave, 2016",
+            "publicationYear": {
+              "display": "2016"
+            }
+          },
+          "dateFirstEdition": {
+            "display": "2016",
+            "year": 2016
+          },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": [
+                "Gengivelse af bogen",
+                "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+              ]
+            }
+          ],
+          "physicalDescriptions": [
+            {
+              "summary": "1 cd i 1 mappe (mp3) 16 t., 30 min.",
+              "numberOfPages": null,
+              "playingTime": "16 t., 30 min."
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
           "shelfmark": null,
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DLF201642"],
+            "otherCatalogues": ["BKM201642", "DAT201713"]
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "bog" } },
-        { "materialTypeSpecific": { "display": "lydbog (online)" } },
-        { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } },
-        { "materialTypeSpecific": { "display": "e-bog" } }
+        {
+          "materialTypeSpecific": {
+            "display": "lydbog (cd-mp3)"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "e-bog"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "bog"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "kærlighed" },
-          { "display": "adoption" },
-          { "display": "familien" },
-          { "display": "slægtsromaner" }
+          {
+            "display": "kærlighed"
+          },
+          {
+            "display": "adoption"
+          },
+          {
+            "display": "familien"
+          },
+          {
+            "display": "slægtsromaner"
+          }
         ],
         "dbcVerified": [
-          { "display": "kærlighed" },
-          { "display": "adoption" },
-          { "display": "familien" },
-          { "display": "slægtsromaner" }
+          {
+            "display": "kærlighed"
+          },
+          {
+            "display": "adoption"
+          },
+          {
+            "display": "familien"
+          },
+          {
+            "display": "slægtsromaner"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "skønlitteratur", "code": "FICTION" },
-      "dk5MainEntry": { "display": "Skønlitteratur" },
+      "fictionNonfiction": {
+        "display": "skønlitteratur",
+        "code": "FICTION"
+      },
+      "dk5MainEntry": {
+        "display": "Skønlitteratur"
+      },
       "relations": {
         "hasReview": [
-          { "pid": "150005-anmeld:81092" },
-          { "pid": "870976-anmeld:129471824" },
-          { "pid": "870971-anmeld:37104132" }
+          {
+            "pid": "150005-anmeld:81092"
+          },
+          {
+            "pid": "870976-anmeld:129471824"
+          },
+          {
+            "pid": "870971-anmeld:37104132"
+          }
         ],
         "hasAdaptation": []
       }

--- a/cypress/fixtures/material-buttons/material-buttons-infomedia-fbi-api.json
+++ b/cypress/fixtures/material-buttons/material-buttons-infomedia-fbi-api.json
@@ -2,13 +2,22 @@
   "data": {
     "work": {
       "workId": "work-of:870971-avis:35731733",
-      "titles": { "full": ["Butlerens utrolige historie"], "original": [] },
+      "titles": {
+        "full": ["Butlerens utrolige historie"],
+        "original": []
+      },
       "abstract": [
-        "Filmen ' The Butler' tager afsæt i en avisartikel, der blev til under usædvanlige omstændigheder. Politiken har talt med Wil Haygood, Washington Post-journalisten, der gik på jagt efter en person, der havde arbejdet i Det Hvide Hus i raceadskillelsens tid - og fandt Eugene Allen"
+        "Filmen ' The Butler' tager afsæt i en avisartikel, der blev til under usædvanlige omstændigheder. Politiken har talt med Wil Haygood, Washington Post-journalisten, der gik på jagt efter en person, der havde arbejdet i Det Hvide Hus i raceadskillelsens tid - og fandt Eugene Allen."
       ],
       "creators": [
-        { "display": "Jakob Nielsen", "__typename": "Person" },
-        { "display": "Will Haygood", "__typename": "Person" }
+        {
+          "display": "Will Haygood",
+          "__typename": "Person"
+        },
+        {
+          "display": "Jakob Nielsen",
+          "__typename": "Person"
+        }
       ],
       "series": [],
       "seriesMembers": [],
@@ -20,7 +29,15 @@
             "pid": "870971-avis:35731733",
             "genreAndForm": [],
             "source": ["Avisartikler"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
               "main": ["Butlerens utrolige historie"],
               "original": []
@@ -30,142 +47,336 @@
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "artikel" } },
-              { "materialTypeSpecific": { "display": "artikel (online)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "artikel"
+                }
+              },
+              {
+                "materialTypeSpecific": {
+                  "display": "artikel (online)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Jakob Nielsen", "__typename": "Person" },
-              { "display": "Will Haygood", "__typename": "Person" }
+              {
+                "display": "Will Haygood",
+                "__typename": "Person"
+              },
+              {
+                "display": "Jakob Nielsen",
+                "__typename": "Person"
+              }
             ],
             "publisher": [],
             "identifiers": [],
             "contributors": [],
             "edition": {
               "summary": "2013",
-              "publicationYear": { "display": "2013" }
+              "publicationYear": {
+                "display": "2013"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": 2, "playingTime": null }
+              {
+                "summary": "Sektion 3, s. 6-7: ill.",
+                "numberOfPages": 2,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
+            "hostPublication": {
+              "summary": "Politiken, 2013-09-19"
+            },
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              },
+              {
+                "code": "ONLINE"
+              }
+            ],
             "access": [
-              { "__typename": "InfomediaService", "id": "e3fba430" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InfomediaService",
+                "id": "e3fba430"
+              }
             ],
             "shelfmark": {
               "postfix": "Butlerens",
               "shelfmark": "99.4 Allen, Eugene"
             },
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["ABU201339", "DAR201339"],
+              "otherCatalogues": []
+            }
           }
         ],
         "latest": {
           "pid": "870971-avis:35731733",
           "genreAndForm": [],
           "source": ["Avisartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Butlerens utrolige historie"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Butlerens utrolige historie"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "faglitteratur",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } },
-            { "materialTypeSpecific": { "display": "artikel (online)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            },
+            {
+              "materialTypeSpecific": {
+                "display": "artikel (online)"
+              }
+            }
           ],
           "creators": [
-            { "display": "Jakob Nielsen", "__typename": "Person" },
-            { "display": "Will Haygood", "__typename": "Person" }
+            {
+              "display": "Will Haygood",
+              "__typename": "Person"
+            },
+            {
+              "display": "Jakob Nielsen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2013",
-            "publicationYear": { "display": "2013" }
+            "publicationYear": {
+              "display": "2013"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 2, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
+          "physicalDescriptions": [
+            {
+              "summary": "Sektion 3, s. 6-7: ill.",
+              "numberOfPages": 2,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Politiken, 2013-09-19"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            },
+            {
+              "code": "ONLINE"
+            }
+          ],
           "access": [
-            { "__typename": "InfomediaService", "id": "e3fba430" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InfomediaService",
+              "id": "e3fba430"
+            }
           ],
           "shelfmark": {
             "postfix": "Butlerens",
             "shelfmark": "99.4 Allen, Eugene"
           },
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201339", "DAR201339"],
+            "otherCatalogues": []
+          }
         },
         "bestRepresentation": {
           "pid": "870971-avis:35731733",
           "genreAndForm": [],
           "source": ["Avisartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Butlerens utrolige historie"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Butlerens utrolige historie"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "faglitteratur",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } },
-            { "materialTypeSpecific": { "display": "artikel (online)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            },
+            {
+              "materialTypeSpecific": {
+                "display": "artikel (online)"
+              }
+            }
           ],
           "creators": [
-            { "display": "Jakob Nielsen", "__typename": "Person" },
-            { "display": "Will Haygood", "__typename": "Person" }
+            {
+              "display": "Will Haygood",
+              "__typename": "Person"
+            },
+            {
+              "display": "Jakob Nielsen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2013",
-            "publicationYear": { "display": "2013" }
+            "publicationYear": {
+              "display": "2013"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 2, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
+          "physicalDescriptions": [
+            {
+              "summary": "Sektion 3, s. 6-7: ill.",
+              "numberOfPages": 2,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Politiken, 2013-09-19"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            },
+            {
+              "code": "ONLINE"
+            }
+          ],
           "access": [
-            { "__typename": "InfomediaService", "id": "e3fba430" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InfomediaService",
+              "id": "e3fba430"
+            }
           ],
           "shelfmark": {
             "postfix": "Butlerens",
             "shelfmark": "99.4 Allen, Eugene"
           },
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201339", "DAR201339"],
+            "otherCatalogues": []
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "artikel" } },
-        { "materialTypeSpecific": { "display": "artikel (online)" } }
+        {
+          "materialTypeSpecific": {
+            "display": "artikel (online)"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "artikel"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "USA" },
-          { "display": "Det Hvide Hus" },
-          { "display": "sorte" },
-          { "display": "hvide" },
-          { "display": "raceadskillelse" },
-          { "display": "Eugene Allen" }
+          {
+            "display": "sorte mennesker"
+          },
+          {
+            "display": "hvide mennesker"
+          },
+          {
+            "display": "raceadskillelse"
+          },
+          {
+            "display": "USA"
+          },
+          {
+            "display": "Det Hvide Hus"
+          },
+          {
+            "display": "Eugene Allen"
+          }
         ],
         "dbcVerified": [
-          { "display": "USA" },
-          { "display": "Det Hvide Hus" },
-          { "display": "sorte" },
-          { "display": "hvide" },
-          { "display": "raceadskillelse" },
-          { "display": "Eugene Allen" }
+          {
+            "display": "sorte mennesker"
+          },
+          {
+            "display": "hvide mennesker"
+          },
+          {
+            "display": "raceadskillelse"
+          },
+          {
+            "display": "USA"
+          },
+          {
+            "display": "Det Hvide Hus"
+          },
+          {
+            "display": "Eugene Allen"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "faglitteratur", "code": "NONFICTION" },
-      "dk5MainEntry": { "display": "99.4 Allen, Eugene" },
-      "relations": { "hasReview": [], "hasAdaptation": [] }
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "99.4 Allen, Eugene"
+      },
+      "relations": {
+        "hasReview": [],
+        "hasAdaptation": []
+      }
     }
   }
 }

--- a/cypress/fixtures/material-buttons/material-buttons-movie-fbi-api.json
+++ b/cypress/fixtures/material-buttons/material-buttons-movie-fbi-api.json
@@ -2,14 +2,18 @@
   "data": {
     "work": {
       "workId": "work-of:870970-basis:46555902",
-      "titles": { "full": ["Underverden"], "original": [] },
+      "titles": {
+        "full": ["Underverden"],
+        "original": ["Underverden"]
+      },
       "abstract": [
-        "Zaid er læge, hjertespecialist, med et godt job. Han har en dyr lejlighed, og en gravid kæreste. Under en fest opsøges Zaid af sin desperate lillebror Yasin, som beder om penge. Zaid afviser Yasin i døren. Kort efter findes lillebror Yasin død"
+        "Zaid er læge, hjertespecialist, med et godt job. Han har en dyr lejlighed, og en gravid kæreste. Under en fest opsøges Zaid af sin desperate lillebror Yasin, som beder om penge. Zaid afviser Yasin i døren. Kort efter findes lillebror Yasin død."
       ],
       "creators": [
-        { "display": "Fenar Ahmad", "__typename": "Person" },
-        { "display": "Adam August", "__typename": "Person" },
-        { "display": "Kasper Tuxen", "__typename": "Person" }
+        {
+          "display": "Fenar Ahmad",
+          "__typename": "Person"
+        }
       ],
       "series": [],
       "seriesMembers": [],
@@ -18,178 +22,507 @@
       "manifestations": {
         "all": [
           {
-            "pid": "870970-basis:46555902",
-            "genreAndForm": ["actionfilm"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Underverden"], "original": [] },
-            "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "film (blu-ray 4K)" } }
-            ],
-            "creators": [
-              { "display": "Fenar Ahmad", "__typename": "Person" },
-              { "display": "Adam August", "__typename": "Person" },
-              { "display": "Kasper Tuxen", "__typename": "Person" }
-            ],
-            "publisher": [
-              "Universal Sony Pictures Home Entertainment Nordic",
-              "Scanbox Entertainment Denmark"
-            ],
-            "identifiers": [{ "value": "1209-11 K 0" }],
-            "contributors": [
-              { "display": "Dar Salim" },
-              { "display": "Stine Fisher Christensen" },
-              { "display": "Ali Sivandi" },
-              { "display": "Dulfi Al-Jabouri" },
-              { "display": "Roland Møller" },
-              { "display": "Jacob Hauberg Lohmann" },
-              { "display": "B. Branco" }
-            ],
-            "edition": {
-              "summary": "2017",
-              "publicationYear": { "display": "2017" }
-            },
-            "dateFirstEdition": null,
-            "audience": {
-              "generalAudience": ["Mærkning: Tilladt for børn over 15 år"]
-            },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "113 min." }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Underverden", "shelfmark": "77.7" },
-            "workYear": null
-          },
-          {
             "pid": "870970-basis:52886619",
             "genreAndForm": ["actionfilm"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Underverden"], "original": [] },
-            "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": ["Undertekster på dansk"]
+            },
+            "titles": {
+              "main": ["Underverden"],
+              "original": ["Underverden"]
+            },
+            "fictionNonfiction": {
+              "display": "fiktion",
+              "code": "FICTION"
+            },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "film (dvd)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "film (dvd)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Fenar Ahmad", "__typename": "Person" },
-              { "display": "Adam August", "__typename": "Person" },
-              { "display": "Kasper Tuxen", "__typename": "Person" }
+              {
+                "display": "Fenar Ahmad",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Scanbox Entertainment Denmark"],
-            "identifiers": [{ "value": "1209-11 D 0" }],
+            "identifiers": [
+              {
+                "value": "1209-11 D 0"
+              }
+            ],
             "contributors": [
-              { "display": "Dar Salim" },
-              { "display": "Stine Fisher Christensen" },
-              { "display": "Ali Sivandi" },
-              { "display": "Dulfi Al-Jabouri" },
-              { "display": "Roland Møller" },
-              { "display": "Jacob Hauberg Lohmann" },
-              { "display": "B. Branco" }
+              {
+                "display": "Adam August",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "manuskript"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Tuxen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "filmfotograf"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Dar Salim",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Stine Fisher Christensen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ali Sivandi",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Dulfi Al-Jabouri",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Roland Møller",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Jacob Hauberg Lohmann",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "B. Branco",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
               "summary": "2017",
-              "publicationYear": { "display": "2017" }
+              "publicationYear": {
+                "display": "2017"
+              }
             },
             "dateFirstEdition": null,
             "audience": {
-              "generalAudience": ["Mærkning: Tilladt for børn over 15 år"]
+              "generalAudience": [],
+              "ages": []
             },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "ca. 109 min." }
+              {
+                "summary": "1 dvd-video ca. 109 min.",
+                "numberOfPages": null,
+                "playingTime": "ca. 109 min."
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
-            "shelfmark": { "postfix": "Underverden", "shelfmark": "77.7" },
-            "workYear": null
+            "shelfmark": {
+              "postfix": "Underverden",
+              "shelfmark": "77.7"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBI201728"],
+              "otherCatalogues": ["ACC201722", "BKM201728"]
+            }
           },
           {
             "pid": "870970-basis:53205747",
             "genreAndForm": ["actionfilm"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Underverden"], "original": [] },
-            "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": ["Undertekster på dansk"]
+            },
+            "titles": {
+              "main": ["Underverden"],
+              "original": ["Underverden"]
+            },
+            "fictionNonfiction": {
+              "display": "fiktion",
+              "code": "FICTION"
+            },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "film (blu-ray)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "film (blu-ray)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Fenar Ahmad", "__typename": "Person" },
-              { "display": "Adam August", "__typename": "Person" },
-              { "display": "Kasper Tuxen", "__typename": "Person" }
+              {
+                "display": "Fenar Ahmad",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Scanbox Entertainment Denmark"],
-            "identifiers": [{ "value": "1209-11 N 0" }],
+            "identifiers": [
+              {
+                "value": "1209-11 N 0"
+              }
+            ],
             "contributors": [
-              { "display": "Dar Salim" },
-              { "display": "Stine Fisher Christensen" },
-              { "display": "Ali Sivandi" },
-              { "display": "Dulfi Al-Jabouri" },
-              { "display": "Roland Møller" },
-              { "display": "Jacob Hauberg Lohmann" },
-              { "display": "B. Branco" }
+              {
+                "display": "Adam August",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "manuskript"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Tuxen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "filmfotograf"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Dar Salim",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Stine Fisher Christensen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ali Sivandi",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Dulfi Al-Jabouri",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Roland Møller",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Jacob Hauberg Lohmann",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "B. Branco",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
               "summary": "2017",
-              "publicationYear": { "display": "2017" }
+              "publicationYear": {
+                "display": "2017"
+              }
             },
             "dateFirstEdition": null,
             "audience": {
-              "generalAudience": ["Mærkning: Tilladt for børn over 15 år"]
+              "generalAudience": [],
+              "ages": []
             },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "ca. 113 min." }
+              {
+                "summary": "1 disc (blu-ray) ca. 113 min.",
+                "numberOfPages": null,
+                "playingTime": "ca. 113 min."
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
-            "shelfmark": { "postfix": "Underverden", "shelfmark": "77.7" },
-            "workYear": null
+            "shelfmark": {
+              "postfix": "Underverden",
+              "shelfmark": "77.7"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBI201728"],
+              "otherCatalogues": ["ACC201722", "BKM201728"]
+            }
           },
           {
             "pid": "870970-basis:53369936",
             "genreAndForm": ["actionfilm"],
             "source": ["Filmstriben"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Underverden"], "original": [] },
-            "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": ["Undertekster på dansk"]
+            },
+            "titles": {
+              "main": ["Underverden"],
+              "original": ["Underverden"]
+            },
+            "fictionNonfiction": {
+              "display": "fiktion",
+              "code": "FICTION"
+            },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "film (online)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "film (online)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Fenar Ahmad", "__typename": "Person" },
-              { "display": "Adam August", "__typename": "Person" },
-              { "display": "Kasper Tuxen", "__typename": "Person" }
+              {
+                "display": "Fenar Ahmad",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Scanbox"],
             "identifiers": [],
             "contributors": [
-              { "display": "Dar Salim" },
-              { "display": "Stine Fisher Christensen" },
-              { "display": "Ali Sivandi" },
-              { "display": "Dulfi Al-Jabouri" },
-              { "display": "Roland Møller" },
-              { "display": "Jacob Hauberg Lohmann" },
-              { "display": "B. Branco" }
+              {
+                "display": "Adam August",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "manuskript"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Kasper Tuxen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "filmfotograf"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Dar Salim",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Stine Fisher Christensen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ali Sivandi",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Dulfi Al-Jabouri",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Roland Møller",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Jacob Hauberg Lohmann",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "B. Branco",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "skuespiller"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
               "summary": "2017",
-              "publicationYear": { "display": "2017" }
+              "publicationYear": {
+                "display": "2017"
+              }
             },
             "dateFirstEdition": null,
             "audience": {
-              "generalAudience": ["Mærkning: Tilladt for børn over 15 år"]
+              "generalAudience": [],
+              "ages": []
             },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "Ca. 113 min." }
+              {
+                "summary": "Ca. 113 min.",
+                "numberOfPages": null,
+                "playingTime": "Ca. 113 min."
+              }
             ],
-            "accessTypes": [{ "code": "ONLINE" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
             "access": [
               {
                 "__typename": "AccessUrl",
@@ -198,147 +531,490 @@
                 "loginRequired": false
               }
             ],
-            "shelfmark": { "postfix": "Underverden", "shelfmark": "77.7" },
-            "workYear": null
+            "shelfmark": {
+              "postfix": "Underverden",
+              "shelfmark": "77.7"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBI201737"],
+              "otherCatalogues": [
+                "ACC201729",
+                "BKM201737",
+                "FSF201737",
+                "DAT201844"
+              ]
+            }
           }
         ],
         "latest": {
-          "pid": "870970-basis:46555902",
+          "pid": "870970-basis:53369936",
           "genreAndForm": ["actionfilm"],
-          "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Underverden"], "original": [] },
-          "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
+          "source": ["Filmstriben"],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": ["Undertekster på dansk"]
+          },
+          "titles": {
+            "main": ["Underverden"],
+            "original": ["Underverden"]
+          },
+          "fictionNonfiction": {
+            "display": "fiktion",
+            "code": "FICTION"
+          },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "film (blu-ray 4K)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "film (online)"
+              }
+            }
           ],
           "creators": [
-            { "display": "Fenar Ahmad", "__typename": "Person" },
-            { "display": "Adam August", "__typename": "Person" },
-            { "display": "Kasper Tuxen", "__typename": "Person" }
+            {
+              "display": "Fenar Ahmad",
+              "__typename": "Person"
+            }
           ],
-          "publisher": [
-            "Universal Sony Pictures Home Entertainment Nordic",
-            "Scanbox Entertainment Denmark"
-          ],
-          "identifiers": [{ "value": "1209-11 K 0" }],
+          "publisher": ["Scanbox"],
+          "identifiers": [],
           "contributors": [
-            { "display": "Dar Salim" },
-            { "display": "Stine Fisher Christensen" },
-            { "display": "Ali Sivandi" },
-            { "display": "Dulfi Al-Jabouri" },
-            { "display": "Roland Møller" },
-            { "display": "Jacob Hauberg Lohmann" },
-            { "display": "B. Branco" }
+            {
+              "display": "Adam August",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "manuskript"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Kasper Tuxen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "filmfotograf"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Dar Salim",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Stine Fisher Christensen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ali Sivandi",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Dulfi Al-Jabouri",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Roland Møller",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Jacob Hauberg Lohmann",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "B. Branco",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            }
           ],
           "edition": {
             "summary": "2017",
-            "publicationYear": { "display": "2017" }
+            "publicationYear": {
+              "display": "2017"
+            }
           },
           "dateFirstEdition": null,
           "audience": {
-            "generalAudience": ["Mærkning: Tilladt for børn over 15 år"]
+            "generalAudience": [],
+            "ages": []
           },
+          "notes": [],
           "physicalDescriptions": [
-            { "numberOfPages": null, "playingTime": "113 min." }
+            {
+              "summary": "Ca. 113 min.",
+              "numberOfPages": null,
+              "playingTime": "Ca. 113 min."
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "ONLINE"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "AccessUrl",
+              "origin": "www.filmstriben.dk",
+              "url": "http://www.filmstriben.dk/fjernleje/film/details.aspx?id=9000004315",
+              "loginRequired": false
+            }
           ],
-          "shelfmark": { "postfix": "Underverden", "shelfmark": "77.7" },
-          "workYear": null
+          "shelfmark": {
+            "postfix": "Underverden",
+            "shelfmark": "77.7"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DBI201737"],
+            "otherCatalogues": [
+              "ACC201729",
+              "BKM201737",
+              "FSF201737",
+              "DAT201844"
+            ]
+          }
         },
         "bestRepresentation": {
-          "pid": "870970-basis:46555902",
+          "pid": "870970-basis:53369936",
           "genreAndForm": ["actionfilm"],
-          "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Underverden"], "original": [] },
-          "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
+          "source": ["Filmstriben"],
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": ["Undertekster på dansk"]
+          },
+          "titles": {
+            "main": ["Underverden"],
+            "original": ["Underverden"]
+          },
+          "fictionNonfiction": {
+            "display": "fiktion",
+            "code": "FICTION"
+          },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "film (blu-ray 4K)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "film (online)"
+              }
+            }
           ],
           "creators": [
-            { "display": "Fenar Ahmad", "__typename": "Person" },
-            { "display": "Adam August", "__typename": "Person" },
-            { "display": "Kasper Tuxen", "__typename": "Person" }
+            {
+              "display": "Fenar Ahmad",
+              "__typename": "Person"
+            }
           ],
-          "publisher": [
-            "Universal Sony Pictures Home Entertainment Nordic",
-            "Scanbox Entertainment Denmark"
-          ],
-          "identifiers": [{ "value": "1209-11 K 0" }],
+          "publisher": ["Scanbox"],
+          "identifiers": [],
           "contributors": [
-            { "display": "Dar Salim" },
-            { "display": "Stine Fisher Christensen" },
-            { "display": "Ali Sivandi" },
-            { "display": "Dulfi Al-Jabouri" },
-            { "display": "Roland Møller" },
-            { "display": "Jacob Hauberg Lohmann" },
-            { "display": "B. Branco" }
+            {
+              "display": "Adam August",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "manuskript"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Kasper Tuxen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "filmfotograf"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Dar Salim",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Stine Fisher Christensen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ali Sivandi",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Dulfi Al-Jabouri",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Roland Møller",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Jacob Hauberg Lohmann",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "B. Branco",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "skuespiller"
+                  }
+                }
+              ]
+            }
           ],
           "edition": {
             "summary": "2017",
-            "publicationYear": { "display": "2017" }
+            "publicationYear": {
+              "display": "2017"
+            }
           },
           "dateFirstEdition": null,
           "audience": {
-            "generalAudience": ["Mærkning: Tilladt for børn over 15 år"]
+            "generalAudience": [],
+            "ages": []
           },
+          "notes": [],
           "physicalDescriptions": [
-            { "numberOfPages": null, "playingTime": "113 min." }
+            {
+              "summary": "Ca. 113 min.",
+              "numberOfPages": null,
+              "playingTime": "Ca. 113 min."
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "ONLINE"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "AccessUrl",
+              "origin": "www.filmstriben.dk",
+              "url": "http://www.filmstriben.dk/fjernleje/film/details.aspx?id=9000004315",
+              "loginRequired": false
+            }
           ],
-          "shelfmark": { "postfix": "Underverden", "shelfmark": "77.7" },
-          "workYear": null
+          "shelfmark": {
+            "postfix": "Underverden",
+            "shelfmark": "77.7"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DBI201737"],
+            "otherCatalogues": [
+              "ACC201729",
+              "BKM201737",
+              "FSF201737",
+              "DAT201844"
+            ]
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "film (blu-ray 4K)" } },
-        { "materialTypeSpecific": { "display": "film (online)" } },
-        { "materialTypeSpecific": { "display": "film (dvd)" } },
-        { "materialTypeSpecific": { "display": "film (blu-ray)" } }
+        {
+          "materialTypeSpecific": {
+            "display": "film (online)"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "film (blu-ray)"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "film (dvd)"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "danske film" },
-          { "display": "selvtægt" },
-          { "display": "indvandrere" },
-          { "display": "brødre" },
-          { "display": "bander" },
-          { "display": "kriminalitet" },
-          { "display": "bandekriminalitet" },
-          { "display": "København" },
-          { "display": "actionfilm" }
+          {
+            "display": "danske film"
+          },
+          {
+            "display": "selvtægt"
+          },
+          {
+            "display": "indvandrere"
+          },
+          {
+            "display": "brødre"
+          },
+          {
+            "display": "bander"
+          },
+          {
+            "display": "kriminalitet"
+          },
+          {
+            "display": "bandekriminalitet"
+          },
+          {
+            "display": "København"
+          },
+          {
+            "display": "actionfilm"
+          }
         ],
         "dbcVerified": [
-          { "display": "selvtægt" },
-          { "display": "indvandrere" },
-          { "display": "brødre" },
-          { "display": "bander" },
-          { "display": "kriminalitet" },
-          { "display": "bandekriminalitet" },
-          { "display": "København" },
-          { "display": "actionfilm" }
+          {
+            "display": "selvtægt"
+          },
+          {
+            "display": "indvandrere"
+          },
+          {
+            "display": "brødre"
+          },
+          {
+            "display": "bander"
+          },
+          {
+            "display": "kriminalitet"
+          },
+          {
+            "display": "bandekriminalitet"
+          },
+          {
+            "display": "København"
+          },
+          {
+            "display": "actionfilm"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "fiktion", "code": "FICTION" },
-      "dk5MainEntry": { "display": "77.7 Spillefilm" },
+      "fictionNonfiction": {
+        "display": "fiktion",
+        "code": "FICTION"
+      },
+      "dk5MainEntry": {
+        "display": "77.7 Spillefilm"
+      },
       "relations": {
         "hasReview": [
-          { "pid": "870976-anmeld:129681799" },
-          { "pid": "870971-anmeld:37307394" },
-          { "pid": "870971-anmeld:37249955" },
-          { "pid": "870971-anmeld:37247405" },
-          { "pid": "870971-anmeld:37249998" },
-          { "pid": "870971-anmeld:37248029" },
-          { "pid": "870971-anmeld:37321664" },
-          { "pid": "870971-anmeld:37247782" }
+          {
+            "pid": "870976-anmeld:129681799"
+          },
+          {
+            "pid": "870971-anmeld:37307394"
+          },
+          {
+            "pid": "870971-anmeld:37249955"
+          },
+          {
+            "pid": "870971-anmeld:37247405"
+          },
+          {
+            "pid": "870971-anmeld:37249998"
+          },
+          {
+            "pid": "870971-anmeld:37248029"
+          },
+          {
+            "pid": "870971-anmeld:37321664"
+          },
+          {
+            "pid": "870971-anmeld:37247782"
+          }
         ],
         "hasAdaptation": []
       }

--- a/cypress/fixtures/material-buttons/material-buttons-order-digital-fbi-api.json
+++ b/cypress/fixtures/material-buttons/material-buttons-order-digital-fbi-api.json
@@ -6,28 +6,23 @@
         "full": ["Faglig formidling er ikke kun skriveteknik"],
         "original": []
       },
-      "abstract": ["Om skriftlig formidling af faglig viden til ikke-fagfolk"],
-      "creators": [{ "display": "Leif Becker Jensen", "__typename": "Person" }],
+      "abstract": ["Om skriftlig formidling af faglig viden til ikke-fagfolk."],
+      "creators": [
+        {
+          "display": "Leif Becker Jensen",
+          "__typename": "Person"
+        }
+      ],
       "series": [
         {
           "title": "Skriftlig faglig formidling",
-          "isPopular": null,
+          "isPopular": false,
           "numberInSeries": null,
           "readThisFirst": null,
           "readThisWhenever": null
         }
       ],
       "seriesMembers": [
-        {
-          "workId": "work-of:870971-tsart:34310831",
-          "titles": {
-            "main": ["Skal det være så svært at lære at skrive godt?"],
-            "full": [
-              "Skal det være så svært at lære at skrive godt? : om at træne grundlæggende skrivekompetencer med udgangspunkt i en konkret tværfaglig skriveopgave i dansk og matematik"
-            ],
-            "original": []
-          }
-        },
         {
           "workId": "work-of:870971-tsart:34310858",
           "titles": {
@@ -49,6 +44,16 @@
           }
         },
         {
+          "workId": "work-of:870971-tsart:34310831",
+          "titles": {
+            "main": ["Skal det være så svært at lære at skrive godt?"],
+            "full": [
+              "Skal det være så svært at lære at skrive godt? : om at træne grundlæggende skrivekompetencer med udgangspunkt i en konkret tværfaglig skriveopgave i dansk og matematik"
+            ],
+            "original": []
+          }
+        },
+        {
           "workId": "work-of:870971-tsart:34310815",
           "titles": {
             "main": ["Faglig formidling er ikke kun skriveteknik"],
@@ -65,7 +70,15 @@
             "pid": "870971-tsart:34310815",
             "genreAndForm": [],
             "source": ["Tidsskriftsartikler"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
               "main": ["Faglig formidling er ikke kun skriveteknik"],
               "original": []
@@ -75,37 +88,87 @@
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "artikel" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "artikel"
+                }
+              }
             ],
             "creators": [
-              { "display": "Leif Becker Jensen", "__typename": "Person" }
+              {
+                "display": "Leif Becker Jensen",
+                "__typename": "Person"
+              }
             ],
             "publisher": [],
             "identifiers": [],
             "contributors": [],
             "edition": {
               "summary": "2010",
-              "publicationYear": { "display": "2010" }
+              "publicationYear": {
+                "display": "2010"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med litteraturhenvisninger"]
+              }
+            ],
             "physicalDescriptions": [
-              { "numberOfPages": 6, "playingTime": null }
+              {
+                "summary": "S. 8-13: ill.",
+                "numberOfPages": 6,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "hostPublication": {
+              "summary": "Dansk noter, Nr. 3 (2010)"
+            },
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "DigitalArticleService", "issn": "01071424" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "DigitalArticleService",
+                "issn": "01071424"
+              },
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
-            "shelfmark": { "postfix": "Faglig", "shelfmark": "19.1" },
-            "workYear": null
+            "shelfmark": {
+              "postfix": "Faglig",
+              "shelfmark": "19.1"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["ABU201042", "DAR201042"],
+              "otherCatalogues": []
+            }
           }
         ],
         "latest": {
           "pid": "870971-tsart:34310815",
           "genreAndForm": [],
           "source": ["Tidsskriftsartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
             "main": ["Faglig formidling er ikke kun skriveteknik"],
             "original": []
@@ -115,34 +178,86 @@
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            }
           ],
           "creators": [
-            { "display": "Leif Becker Jensen", "__typename": "Person" }
+            {
+              "display": "Leif Becker Jensen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2010",
-            "publicationYear": { "display": "2010" }
+            "publicationYear": {
+              "display": "2010"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 6, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "01071424" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["Med litteraturhenvisninger"]
+            }
           ],
-          "shelfmark": { "postfix": "Faglig", "shelfmark": "19.1" },
-          "workYear": null
+          "physicalDescriptions": [
+            {
+              "summary": "S. 8-13: ill.",
+              "numberOfPages": 6,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Dansk noter, Nr. 3 (2010)"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "01071424"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Faglig",
+            "shelfmark": "19.1"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201042", "DAR201042"],
+            "otherCatalogues": []
+          }
         },
         "bestRepresentation": {
           "pid": "870971-tsart:34310815",
           "genreAndForm": [],
           "source": ["Tidsskriftsartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
             "main": ["Faglig formidling er ikke kun skriveteknik"],
             "original": []
@@ -152,51 +267,134 @@
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            }
           ],
           "creators": [
-            { "display": "Leif Becker Jensen", "__typename": "Person" }
+            {
+              "display": "Leif Becker Jensen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2010",
-            "publicationYear": { "display": "2010" }
+            "publicationYear": {
+              "display": "2010"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 6, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "01071424" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["Med litteraturhenvisninger"]
+            }
           ],
-          "shelfmark": { "postfix": "Faglig", "shelfmark": "19.1" },
-          "workYear": null
+          "physicalDescriptions": [
+            {
+              "summary": "S. 8-13: ill.",
+              "numberOfPages": 6,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Dansk noter, Nr. 3 (2010)"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "01071424"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Faglig",
+            "shelfmark": "19.1"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201042", "DAR201042"],
+            "otherCatalogues": []
+          }
         }
       },
-      "materialTypes": [{ "materialTypeSpecific": { "display": "artikel" } }],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "materialTypes": [
+        {
+          "materialTypeSpecific": {
+            "display": "artikel"
+          }
+        }
+      ],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "formidling" },
-          { "display": "videnskab" },
-          { "display": "retorik" },
-          { "display": "forskning" },
-          { "display": "skriftlig fremstilling" }
+          {
+            "display": "formidling"
+          },
+          {
+            "display": "videnskab"
+          },
+          {
+            "display": "retorik"
+          },
+          {
+            "display": "forskning"
+          },
+          {
+            "display": "skriftlig fremstilling"
+          }
         ],
         "dbcVerified": [
-          { "display": "formidling" },
-          { "display": "videnskab" },
-          { "display": "retorik" },
-          { "display": "forskning" },
-          { "display": "skriftlig fremstilling" }
+          {
+            "display": "formidling"
+          },
+          {
+            "display": "videnskab"
+          },
+          {
+            "display": "retorik"
+          },
+          {
+            "display": "forskning"
+          },
+          {
+            "display": "skriftlig fremstilling"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "faglitteratur", "code": "NONFICTION" },
-      "dk5MainEntry": { "display": "19.1 Forskningsteknik i alm." },
-      "relations": { "hasReview": [], "hasAdaptation": [] }
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "19.1 Forskningsteknik i alm."
+      },
+      "relations": {
+        "hasReview": [],
+        "hasAdaptation": []
+      }
     }
   }
 }

--- a/cypress/fixtures/material/availability-reservation.json
+++ b/cypress/fixtures/material/availability-reservation.json
@@ -1,7 +1,7 @@
 [
   {
     "available": true,
-    "recordId": "46615743",
+    "recordId": "52557240",
     "reservable": true,
     "reservations": 2
   },

--- a/cypress/fixtures/material/availability.json
+++ b/cypress/fixtures/material/availability.json
@@ -1,7 +1,7 @@
 [
   {
     "available": true,
-    "recordId": "46615743",
+    "recordId": "52557240",
     "reservable": true,
     "reservations": 2
   }

--- a/cypress/fixtures/material/fbi-api-nonfiction.json
+++ b/cypress/fixtures/material/fbi-api-nonfiction.json
@@ -2,739 +2,733 @@
   "data": {
     "work": {
       "workId": "work-of:870970-basis:20636866",
-      "titles": { "full": ["Turen går til Rom"], "original": [] },
+      "titles": {
+        "full": ["Turen går til Rom"],
+        "original": []
+      },
       "abstract": [
-        "Turen Går Til Rom dækker alle de centrale kvarterer i Den Evige Stad. I det sidste kapitel er der også forslag til ture ud af byen. Den kendte dansk-italienske journalist Alfredo Tesio tager kyndigt sine læsere med på en tidsrejse gennem Roms forunderlige historie. Byen er dog meget mere end romerske søjler og barok-facader. Rom er fuld af indtryk, og bogen har derfor også mange gode bud på spisesteder, cafeer og shopping-muligheder, ligesom Alfredo Tesio viser vej til grønne parker, smukke torve og andre romantiske hjørner. TUREN GÅR TIL har eksisteret siden 1952 og er blandt verdens hyppigst opdaterede rejsebogsserier. Serien dækker hele verden fra Nordatlanten til Australien. Bøgerne skrives på dansk af forfattere og journalister med et særligt indgående kendskab til de enkelte destinationer. Med nøje udvalgte attraktioner, herunder spisesteder, viser vi vej til de største oplevelser"
+        "Turen Går Til Rom dækker alle de centrale kvarterer i Den Evige Stad. I det sidste kapitel er der også forslag til ture ud af byen. Den kendte dansk-italienske journalist Alfredo Tesio tager kyndigt sine læsere med på en tidsrejse gennem Roms forunderlige historie. Byen er dog meget mere end romerske søjler og barok-facader. Rom er fuld af indtryk, og bogen har derfor også mange gode bud på spisesteder, cafeer og shopping-muligheder, ligesom Alfredo Tesio viser vej til grønne parker, smukke torve og andre romantiske hjørner. TUREN GÅR TIL har eksisteret siden 1952 og er blandt verdens hyppigst opdaterede rejsebogsserier. Serien dækker hele verden fra Nordatlanten til Australien. Bøgerne skrives på dansk af forfattere og journalister med et særligt indgående kendskab til de enkelte destinationer. Med nøje udvalgte attraktioner, herunder spisesteder, viser vi vej til de største oplevelser."
       ],
-      "creators": [{ "display": "Alfredo Tesio", "__typename": "Person" }],
+      "creators": [
+        {
+          "display": "Alfredo Tesio",
+          "__typename": "Person"
+        }
+      ],
       "series": [],
       "seriesMembers": [],
       "workYear": null,
-      "genreAndForm": ["rejseførere"],
+      "genreAndForm": ["rejseguides", "rejseførere"],
       "manifestations": {
         "all": [
           {
-            "pid": "870970-basis:20636866",
-            "genreAndForm": ["rejseførere"],
+            "pid": "870970-basis:138130479",
+            "genreAndForm": ["rejseguides"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
+            },
             "fictionNonfiction": {
               "display": "faglitteratur",
               "code": "NONFICTION"
             },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
             "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "87-567-5352-7" }],
-            "contributors": [],
-            "edition": {
-              "summary": "18. udgave / af Alfredo Tesio ; redaktion: Lone Burmeister ; kort: UBQ-Kortdesign og Folia/Legindkort, 1994",
-              "publicationYear": { "display": "1994" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 128, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:21417890",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "87-567-5673-9" }],
-            "contributors": [],
-            "edition": {
-              "summary": "19. udgave / af Alfredo Tesio ; kort: Ulla Britze, 1996",
-              "publicationYear": { "display": "1996" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 156, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:22223623",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "87-567-5973-8" }],
-            "contributors": [],
-            "edition": {
-              "summary": "20. udgave / af Alfredo Tesio ; redaktør: Anette Stoffersen ; kort: Ulla Britze ; fotos: Søren Lauridsen, Carsten Bach-Nielsen, 1998",
-              "publicationYear": { "display": "1998" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 156, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:23445158",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "87-567-6313-1" }],
-            "contributors": [],
-            "edition": {
-              "summary": "21. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2001",
-              "publicationYear": { "display": "2001" }
-            },
-            "dateFirstEdition": { "display": "2001", "year": 2001 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 156, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:24922197",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "87-567-6874-5" }],
-            "contributors": [],
-            "edition": {
-              "summary": "22. udgave / forfatter: Alfredo Tesio ; redaktør: Jytte Flamsholt Christensen ; kort: Ulla Britze ; fotos: Søren Lauridsen, 2003",
-              "publicationYear": { "display": "2003" }
-            },
-            "dateFirstEdition": { "display": "2003", "year": 2003 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:26019109",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Politiken"],
             "identifiers": [
-              { "value": "9788756773126" },
-              { "value": "87-567-7312-9" }
+              {
+                "value": "9788740088588"
+              }
             ],
-            "contributors": [],
-            "edition": {
-              "summary": "23. udgave / af Alfredo Tesio ; redaktør: Karen Lise Søndergaard og Inge-Lise Paulsen ; kort: Ulla Britze, 2005",
-              "publicationYear": { "display": "2005" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:27173640",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788756781107" }],
-            "contributors": [],
-            "edition": {
-              "summary": "24. udgave / af Alfredo Tesio ; redaktør: Inge-Lise Paulsen ; kort: Britze, 2008",
-              "publicationYear": { "display": "2008" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:28477074",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788756795036" }],
             "contributors": [
-              { "display": "Marita Hoydal" },
-              { "display": "Pipaluk Balslev Fabricius" },
-              { "display": "Ulla Britze" },
-              { "display": "Søren Lauridsen" }
+              {
+                "display": "Thomas Linder Thomsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Marine Gastineau",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Martin Thomas",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
-              "summary": "25. udgave, 2010",
-              "publicationYear": { "display": "2010" }
+              "summary": "30. udgave, 2024",
+              "publicationYear": {
+                "display": "2024"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:29798079",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
             },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740003437" }],
-            "contributors": [
-              { "display": "Ulla Britze" },
-              { "display": "Birgitta Lund" },
-              { "display": "Kasper Monty" }
-            ],
-            "edition": {
-              "summary": "26. udgave, 2013",
-              "publicationYear": { "display": "2013" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:47077435",
-            "genreAndForm": [],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (online)" } }
-            ],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740059311" }],
-            "contributors": [{ "display": "Karen Abrahamsen" }],
-            "edition": {
-              "summary": "2019",
-              "publicationYear": { "display": "2019" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "80 min." }
-            ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:50690601",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
-            ],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740010671" }],
-            "contributors": [
-              { "display": "Ulla Britze" },
-              { "display": "Birgitta Lund" },
-              { "display": "Kasper Monty" }
-            ],
-            "edition": {
-              "summary": "26. udgave, 2013",
-              "publicationYear": { "display": "2013" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:51634764",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740013115" }],
-            "contributors": [{ "display": "Ulla Britze" }],
-            "edition": {
-              "summary": "27. udgave, 2015",
-              "publicationYear": { "display": "2015" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:51658256",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
-            ],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740018493" }],
-            "contributors": [{ "display": "Ulla Britze" }],
-            "edition": {
-              "summary": "1. e-bogsudgave, 2015",
-              "publicationYear": { "display": "2015" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:53787495",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
-            ],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740025316" }],
-            "contributors": [
-              { "display": "Ulla Britze" },
-              { "display": "Kasper Monty" },
-              { "display": "Birgitta Lund" }
-            ],
-            "edition": {
-              "summary": "Ny e-bogsudgave, 2017",
-              "publicationYear": { "display": "2017" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202415"],
+              "otherCatalogues": ["ACC202412", "BKM202415", "BKX202413"]
+            }
           },
           {
             "pid": "870970-basis:53976018",
-            "genreAndForm": ["rejseførere"],
+            "genreAndForm": ["rejseguides"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
             },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740025323" }],
-            "contributors": [{ "display": "Ulla Britze" }],
-            "edition": {
-              "summary": "28. udgave, 2018",
-              "publicationYear": { "display": "2018" }
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
             },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:61809988",
-            "genreAndForm": ["rejseførere"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
             "fictionNonfiction": {
               "display": "faglitteratur",
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740067156" }],
+            "identifiers": [
+              {
+                "value": "9788740025323"
+              }
+            ],
             "contributors": [
-              { "display": "Ulla Britze" },
-              { "display": "Susan Bergqvist" },
-              { "display": "Trine Blak Kosteljanetz" },
-              { "display": "Birgitta Lund" }
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
-              "summary": "4. e-bogsudgave, 2021",
-              "publicationYear": { "display": "2021" }
+              "summary": "28. udgave, 2018",
+              "publicationYear": {
+                "display": "2018"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med links"]
+              }
             ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
+            "physicalDescriptions": [
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201810"],
+              "otherCatalogues": ["ACC201807", "BKX201809", "BKM201810"]
+            }
           },
           {
             "pid": "870970-basis:61991484",
-            "genreAndForm": ["rejseførere"],
+            "genreAndForm": ["rejseguides"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
-            "fictionNonfiction": {
-              "display": "faglitteratur",
-              "code": "NONFICTION"
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
             },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740063585" }],
-            "contributors": [
-              { "display": "Marine Gastineau" },
-              { "display": "Martin Thomas" },
-              { "display": "Thomas Linder Thomsen" },
-              { "display": "Ulla Britze" },
-              { "display": "Susan Bergqvist" },
-              { "display": "Trine Blak Kosteljanetz" },
-              { "display": "Birgitta Lund" }
-            ],
-            "edition": {
-              "summary": "29. udgave, 2021",
-              "publicationYear": { "display": "2021" }
+            "titles": {
+              "main": ["Turen går til Rom"],
+              "original": []
             },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 168, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:62820586",
-            "genreAndForm": [],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Turen går til Rom"], "original": [] },
             "fictionNonfiction": {
               "display": "faglitteratur",
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (online)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Alfredo Tesio", "__typename": "Person" }
+              {
+                "display": "Alfredo Tesio",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740067163" }],
+            "identifiers": [
+              {
+                "value": "9788740063585"
+              }
+            ],
             "contributors": [
-              { "display": "Paul Becker" },
-              { "display": "Trine Blak Kosteljanetz" }
+              {
+                "display": "Marine Gastineau",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Martin Thomas",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Thomas Linder Thomsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "illustrator"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Britze",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Susan Bergqvist",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "korttegner"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Trine Blak Kosteljanetz",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "redaktør"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Birgitta Lund",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "diverse"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
-              "summary": "2022",
-              "publicationYear": { "display": "2022" }
+              "summary": "29. udgave, 2021",
+              "publicationYear": {
+                "display": "2021"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "80 min." }
+              {
+                "summary": "168 sider: ill. i farver",
+                "numberOfPages": 168,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-            "workYear": null
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Tesio",
+              "shelfmark": "47.57 Rom"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202207"],
+              "otherCatalogues": ["ACF202202", "ACC202203", "BKM202207"]
+            }
           }
         ],
         "latest": {
-          "pid": "870970-basis:62820586",
-          "genreAndForm": [],
+          "pid": "870970-basis:138130479",
+          "genreAndForm": ["rejseguides"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Turen går til Rom"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Turen går til Rom"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "faglitteratur",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "lydbog (online)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
+            }
           ],
-          "creators": [{ "display": "Alfredo Tesio", "__typename": "Person" }],
+          "creators": [
+            {
+              "display": "Alfredo Tesio",
+              "__typename": "Person"
+            }
+          ],
           "publisher": ["Politiken"],
-          "identifiers": [{ "value": "9788740067163" }],
+          "identifiers": [
+            {
+              "value": "9788740088588"
+            }
+          ],
           "contributors": [
-            { "display": "Paul Becker" },
-            { "display": "Trine Blak Kosteljanetz" }
+            {
+              "display": "Thomas Linder Thomsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Marine Gastineau",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Martin Thomas",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Britze",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Susan Bergqvist",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            }
           ],
           "edition": {
-            "summary": "2022",
-            "publicationYear": { "display": "2022" }
+            "summary": "30. udgave, 2024",
+            "publicationYear": {
+              "display": "2024"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
           "physicalDescriptions": [
-            { "numberOfPages": null, "playingTime": "80 min." }
+            {
+              "summary": "168 sider: ill. i farver",
+              "numberOfPages": 168,
+              "playingTime": null
+            }
           ],
-          "accessTypes": [{ "code": "ONLINE" }],
-          "access": [],
-          "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-          "workYear": null
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Tesio",
+            "shelfmark": "47.57 Rom"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DBF202415"],
+            "otherCatalogues": ["ACC202412", "BKM202415", "BKX202413"]
+          }
         },
         "bestRepresentation": {
-          "pid": "870970-basis:61991484",
-          "genreAndForm": ["rejseførere"],
+          "pid": "870970-basis:138130479",
+          "genreAndForm": ["rejseguides"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Turen går til Rom"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Turen går til Rom"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "faglitteratur",
             "code": "NONFICTION"
           },
-          "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-          "creators": [{ "display": "Alfredo Tesio", "__typename": "Person" }],
+          "materialTypes": [
+            {
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
+            }
+          ],
+          "creators": [
+            {
+              "display": "Alfredo Tesio",
+              "__typename": "Person"
+            }
+          ],
           "publisher": ["Politiken"],
-          "identifiers": [{ "value": "9788740063585" }],
+          "identifiers": [
+            {
+              "value": "9788740088588"
+            }
+          ],
           "contributors": [
-            { "display": "Marine Gastineau" },
-            { "display": "Martin Thomas" },
-            { "display": "Thomas Linder Thomsen" },
-            { "display": "Ulla Britze" },
-            { "display": "Susan Bergqvist" },
-            { "display": "Trine Blak Kosteljanetz" },
-            { "display": "Birgitta Lund" }
+            {
+              "display": "Thomas Linder Thomsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Marine Gastineau",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Martin Thomas",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "illustrator"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Britze",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Susan Bergqvist",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "korttegner"
+                  }
+                }
+              ]
+            }
           ],
           "edition": {
-            "summary": "29. udgave, 2021",
-            "publicationYear": { "display": "2021" }
+            "summary": "30. udgave, 2024",
+            "publicationYear": {
+              "display": "2024"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
           "physicalDescriptions": [
-            { "numberOfPages": 168, "playingTime": null }
+            {
+              "summary": "168 sider: ill. i farver",
+              "numberOfPages": 168,
+              "playingTime": null
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
-          "shelfmark": { "postfix": "Tesio", "shelfmark": "47.57 Rom" },
-          "workYear": null
+          "shelfmark": {
+            "postfix": "Tesio",
+            "shelfmark": "47.57 Rom"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DBF202415"],
+            "otherCatalogues": ["ACC202412", "BKM202415", "BKX202413"]
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "bog" } },
-        { "materialTypeSpecific": { "display": "lydbog (online)" } },
-        { "materialTypeSpecific": { "display": "e-bog" } }
+        {
+          "materialTypeSpecific": {
+            "display": "bog"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "Rom" },
-          { "display": "Italien" },
-          { "display": "Rejseførere" }
+          {
+            "display": "Rom"
+          },
+          {
+            "display": "Italien"
+          },
+          {
+            "display": "Rejseførere"
+          }
         ],
-        "dbcVerified": [{ "display": "Rom" }, { "display": "Italien" }]
+        "dbcVerified": [
+          {
+            "display": "Rom"
+          },
+          {
+            "display": "Italien"
+          }
+        ]
       },
-      "fictionNonfiction": { "display": "faglitteratur", "code": "NONFICTION" },
-      "dk5MainEntry": { "display": "47.57 Rom" },
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "47.57 Rom"
+      },
       "relations": {
         "hasReview": [
-          { "pid": "870971-anmeld:83421541" },
-          { "pid": "870971-anmeld:83421673" },
-          { "pid": "870971-anmeld:62154837" }
+          {
+            "pid": "870971-anmeld:83421541"
+          },
+          {
+            "pid": "870971-anmeld:83421673"
+          },
+          {
+            "pid": "870971-anmeld:62154837"
+          }
         ],
         "hasAdaptation": []
       }

--- a/cypress/fixtures/material/fbi-api.json
+++ b/cypress/fixtures/material/fbi-api.json
@@ -7,14 +7,22 @@
         "original": ["The seven sisters"]
       },
       "abstract": [
-        "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav"
+        "Pa Salt dør og hans seks adoptivdøtre står tilbage med muligheden for at finde deres ophav."
       ],
-      "creators": [{ "display": "Lucinda Riley", "__typename": "Person" }],
+      "creators": [
+        {
+          "display": "Lucinda Riley",
+          "__typename": "Person"
+        }
+      ],
       "series": [
         {
           "title": "De syv søstre-serien",
           "isPopular": true,
-          "numberInSeries": { "display": "1", "number": [1] },
+          "numberInSeries": {
+            "display": "1",
+            "number": [1]
+          },
           "readThisFirst": true,
           "readThisWhenever": null
         }
@@ -90,82 +98,18 @@
       "manifestations": {
         "all": [
           {
-            "pid": "870970-basis:46615743",
-            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Cicero"],
-            "identifiers": [{ "value": "9788763863285" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "3. udgave, 2019",
-              "publicationYear": { "display": "2019" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
             "pid": "870970-basis:52557240",
             "genreAndForm": ["roman", "slægtsromaner"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
             },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Cicero"],
-            "identifiers": [{ "value": "9788763844116" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "1. udgave, 2016",
-              "publicationYear": { "display": "2016" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:52590302",
-            "genreAndForm": ["roman", "slægtsromaner"],
-            "source": ["eReolen"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
             "titles": {
               "main": ["De syv søstre"],
               "original": ["The seven sisters"]
@@ -175,25 +119,150 @@
               "code": "FICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
             ],
             "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Cicero"],
             "identifiers": [
-              { "value": "9788763844123" },
-              { "value": "9788763844123" }
+              {
+                "value": "9788763844116"
+              }
             ],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "oversætter"
+                    }
+                  }
+                ]
+              }
+            ],
             "edition": {
-              "summary": "1. eBogsudgave, 2016",
-              "publicationYear": { "display": "2016" }
+              "summary": "1. udgave, 2016",
+              "publicationYear": {
+                "display": "2016"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
+            "physicalDescriptions": [
+              {
+                "summary": "523 sider",
+                "numberOfPages": 523,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": null,
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201835"],
+              "otherCatalogues": ["ACC201634", "BKM201835"]
+            }
+          },
+          {
+            "pid": "870970-basis:52590302",
+            "genreAndForm": ["roman", "slægtsromaner"],
+            "source": ["eReolen"],
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["De syv søstre"],
+              "original": ["The seven sisters"]
+            },
+            "fictionNonfiction": {
+              "display": "skønlitteratur",
+              "code": "FICTION"
+            },
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "e-bog"
+                }
+              }
+            ],
+            "creators": [
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
+            ],
+            "publisher": ["Cicero"],
+            "identifiers": [
+              {
+                "value": "9788763844123"
+              },
+              {
+                "value": "9788763844123"
+              }
+            ],
+            "contributors": [
+              {
+                "display": "Ulla Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "oversætter"
+                    }
+                  }
+                ]
+              }
+            ],
+            "edition": {
+              "summary": "1. eBogsudgave, 2016",
+              "publicationYear": {
+                "display": "2016"
+              }
+            },
+            "dateFirstEdition": null,
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [],
-            "accessTypes": [{ "code": "ONLINE" }],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "ONLINE"
+              }
+            ],
             "access": [
               {
                 "__typename": "Ereol",
@@ -203,13 +272,30 @@
               }
             ],
             "shelfmark": null,
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF201639"],
+              "otherCatalogues": [
+                "ACC201636",
+                "BKM201639",
+                "ERE202235",
+                "DAT201713"
+              ]
+            }
           },
           {
             "pid": "870970-basis:52643414",
             "genreAndForm": ["roman"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
               "main": ["De syv søstre (mp3)"],
               "original": ["The seven sisters"]
@@ -219,242 +305,390 @@
               "code": "FICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "lydbog (cd-mp3)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
+              {
+                "display": "Lucinda Riley",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Rosinante"],
-            "identifiers": [{ "value": "9788763850636" }],
+            "identifiers": [
+              {
+                "value": "9788763850636"
+              }
+            ],
             "contributors": [
-              { "display": "Maria Stokholm" },
-              { "display": "Ulla Lauridsen" }
+              {
+                "display": "Maria Stokholm",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "indlæser"
+                    }
+                  }
+                ]
+              },
+              {
+                "display": "Ulla Lauridsen",
+                "roles": [
+                  {
+                    "function": {
+                      "singular": "oversætter"
+                    }
+                  }
+                ]
+              }
             ],
             "edition": {
               "summary": "1. lydbogsudgave, 2016",
-              "publicationYear": { "display": "2016" }
+              "publicationYear": {
+                "display": "2016"
+              }
             },
-            "dateFirstEdition": { "display": "2016", "year": 2016 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "16 t., 30 min." }
+            "dateFirstEdition": {
+              "display": "2016",
+              "year": 2016
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": [
+                  "Gengivelse af bogen",
+                  "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+                ]
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "physicalDescriptions": [
+              {
+                "summary": "1 cd i 1 mappe (mp3) 16 t., 30 min.",
+                "numberOfPages": null,
+                "playingTime": "16 t., 30 min."
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
             "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:52643503",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (online)" } }
-            ],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Rosinante"],
-            "identifiers": [{ "value": "9788763847995" }],
-            "contributors": [
-              { "display": "Maria Stokholm" },
-              { "display": "Ulla Lauridsen" }
-            ],
-            "edition": {
-              "summary": "2016",
-              "publicationYear": { "display": "2016" }
-            },
-            "dateFirstEdition": { "display": "2016", "year": 2016 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "16 t., 30 min." }
-            ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:53200346",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Gyldendals Bogklubber"],
-            "identifiers": [{ "value": "9788703079875" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "1. bogklubudgave, 2017",
-              "publicationYear": { "display": "2017" }
-            },
-            "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
-          },
-          {
-            "pid": "870970-basis:53292968",
-            "genreAndForm": ["roman", "slægtsromaner", "romaner"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": {
-              "main": ["De syv søstre"],
-              "original": ["The seven sisters"]
-            },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-            "creators": [
-              { "display": "Lucinda Riley", "__typename": "Person" }
-            ],
-            "publisher": ["Cicero"],
-            "identifiers": [{ "value": "9788763849630" }],
-            "contributors": [{ "display": "Ulla Lauridsen" }],
-            "edition": {
-              "summary": "2. udgave, 2017",
-              "publicationYear": { "display": "2017" }
-            },
-            "dateFirstEdition": { "display": "2016", "year": 2016 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 523, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
-            ],
-            "shelfmark": null,
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DLF201642"],
+              "otherCatalogues": ["BKM201642", "DAT201713"]
+            }
           }
         ],
         "latest": {
-          "pid": "870970-basis:46615743",
-          "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+          "pid": "870970-basis:52643414",
+          "genreAndForm": ["roman"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
-            "main": ["De syv søstre"],
+            "main": ["De syv søstre (mp3)"],
             "original": ["The seven sisters"]
           },
           "fictionNonfiction": {
             "display": "skønlitteratur",
             "code": "FICTION"
           },
-          "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-          "creators": [{ "display": "Lucinda Riley", "__typename": "Person" }],
-          "publisher": ["Cicero"],
-          "identifiers": [{ "value": "9788763863285" }],
-          "contributors": [{ "display": "Ulla Lauridsen" }],
-          "edition": {
-            "summary": "3. udgave, 2019",
-            "publicationYear": { "display": "2019" }
-          },
-          "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [
-            { "numberOfPages": 523, "playingTime": null }
+          "materialTypes": [
+            {
+              "materialTypeSpecific": {
+                "display": "lydbog (cd-mp3)"
+              }
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "creators": [
+            {
+              "display": "Lucinda Riley",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": ["Rosinante"],
+          "identifiers": [
+            {
+              "value": "9788763850636"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Maria Stokholm",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "indlæser"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Lauridsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "oversætter"
+                  }
+                }
+              ]
+            }
+          ],
+          "edition": {
+            "summary": "1. lydbogsudgave, 2016",
+            "publicationYear": {
+              "display": "2016"
+            }
+          },
+          "dateFirstEdition": {
+            "display": "2016",
+            "year": 2016
+          },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": [
+                "Gengivelse af bogen",
+                "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+              ]
+            }
+          ],
+          "physicalDescriptions": [
+            {
+              "summary": "1 cd i 1 mappe (mp3) 16 t., 30 min.",
+              "numberOfPages": null,
+              "playingTime": "16 t., 30 min."
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
           "shelfmark": null,
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DLF201642"],
+            "otherCatalogues": ["BKM201642", "DAT201713"]
+          }
         },
         "bestRepresentation": {
-          "pid": "870970-basis:46615743",
-          "genreAndForm": ["roman", "slægtsromaner", "romaner"],
+          "pid": "870970-basis:52643414",
+          "genreAndForm": ["roman"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
-            "main": ["De syv søstre"],
+            "main": ["De syv søstre (mp3)"],
             "original": ["The seven sisters"]
           },
           "fictionNonfiction": {
             "display": "skønlitteratur",
             "code": "FICTION"
           },
-          "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
-          "creators": [{ "display": "Lucinda Riley", "__typename": "Person" }],
-          "publisher": ["Cicero"],
-          "identifiers": [{ "value": "9788763863285" }],
-          "contributors": [{ "display": "Ulla Lauridsen" }],
-          "edition": {
-            "summary": "3. udgave, 2019",
-            "publicationYear": { "display": "2019" }
-          },
-          "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [
-            { "numberOfPages": 523, "playingTime": null }
+          "materialTypes": [
+            {
+              "materialTypeSpecific": {
+                "display": "lydbog (cd-mp3)"
+              }
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "creators": [
+            {
+              "display": "Lucinda Riley",
+              "__typename": "Person"
+            }
+          ],
+          "publisher": ["Rosinante"],
+          "identifiers": [
+            {
+              "value": "9788763850636"
+            }
+          ],
+          "contributors": [
+            {
+              "display": "Maria Stokholm",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "indlæser"
+                  }
+                }
+              ]
+            },
+            {
+              "display": "Ulla Lauridsen",
+              "roles": [
+                {
+                  "function": {
+                    "singular": "oversætter"
+                  }
+                }
+              ]
+            }
+          ],
+          "edition": {
+            "summary": "1. lydbogsudgave, 2016",
+            "publicationYear": {
+              "display": "2016"
+            }
+          },
+          "dateFirstEdition": {
+            "display": "2016",
+            "year": 2016
+          },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": [
+                "Gengivelse af bogen",
+                "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+              ]
+            }
+          ],
+          "physicalDescriptions": [
+            {
+              "summary": "1 cd i 1 mappe (mp3) 16 t., 30 min.",
+              "numberOfPages": null,
+              "playingTime": "16 t., 30 min."
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
           "shelfmark": null,
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DLF201642"],
+            "otherCatalogues": ["BKM201642", "DAT201713"]
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "bog" } },
-        { "materialTypeSpecific": { "display": "lydbog (online)" } },
-        { "materialTypeSpecific": { "display": "lydbog (cd-mp3)" } },
-        { "materialTypeSpecific": { "display": "e-bog" } }
+        {
+          "materialTypeSpecific": {
+            "display": "lydbog (cd-mp3)"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "e-bog"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "bog"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "kærlighed" },
-          { "display": "adoption" },
-          { "display": "familien" },
-          { "display": "slægtsromaner" }
+          {
+            "display": "kærlighed"
+          },
+          {
+            "display": "adoption"
+          },
+          {
+            "display": "familien"
+          },
+          {
+            "display": "slægtsromaner"
+          }
         ],
         "dbcVerified": [
-          { "display": "kærlighed" },
-          { "display": "adoption" },
-          { "display": "familien" },
-          { "display": "slægtsromaner" }
+          {
+            "display": "kærlighed"
+          },
+          {
+            "display": "adoption"
+          },
+          {
+            "display": "familien"
+          },
+          {
+            "display": "slægtsromaner"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "skønlitteratur", "code": "FICTION" },
-      "dk5MainEntry": { "display": "Skønlitteratur" },
+      "fictionNonfiction": {
+        "display": "skønlitteratur",
+        "code": "FICTION"
+      },
+      "dk5MainEntry": {
+        "display": "Skønlitteratur"
+      },
       "relations": {
         "hasReview": [
-          { "pid": "150005-anmeld:81092" },
-          { "pid": "870976-anmeld:129471824" },
-          { "pid": "870971-anmeld:37104132" }
+          {
+            "pid": "150005-anmeld:81092"
+          },
+          {
+            "pid": "870976-anmeld:129471824"
+          },
+          {
+            "pid": "870971-anmeld:37104132"
+          }
         ],
         "hasAdaptation": []
       }

--- a/cypress/fixtures/material/holdings.json
+++ b/cypress/fixtures/material/holdings.json
@@ -1,6 +1,6 @@
 [
   {
-    "recordId": "46615743",
+    "recordId": "52557240",
     "reservable": false,
     "reservations": 0,
     "holdings": []

--- a/cypress/fixtures/material/infomedia-fbi-api.json
+++ b/cypress/fixtures/material/infomedia-fbi-api.json
@@ -2,13 +2,22 @@
   "data": {
     "work": {
       "workId": "work-of:870971-avis:35731733",
-      "titles": { "full": ["Butlerens utrolige historie"], "original": [] },
+      "titles": {
+        "full": ["Butlerens utrolige historie"],
+        "original": []
+      },
       "abstract": [
-        "Filmen ' The Butler' tager afsæt i en avisartikel, der blev til under usædvanlige omstændigheder. Politiken har talt med Wil Haygood, Washington Post-journalisten, der gik på jagt efter en person, der havde arbejdet i Det Hvide Hus i raceadskillelsens tid - og fandt Eugene Allen"
+        "Filmen ' The Butler' tager afsæt i en avisartikel, der blev til under usædvanlige omstændigheder. Politiken har talt med Wil Haygood, Washington Post-journalisten, der gik på jagt efter en person, der havde arbejdet i Det Hvide Hus i raceadskillelsens tid - og fandt Eugene Allen."
       ],
       "creators": [
-        { "display": "Jakob Nielsen", "__typename": "Person" },
-        { "display": "Will Haygood", "__typename": "Person" }
+        {
+          "display": "Will Haygood",
+          "__typename": "Person"
+        },
+        {
+          "display": "Jakob Nielsen",
+          "__typename": "Person"
+        }
       ],
       "series": [],
       "seriesMembers": [],
@@ -20,7 +29,15 @@
             "pid": "870971-avis:35731733",
             "genreAndForm": [],
             "source": ["Avisartikler"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
               "main": ["Butlerens utrolige historie"],
               "original": []
@@ -30,142 +47,336 @@
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "artikel" } },
-              { "materialTypeSpecific": { "display": "artikel (online)" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "artikel"
+                }
+              },
+              {
+                "materialTypeSpecific": {
+                  "display": "artikel (online)"
+                }
+              }
             ],
             "creators": [
-              { "display": "Jakob Nielsen", "__typename": "Person" },
-              { "display": "Will Haygood", "__typename": "Person" }
+              {
+                "display": "Will Haygood",
+                "__typename": "Person"
+              },
+              {
+                "display": "Jakob Nielsen",
+                "__typename": "Person"
+              }
             ],
             "publisher": [],
             "identifiers": [],
             "contributors": [],
             "edition": {
               "summary": "2013",
-              "publicationYear": { "display": "2013" }
+              "publicationYear": {
+                "display": "2013"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [],
             "physicalDescriptions": [
-              { "numberOfPages": 2, "playingTime": null }
+              {
+                "summary": "Sektion 3, s. 6-7: ill.",
+                "numberOfPages": 2,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
+            "hostPublication": {
+              "summary": "Politiken, 2013-09-19"
+            },
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              },
+              {
+                "code": "ONLINE"
+              }
+            ],
             "access": [
-              { "__typename": "InfomediaService", "id": "e3fba430" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InfomediaService",
+                "id": "e3fba430"
+              }
             ],
             "shelfmark": {
               "postfix": "Butlerens",
               "shelfmark": "99.4 Allen, Eugene"
             },
-            "workYear": null
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["ABU201339", "DAR201339"],
+              "otherCatalogues": []
+            }
           }
         ],
         "latest": {
           "pid": "870971-avis:35731733",
           "genreAndForm": [],
           "source": ["Avisartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Butlerens utrolige historie"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Butlerens utrolige historie"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "faglitteratur",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } },
-            { "materialTypeSpecific": { "display": "artikel (online)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            },
+            {
+              "materialTypeSpecific": {
+                "display": "artikel (online)"
+              }
+            }
           ],
           "creators": [
-            { "display": "Jakob Nielsen", "__typename": "Person" },
-            { "display": "Will Haygood", "__typename": "Person" }
+            {
+              "display": "Will Haygood",
+              "__typename": "Person"
+            },
+            {
+              "display": "Jakob Nielsen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2013",
-            "publicationYear": { "display": "2013" }
+            "publicationYear": {
+              "display": "2013"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 2, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
+          "physicalDescriptions": [
+            {
+              "summary": "Sektion 3, s. 6-7: ill.",
+              "numberOfPages": 2,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Politiken, 2013-09-19"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            },
+            {
+              "code": "ONLINE"
+            }
+          ],
           "access": [
-            { "__typename": "InfomediaService", "id": "e3fba430" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InfomediaService",
+              "id": "e3fba430"
+            }
           ],
           "shelfmark": {
             "postfix": "Butlerens",
             "shelfmark": "99.4 Allen, Eugene"
           },
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201339", "DAR201339"],
+            "otherCatalogues": []
+          }
         },
         "bestRepresentation": {
           "pid": "870971-avis:35731733",
           "genreAndForm": [],
           "source": ["Avisartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Butlerens utrolige historie"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Butlerens utrolige historie"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "faglitteratur",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } },
-            { "materialTypeSpecific": { "display": "artikel (online)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            },
+            {
+              "materialTypeSpecific": {
+                "display": "artikel (online)"
+              }
+            }
           ],
           "creators": [
-            { "display": "Jakob Nielsen", "__typename": "Person" },
-            { "display": "Will Haygood", "__typename": "Person" }
+            {
+              "display": "Will Haygood",
+              "__typename": "Person"
+            },
+            {
+              "display": "Jakob Nielsen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2013",
-            "publicationYear": { "display": "2013" }
+            "publicationYear": {
+              "display": "2013"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 2, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }, { "code": "ONLINE" }],
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [],
+          "physicalDescriptions": [
+            {
+              "summary": "Sektion 3, s. 6-7: ill.",
+              "numberOfPages": 2,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Politiken, 2013-09-19"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            },
+            {
+              "code": "ONLINE"
+            }
+          ],
           "access": [
-            { "__typename": "InfomediaService", "id": "e3fba430" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InfomediaService",
+              "id": "e3fba430"
+            }
           ],
           "shelfmark": {
             "postfix": "Butlerens",
             "shelfmark": "99.4 Allen, Eugene"
           },
-          "workYear": null
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201339", "DAR201339"],
+            "otherCatalogues": []
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "artikel" } },
-        { "materialTypeSpecific": { "display": "artikel (online)" } }
+        {
+          "materialTypeSpecific": {
+            "display": "artikel"
+          }
+        },
+        {
+          "materialTypeSpecific": {
+            "display": "artikel (online)"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "USA" },
-          { "display": "Det Hvide Hus" },
-          { "display": "sorte" },
-          { "display": "hvide" },
-          { "display": "raceadskillelse" },
-          { "display": "Eugene Allen" }
+          {
+            "display": "sorte mennesker"
+          },
+          {
+            "display": "hvide mennesker"
+          },
+          {
+            "display": "raceadskillelse"
+          },
+          {
+            "display": "USA"
+          },
+          {
+            "display": "Det Hvide Hus"
+          },
+          {
+            "display": "Eugene Allen"
+          }
         ],
         "dbcVerified": [
-          { "display": "USA" },
-          { "display": "Det Hvide Hus" },
-          { "display": "sorte" },
-          { "display": "hvide" },
-          { "display": "raceadskillelse" },
-          { "display": "Eugene Allen" }
+          {
+            "display": "sorte mennesker"
+          },
+          {
+            "display": "hvide mennesker"
+          },
+          {
+            "display": "raceadskillelse"
+          },
+          {
+            "display": "USA"
+          },
+          {
+            "display": "Det Hvide Hus"
+          },
+          {
+            "display": "Eugene Allen"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "faglitteratur", "code": "NONFICTION" },
-      "dk5MainEntry": { "display": "99.4 Allen, Eugene" },
-      "relations": { "hasReview": [], "hasAdaptation": [] }
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "99.4 Allen, Eugene"
+      },
+      "relations": {
+        "hasReview": [],
+        "hasAdaptation": []
+      }
     }
   }
 }

--- a/cypress/fixtures/material/instant-loan/fbi-api.json
+++ b/cypress/fixtures/material/instant-loan/fbi-api.json
@@ -2,19 +2,31 @@
   "data": {
     "work": {
       "workId": "work-of:870970-basis:134015012",
-      "titles": { "full": ["Skyggeriget : krimi"], "original": [] },
+      "titles": {
+        "full": ["Skyggeriget"],
+        "original": []
+      },
       "abstract": [
-        "I Aalborg bliver et kraftværk udsat for terror. I København bliver klimaministerens søn dræbt. Kan der være en sammenhæng mellem sagerne, som politimanden Martin Juncker bliver indblandet i privat? For læsere af realistiske danske krimier"
+        "I Aalborg bliver et kraftværk udsat for terror. I København bliver klimaministerens søn dræbt. Kan der være en sammenhæng mellem sagerne, som politimanden Martin Juncker bliver indblandet i privat? For læsere af realistiske danske krimier."
       ],
       "creators": [
-        { "display": "Kim Faber", "__typename": "Person" },
-        { "display": "Janni Pedersen (f. 1968)", "__typename": "Person" }
+        {
+          "display": "Kim Faber",
+          "__typename": "Person"
+        },
+        {
+          "display": "Janni Pedersen (f. 1968)",
+          "__typename": "Person"
+        }
       ],
       "series": [
         {
           "title": "Krimiserien med Martin Juncker og Signe Kristiansen",
           "isPopular": true,
-          "numberInSeries": { "display": "4", "number": [4] },
+          "numberInSeries": {
+            "display": "4",
+            "number": [4]
+          },
           "readThisFirst": null,
           "readThisWhenever": null
         }
@@ -48,12 +60,22 @@
           "workId": "work-of:870970-basis:134015012",
           "titles": {
             "main": ["Skyggeriget"],
-            "full": ["Skyggeriget : krimi"],
+            "full": ["Skyggeriget"],
+            "original": []
+          }
+        },
+        {
+          "workId": "work-of:870970-basis:137746069",
+          "titles": {
+            "main": ["Løgner"],
+            "full": ["Løgner : krimi"],
             "original": []
           }
         }
       ],
-      "workYear": { "year": 2022 },
+      "workYear": {
+        "year": 2022
+      },
       "genreAndForm": ["roman", "krimi", "romaner", "politiromaner"],
       "manifestations": {
         "all": [
@@ -61,226 +83,491 @@
             "pid": "870970-basis:134015012",
             "genreAndForm": ["roman", "krimi", "romaner", "politiromaner"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Skyggeriget"], "original": [] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Skyggeriget"],
+              "original": []
+            },
             "fictionNonfiction": {
               "display": "skønlitteratur",
               "code": "FICTION"
             },
-            "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
+            "materialTypes": [
+              {
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
+              }
+            ],
             "creators": [
-              { "display": "Kim Faber", "__typename": "Person" },
-              { "display": "Janni Pedersen (f. 1968)", "__typename": "Person" }
+              {
+                "display": "Kim Faber",
+                "__typename": "Person"
+              },
+              {
+                "display": "Janni Pedersen (f. 1968)",
+                "__typename": "Person"
+              }
             ],
             "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740074918" }],
+            "identifiers": [
+              {
+                "value": "9788740074918"
+              }
+            ],
             "contributors": [],
             "edition": {
               "summary": "1. udgave, 2022",
-              "publicationYear": { "display": "2022" }
+              "publicationYear": {
+                "display": "2022"
+              }
             },
-            "dateFirstEdition": { "display": "2022", "year": 2022 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 365, "playingTime": null }
+            "dateFirstEdition": {
+              "display": "2022",
+              "year": 2022
+            },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Originaludgave: 2022"]
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "physicalDescriptions": [
+              {
+                "summary": "365 sider",
+                "numberOfPages": 365,
+                "playingTime": null
+              }
+            ],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
             "shelfmark": null,
-            "workYear": { "year": 2022 }
-          },
-          {
-            "pid": "870970-basis:31790603",
-            "genreAndForm": ["roman"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Skyggeriget"], "original": [] },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
+            "workYear": {
+              "year": 2022
             },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "lydbog (online)" } }
-            ],
-            "creators": [
-              { "display": "Kim Faber", "__typename": "Person" },
-              { "display": "Janni Pedersen (f. 1968)", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740080865" }],
-            "contributors": [{ "display": "Dan Schlosser" }],
-            "edition": {
-              "summary": "2022",
-              "publicationYear": { "display": "2022" }
-            },
-            "dateFirstEdition": { "display": "2022", "year": 2022 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": null, "playingTime": "9 t., 3 min." }
-            ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": null,
-            "workYear": { "year": 2022 }
-          },
-          {
-            "pid": "870970-basis:62993537",
-            "genreAndForm": ["roman", "krimi", "romaner", "politiromaner"],
-            "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Skyggeriget"], "original": [] },
-            "fictionNonfiction": {
-              "display": "skønlitteratur",
-              "code": "FICTION"
-            },
-            "materialTypes": [
-              { "materialTypeSpecific": { "display": "e-bog" } }
-            ],
-            "creators": [
-              { "display": "Kim Faber", "__typename": "Person" },
-              { "display": "Janni Pedersen (f. 1968)", "__typename": "Person" }
-            ],
-            "publisher": ["Politiken"],
-            "identifiers": [{ "value": "9788740080872" }],
-            "contributors": [],
-            "edition": {
-              "summary": "1. e-bogsudgave, 2022",
-              "publicationYear": { "display": "2022" }
-            },
-            "dateFirstEdition": { "display": "2022", "year": 2022 },
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [
-              { "numberOfPages": 365, "playingTime": null }
-            ],
-            "accessTypes": [{ "code": "ONLINE" }],
-            "access": [],
-            "shelfmark": null,
-            "workYear": { "year": 2022 }
+            "catalogueCodes": {
+              "nationalBibliography": ["DBF202245"],
+              "otherCatalogues": [
+                "ACF202227",
+                "ACC202242",
+                "BKM202245",
+                "BKX202244",
+                "DAT202211"
+              ]
+            }
           }
         ],
         "latest": {
-          "pid": "870970-basis:31790603",
-          "genreAndForm": ["roman"],
+          "pid": "870970-basis:134015012",
+          "genreAndForm": ["roman", "krimi", "romaner", "politiromaner"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Skyggeriget"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Skyggeriget"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "skønlitteratur",
             "code": "FICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "lydbog (online)" } }
+            {
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
+            }
           ],
           "creators": [
-            { "display": "Kim Faber", "__typename": "Person" },
-            { "display": "Janni Pedersen (f. 1968)", "__typename": "Person" }
+            {
+              "display": "Kim Faber",
+              "__typename": "Person"
+            },
+            {
+              "display": "Janni Pedersen (f. 1968)",
+              "__typename": "Person"
+            }
           ],
           "publisher": ["Politiken"],
-          "identifiers": [{ "value": "9788740080865" }],
-          "contributors": [{ "display": "Dan Schlosser" }],
-          "edition": {
-            "summary": "2022",
-            "publicationYear": { "display": "2022" }
-          },
-          "dateFirstEdition": { "display": "2022", "year": 2022 },
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [
-            { "numberOfPages": null, "playingTime": "9 t., 3 min." }
+          "identifiers": [
+            {
+              "value": "9788740074918"
+            }
           ],
-          "accessTypes": [{ "code": "ONLINE" }],
-          "access": [],
+          "contributors": [],
+          "edition": {
+            "summary": "1. udgave, 2022",
+            "publicationYear": {
+              "display": "2022"
+            }
+          },
+          "dateFirstEdition": {
+            "display": "2022",
+            "year": 2022
+          },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["Originaludgave: 2022"]
+            }
+          ],
+          "physicalDescriptions": [
+            {
+              "summary": "365 sider",
+              "numberOfPages": 365,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
           "shelfmark": null,
-          "workYear": { "year": 2022 }
+          "workYear": {
+            "year": 2022
+          },
+          "catalogueCodes": {
+            "nationalBibliography": ["DBF202245"],
+            "otherCatalogues": [
+              "ACF202227",
+              "ACC202242",
+              "BKM202245",
+              "BKX202244",
+              "DAT202211"
+            ]
+          }
         },
         "bestRepresentation": {
           "pid": "870970-basis:134015012",
           "genreAndForm": ["roman", "krimi", "romaner", "politiromaner"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Skyggeriget"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Skyggeriget"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "skønlitteratur",
             "code": "FICTION"
           },
-          "materialTypes": [{ "materialTypeSpecific": { "display": "bog" } }],
+          "materialTypes": [
+            {
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
+            }
+          ],
           "creators": [
-            { "display": "Kim Faber", "__typename": "Person" },
-            { "display": "Janni Pedersen (f. 1968)", "__typename": "Person" }
+            {
+              "display": "Kim Faber",
+              "__typename": "Person"
+            },
+            {
+              "display": "Janni Pedersen (f. 1968)",
+              "__typename": "Person"
+            }
           ],
           "publisher": ["Politiken"],
-          "identifiers": [{ "value": "9788740074918" }],
+          "identifiers": [
+            {
+              "value": "9788740074918"
+            }
+          ],
           "contributors": [],
           "edition": {
             "summary": "1. udgave, 2022",
-            "publicationYear": { "display": "2022" }
+            "publicationYear": {
+              "display": "2022"
+            }
           },
-          "dateFirstEdition": { "display": "2022", "year": 2022 },
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [
-            { "numberOfPages": 365, "playingTime": null }
+          "dateFirstEdition": {
+            "display": "2022",
+            "year": 2022
+          },
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["Originaludgave: 2022"]
+            }
           ],
-          "accessTypes": [{ "code": "PHYSICAL" }],
+          "physicalDescriptions": [
+            {
+              "summary": "365 sider",
+              "numberOfPages": 365,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
           "access": [
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
           ],
           "shelfmark": null,
-          "workYear": { "year": 2022 }
+          "workYear": {
+            "year": 2022
+          },
+          "catalogueCodes": {
+            "nationalBibliography": ["DBF202245"],
+            "otherCatalogues": [
+              "ACF202227",
+              "ACC202242",
+              "BKM202245",
+              "BKX202244",
+              "DAT202211"
+            ]
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "bog" } },
-        { "materialTypeSpecific": { "display": "lydbog (online)" } },
-        { "materialTypeSpecific": { "display": "e-bog" } }
+        {
+          "materialTypeSpecific": {
+            "display": "bog"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "Martin Juncker" },
-          { "display": "Signe Kristiansen" },
-          { "display": "mord" },
-          { "display": "drab" },
-          { "display": "hemmeligheder" },
-          { "display": "hævn" },
-          { "display": "politikere" },
-          { "display": "krigsveteraner" },
-          { "display": "narkokriminalitet" },
-          { "display": "miljøaktioner" },
-          { "display": "politibetjente" },
-          { "display": "Danmark" },
-          { "display": "København" },
-          { "display": "Aalborg" },
-          { "display": "Aalborg" },
-          { "display": "2020'erne" }
+          {
+            "display": "Martin Juncker"
+          },
+          {
+            "display": "Signe Kristiansen"
+          },
+          {
+            "display": "mord"
+          },
+          {
+            "display": "drab"
+          },
+          {
+            "display": "hemmeligheder"
+          },
+          {
+            "display": "hævn"
+          },
+          {
+            "display": "politikere"
+          },
+          {
+            "display": "krigsveteraner"
+          },
+          {
+            "display": "narkokriminalitet"
+          },
+          {
+            "display": "miljøaktioner"
+          },
+          {
+            "display": "politibetjente"
+          },
+          {
+            "display": "Danmark"
+          },
+          {
+            "display": "København"
+          },
+          {
+            "display": "Aalborg"
+          },
+          {
+            "display": "Aalborg"
+          },
+          {
+            "display": "2020'erne"
+          },
+          {
+            "display": "overraskende"
+          },
+          {
+            "display": "spændende"
+          },
+          {
+            "display": "dramatisk"
+          },
+          {
+            "display": "skæbnesvanger"
+          },
+          {
+            "display": "skiftende synsvinkler"
+          },
+          {
+            "display": "fremadskridende"
+          },
+          {
+            "display": "storbyen"
+          },
+          {
+            "display": "provinsen"
+          },
+          {
+            "display": "realistisk"
+          }
         ],
         "dbcVerified": [
-          { "display": "Martin Juncker" },
-          { "display": "Signe Kristiansen" },
-          { "display": "mord" },
-          { "display": "drab" },
-          { "display": "hemmeligheder" },
-          { "display": "hævn" },
-          { "display": "politikere" },
-          { "display": "krigsveteraner" },
-          { "display": "narkokriminalitet" },
-          { "display": "miljøaktioner" },
-          { "display": "politibetjente" },
-          { "display": "Danmark" },
-          { "display": "København" },
-          { "display": "Aalborg" },
-          { "display": "Aalborg" },
-          { "display": "2020'erne" }
+          {
+            "display": "Martin Juncker"
+          },
+          {
+            "display": "Signe Kristiansen"
+          },
+          {
+            "display": "mord"
+          },
+          {
+            "display": "drab"
+          },
+          {
+            "display": "hemmeligheder"
+          },
+          {
+            "display": "hævn"
+          },
+          {
+            "display": "politikere"
+          },
+          {
+            "display": "krigsveteraner"
+          },
+          {
+            "display": "narkokriminalitet"
+          },
+          {
+            "display": "miljøaktioner"
+          },
+          {
+            "display": "politibetjente"
+          },
+          {
+            "display": "Danmark"
+          },
+          {
+            "display": "København"
+          },
+          {
+            "display": "Aalborg"
+          },
+          {
+            "display": "Aalborg"
+          },
+          {
+            "display": "2020'erne"
+          },
+          {
+            "display": "overraskende"
+          },
+          {
+            "display": "spændende"
+          },
+          {
+            "display": "dramatisk"
+          },
+          {
+            "display": "skæbnesvanger"
+          },
+          {
+            "display": "skiftende synsvinkler"
+          },
+          {
+            "display": "fremadskridende"
+          },
+          {
+            "display": "storbyen"
+          },
+          {
+            "display": "provinsen"
+          },
+          {
+            "display": "realistisk"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "skønlitteratur", "code": "FICTION" },
-      "dk5MainEntry": { "display": "Skønlitteratur" },
+      "fictionNonfiction": {
+        "display": "skønlitteratur",
+        "code": "FICTION"
+      },
+      "dk5MainEntry": {
+        "display": "Skønlitteratur"
+      },
       "relations": {
         "hasReview": [
-          { "pid": "870976-anmeld:134907851" },
-          { "pid": "870971-anmeld:134966262" },
-          { "pid": "870971-anmeld:134876913" },
-          { "pid": "870971-anmeld:135044482" }
+          {
+            "pid": "870976-anmeld:134907851"
+          },
+          {
+            "pid": "870971-anmeld:134966262"
+          },
+          {
+            "pid": "870971-anmeld:134876913"
+          },
+          {
+            "pid": "870971-anmeld:135044482"
+          }
         ],
         "hasAdaptation": []
       }

--- a/cypress/fixtures/material/music-fbi-api.json
+++ b/cypress/fixtures/material/music-fbi-api.json
@@ -1,0 +1,834 @@
+{
+  "data": {
+      "work": {
+          "workId": "work-of:870970-basis:137949814",
+          "titles": {
+              "full": [
+                  "Billion dollar babies"
+              ],
+              "original": []
+          },
+          "abstract": [],
+          "creators": [
+              {
+                  "display": "Alice Cooper",
+                  "__typename": "Person"
+              }
+          ],
+          "series": [],
+          "seriesMembers": [],
+          "workYear": null,
+          "genreAndForm": [
+              "rock",
+              "heavy rock",
+              "70'er rock"
+          ],
+          "manifestations": {
+              "all": [
+                  {
+                      "pid": "775100-katalog:10343852",
+                      "genreAndForm": [],
+                      "source": [
+                          "Bibliotekskatalog"
+                      ],
+                      "languages": {
+                          "main": [],
+                          "notes": []
+                      },
+                      "titles": {
+                          "main": [
+                              "Billion dollar babies"
+                          ],
+                          "original": []
+                      },
+                      "fictionNonfiction": {
+                          "display": "vides ikke",
+                          "code": "NOT_SPECIFIED"
+                      },
+                      "materialTypes": [
+                          {
+                              "materialTypeSpecific": {
+                                  "display": "musik (cd)"
+                              }
+                          }
+                      ],
+                      "creators": [
+                          {
+                              "display": "Alice Cooper",
+                              "__typename": "Person"
+                          }
+                      ],
+                      "publisher": [
+                          "Warner Bros."
+                      ],
+                      "identifiers": [
+                          {
+                              "value": "Warner Bros. 7599-27269-2"
+                          }
+                      ],
+                      "contributors": [
+                          {
+                              "display": "Michael Bruce",
+                              "roles": []
+                          },
+                          {
+                              "display": "Dennis Dunaway",
+                              "roles": []
+                          },
+                          {
+                              "display": "Neal Smith",
+                              "roles": []
+                          },
+                          {
+                              "display": "Glen Buxton",
+                              "roles": []
+                          }
+                      ],
+                      "edition": null,
+                      "dateFirstEdition": null,
+                      "audience": {
+                          "generalAudience": [],
+                          "ages": []
+                      },
+                      "notes": [],
+                      "physicalDescriptions": [
+                          {
+                              "summary": "Stereo",
+                              "numberOfPages": null,
+                              "playingTime": null
+                          }
+                      ],
+                      "hostPublication": null,
+                      "manifestationParts": {
+                          "parts": [
+                              {
+                                  "title": "Hello hooray"
+                              },
+                              {
+                                  "title": "Raped and freezin'"
+                              },
+                              {
+                                  "title": "Elected"
+                              },
+                              {
+                                  "title": "Billion dollar babies"
+                              },
+                              {
+                                  "title": "Unfinished sweet"
+                              },
+                              {
+                                  "title": "No more Mr. Nice Guy"
+                              },
+                              {
+                                  "title": "Generation landslide"
+                              },
+                              {
+                                  "title": "Sick things"
+                              },
+                              {
+                                  "title": "Mary Ann"
+                              },
+                              {
+                                  "title": "I love the dead"
+                              }
+                          ]
+                      },
+                      "accessTypes": [
+                          {
+                              "code": "PHYSICAL"
+                          }
+                      ],
+                      "access": [
+                          {
+                              "__typename": "InterLibraryLoan",
+                              "loanIsPossible": true
+                          }
+                      ],
+                      "shelfmark": {
+                          "postfix": "Cooper",
+                          "shelfmark": "Rock"
+                      },
+                      "workYear": null,
+                      "catalogueCodes": {
+                          "nationalBibliography": [],
+                          "otherCatalogues": []
+                      }
+                  },
+                  {
+                      "pid": "870970-basis:137949814",
+                      "genreAndForm": [
+                          "rock",
+                          "heavy rock",
+                          "70'er rock"
+                      ],
+                      "source": [
+                          "Bibliotekskatalog"
+                      ],
+                      "languages": {
+                          "main": [
+                              {
+                                  "display": "engelsk",
+                                  "isoCode": "eng"
+                              }
+                          ],
+                          "notes": []
+                      },
+                      "titles": {
+                          "main": [
+                              "Billion dollar babies"
+                          ],
+                          "original": []
+                      },
+                      "fictionNonfiction": {
+                          "display": "vides ikke",
+                          "code": "NOT_SPECIFIED"
+                      },
+                      "materialTypes": [
+                          {
+                              "materialTypeSpecific": {
+                                  "display": "musik (cd)"
+                              }
+                          }
+                      ],
+                      "creators": [
+                          {
+                              "display": "Alice Cooper",
+                              "__typename": "Person"
+                          }
+                      ],
+                      "publisher": [
+                          "Warner Records"
+                      ],
+                      "identifiers": [
+                          {
+                              "value": "Warner Rhino 603497832415"
+                          }
+                      ],
+                      "contributors": [
+                          {
+                              "display": "Michael Bruce",
+                              "roles": []
+                          },
+                          {
+                              "display": "Glen Buxton",
+                              "roles": []
+                          },
+                          {
+                              "display": "Dennis Dunaway",
+                              "roles": []
+                          },
+                          {
+                              "display": "Neal Smith",
+                              "roles": []
+                          }
+                      ],
+                      "edition": {
+                          "summary": "50th-anniversary edition, ℗2024",
+                          "publicationYear": {
+                              "display": "℗2024"
+                          }
+                      },
+                      "dateFirstEdition": null,
+                      "audience": {
+                          "generalAudience": [],
+                          "ages": []
+                      },
+                      "notes": [],
+                      "physicalDescriptions": [
+                          {
+                              "summary": "2 cd'er (1 kommentarbilag)",
+                              "numberOfPages": null,
+                              "playingTime": null
+                          }
+                      ],
+                      "hostPublication": null,
+                      "manifestationParts": {
+                          "parts": [
+                              {
+                                  "title": "Hello Hooray"
+                              },
+                              {
+                                  "title": "Raped and Freezin'"
+                              },
+                              {
+                                  "title": "Elected"
+                              },
+                              {
+                                  "title": "Billion Dollar Babies"
+                              },
+                              {
+                                  "title": "Unfinished Sweet"
+                              },
+                              {
+                                  "title": "No More Mr. Nice Guy"
+                              },
+                              {
+                                  "title": "Generation Landslide"
+                              },
+                              {
+                                  "title": "Sick Things"
+                              },
+                              {
+                                  "title": "Mary Ann"
+                              },
+                              {
+                                  "title": "I Love the Dead"
+                              },
+                              {
+                                  "title": "Hello Hooray (Live)"
+                              },
+                              {
+                                  "title": "Billion Dollar Babies (Live)"
+                              },
+                              {
+                                  "title": "Elected (Live)"
+                              },
+                              {
+                                  "title": "I'm Eighteen (Live, 1973)"
+                              },
+                              {
+                                  "title": "Raped and Freezin' (Live)"
+                              },
+                              {
+                                  "title": "No More Mr. Nice Guy (Live)"
+                              },
+                              {
+                                  "title": "My Stars (Live)"
+                              },
+                              {
+                                  "title": "Unfinished Sweet (Live)"
+                              },
+                              {
+                                  "title": "Sick Things (Live)"
+                              },
+                              {
+                                  "title": "Dead Babies (Live)"
+                              },
+                              {
+                                  "title": "I Love the Dead (Live)"
+                              },
+                              {
+                                  "title": "School's Out (Live 1973)"
+                              },
+                              {
+                                  "title": "Under My Wheels (Live 1973)"
+                              },
+                              {
+                                  "title": "Coal Black Model T (Outtake)"
+                              },
+                              {
+                                  "title": "Son Of Billion Dollar Babies (Generation Landslide) (Outtake)"
+                              },
+                              {
+                                  "title": "Hello Hooray (Single Version)"
+                              },
+                              {
+                                  "title": "Billion Dollar Babies 8Single Version"
+                              },
+                              {
+                                  "title": "Elected (Single Version)"
+                              },
+                              {
+                                  "title": "Mary Ann (Single Version)"
+                              },
+                              {
+                                  "title": "Slick Black Limousine"
+                              }
+                          ]
+                      },
+                      "accessTypes": [
+                          {
+                              "code": "PHYSICAL"
+                          }
+                      ],
+                      "access": [
+                          {
+                              "__typename": "InterLibraryLoan",
+                              "loanIsPossible": true
+                          }
+                      ],
+                      "shelfmark": {
+                          "postfix": "Cooper",
+                          "shelfmark": "Rock"
+                      },
+                      "workYear": null,
+                      "catalogueCodes": {
+                          "nationalBibliography": [],
+                          "otherCatalogues": [
+                              "ACM202407",
+                              "BKM202415"
+                          ]
+                      }
+                  }
+              ],
+              "latest": {
+                  "pid": "870970-basis:137949814",
+                  "genreAndForm": [
+                      "rock",
+                      "heavy rock",
+                      "70'er rock"
+                  ],
+                  "source": [
+                      "Bibliotekskatalog"
+                  ],
+                  "languages": {
+                      "main": [
+                          {
+                              "display": "engelsk",
+                              "isoCode": "eng"
+                          }
+                      ],
+                      "notes": []
+                  },
+                  "titles": {
+                      "main": [
+                          "Billion dollar babies"
+                      ],
+                      "original": []
+                  },
+                  "fictionNonfiction": {
+                      "display": "vides ikke",
+                      "code": "NOT_SPECIFIED"
+                  },
+                  "materialTypes": [
+                      {
+                          "materialTypeSpecific": {
+                              "display": "musik (cd)"
+                          }
+                      }
+                  ],
+                  "creators": [
+                      {
+                          "display": "Alice Cooper",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "publisher": [
+                      "Warner Records"
+                  ],
+                  "identifiers": [
+                      {
+                          "value": "Warner Rhino 603497832415"
+                      }
+                  ],
+                  "contributors": [
+                      {
+                          "display": "Michael Bruce",
+                          "roles": []
+                      },
+                      {
+                          "display": "Glen Buxton",
+                          "roles": []
+                      },
+                      {
+                          "display": "Dennis Dunaway",
+                          "roles": []
+                      },
+                      {
+                          "display": "Neal Smith",
+                          "roles": []
+                      }
+                  ],
+                  "edition": {
+                      "summary": "50th-anniversary edition, ℗2024",
+                      "publicationYear": {
+                          "display": "℗2024"
+                      }
+                  },
+                  "dateFirstEdition": null,
+                  "audience": {
+                      "generalAudience": [],
+                      "ages": []
+                  },
+                  "notes": [],
+                  "physicalDescriptions": [
+                      {
+                          "summary": "2 cd'er (1 kommentarbilag)",
+                          "numberOfPages": null,
+                          "playingTime": null
+                      }
+                  ],
+                  "hostPublication": null,
+                  "manifestationParts": {
+                      "parts": [
+                          {
+                              "title": "Hello Hooray"
+                          },
+                          {
+                              "title": "Raped and Freezin'"
+                          },
+                          {
+                              "title": "Elected"
+                          },
+                          {
+                              "title": "Billion Dollar Babies"
+                          },
+                          {
+                              "title": "Unfinished Sweet"
+                          },
+                          {
+                              "title": "No More Mr. Nice Guy"
+                          },
+                          {
+                              "title": "Generation Landslide"
+                          },
+                          {
+                              "title": "Sick Things"
+                          },
+                          {
+                              "title": "Mary Ann"
+                          },
+                          {
+                              "title": "I Love the Dead"
+                          },
+                          {
+                              "title": "Hello Hooray (Live)"
+                          },
+                          {
+                              "title": "Billion Dollar Babies (Live)"
+                          },
+                          {
+                              "title": "Elected (Live)"
+                          },
+                          {
+                              "title": "I'm Eighteen (Live, 1973)"
+                          },
+                          {
+                              "title": "Raped and Freezin' (Live)"
+                          },
+                          {
+                              "title": "No More Mr. Nice Guy (Live)"
+                          },
+                          {
+                              "title": "My Stars (Live)"
+                          },
+                          {
+                              "title": "Unfinished Sweet (Live)"
+                          },
+                          {
+                              "title": "Sick Things (Live)"
+                          },
+                          {
+                              "title": "Dead Babies (Live)"
+                          },
+                          {
+                              "title": "I Love the Dead (Live)"
+                          },
+                          {
+                              "title": "School's Out (Live 1973)"
+                          },
+                          {
+                              "title": "Under My Wheels (Live 1973)"
+                          },
+                          {
+                              "title": "Coal Black Model T (Outtake)"
+                          },
+                          {
+                              "title": "Son Of Billion Dollar Babies (Generation Landslide) (Outtake)"
+                          },
+                          {
+                              "title": "Hello Hooray (Single Version)"
+                          },
+                          {
+                              "title": "Billion Dollar Babies 8Single Version"
+                          },
+                          {
+                              "title": "Elected (Single Version)"
+                          },
+                          {
+                              "title": "Mary Ann (Single Version)"
+                          },
+                          {
+                              "title": "Slick Black Limousine"
+                          }
+                      ]
+                  },
+                  "accessTypes": [
+                      {
+                          "code": "PHYSICAL"
+                      }
+                  ],
+                  "access": [
+                      {
+                          "__typename": "InterLibraryLoan",
+                          "loanIsPossible": true
+                      }
+                  ],
+                  "shelfmark": {
+                      "postfix": "Cooper",
+                      "shelfmark": "Rock"
+                  },
+                  "workYear": null,
+                  "catalogueCodes": {
+                      "nationalBibliography": [],
+                      "otherCatalogues": [
+                          "ACM202407",
+                          "BKM202415"
+                      ]
+                  }
+              },
+              "bestRepresentation": {
+                  "pid": "870970-basis:137949814",
+                  "genreAndForm": [
+                      "rock",
+                      "heavy rock",
+                      "70'er rock"
+                  ],
+                  "source": [
+                      "Bibliotekskatalog"
+                  ],
+                  "languages": {
+                      "main": [
+                          {
+                              "display": "engelsk",
+                              "isoCode": "eng"
+                          }
+                      ],
+                      "notes": []
+                  },
+                  "titles": {
+                      "main": [
+                          "Billion dollar babies"
+                      ],
+                      "original": []
+                  },
+                  "fictionNonfiction": {
+                      "display": "vides ikke",
+                      "code": "NOT_SPECIFIED"
+                  },
+                  "materialTypes": [
+                      {
+                          "materialTypeSpecific": {
+                              "display": "musik (cd)"
+                          }
+                      }
+                  ],
+                  "creators": [
+                      {
+                          "display": "Alice Cooper",
+                          "__typename": "Person"
+                      }
+                  ],
+                  "publisher": [
+                      "Warner Records"
+                  ],
+                  "identifiers": [
+                      {
+                          "value": "Warner Rhino 603497832415"
+                      }
+                  ],
+                  "contributors": [
+                      {
+                          "display": "Michael Bruce",
+                          "roles": []
+                      },
+                      {
+                          "display": "Glen Buxton",
+                          "roles": []
+                      },
+                      {
+                          "display": "Dennis Dunaway",
+                          "roles": []
+                      },
+                      {
+                          "display": "Neal Smith",
+                          "roles": []
+                      }
+                  ],
+                  "edition": {
+                      "summary": "50th-anniversary edition, ℗2024",
+                      "publicationYear": {
+                          "display": "℗2024"
+                      }
+                  },
+                  "dateFirstEdition": null,
+                  "audience": {
+                      "generalAudience": [],
+                      "ages": []
+                  },
+                  "notes": [],
+                  "physicalDescriptions": [
+                      {
+                          "summary": "2 cd'er (1 kommentarbilag)",
+                          "numberOfPages": null,
+                          "playingTime": null
+                      }
+                  ],
+                  "hostPublication": null,
+                  "manifestationParts": {
+                      "parts": [
+                          {
+                              "title": "Hello Hooray"
+                          },
+                          {
+                              "title": "Raped and Freezin'"
+                          },
+                          {
+                              "title": "Elected"
+                          },
+                          {
+                              "title": "Billion Dollar Babies"
+                          },
+                          {
+                              "title": "Unfinished Sweet"
+                          },
+                          {
+                              "title": "No More Mr. Nice Guy"
+                          },
+                          {
+                              "title": "Generation Landslide"
+                          },
+                          {
+                              "title": "Sick Things"
+                          },
+                          {
+                              "title": "Mary Ann"
+                          },
+                          {
+                              "title": "I Love the Dead"
+                          },
+                          {
+                              "title": "Hello Hooray (Live)"
+                          },
+                          {
+                              "title": "Billion Dollar Babies (Live)"
+                          },
+                          {
+                              "title": "Elected (Live)"
+                          },
+                          {
+                              "title": "I'm Eighteen (Live, 1973)"
+                          },
+                          {
+                              "title": "Raped and Freezin' (Live)"
+                          },
+                          {
+                              "title": "No More Mr. Nice Guy (Live)"
+                          },
+                          {
+                              "title": "My Stars (Live)"
+                          },
+                          {
+                              "title": "Unfinished Sweet (Live)"
+                          },
+                          {
+                              "title": "Sick Things (Live)"
+                          },
+                          {
+                              "title": "Dead Babies (Live)"
+                          },
+                          {
+                              "title": "I Love the Dead (Live)"
+                          },
+                          {
+                              "title": "School's Out (Live 1973)"
+                          },
+                          {
+                              "title": "Under My Wheels (Live 1973)"
+                          },
+                          {
+                              "title": "Coal Black Model T (Outtake)"
+                          },
+                          {
+                              "title": "Son Of Billion Dollar Babies (Generation Landslide) (Outtake)"
+                          },
+                          {
+                              "title": "Hello Hooray (Single Version)"
+                          },
+                          {
+                              "title": "Billion Dollar Babies 8Single Version"
+                          },
+                          {
+                              "title": "Elected (Single Version)"
+                          },
+                          {
+                              "title": "Mary Ann (Single Version)"
+                          },
+                          {
+                              "title": "Slick Black Limousine"
+                          }
+                      ]
+                  },
+                  "accessTypes": [
+                      {
+                          "code": "PHYSICAL"
+                      }
+                  ],
+                  "access": [
+                      {
+                          "__typename": "InterLibraryLoan",
+                          "loanIsPossible": true
+                      }
+                  ],
+                  "shelfmark": {
+                      "postfix": "Cooper",
+                      "shelfmark": "Rock"
+                  },
+                  "workYear": null,
+                  "catalogueCodes": {
+                      "nationalBibliography": [],
+                      "otherCatalogues": [
+                          "ACM202407",
+                          "BKM202415"
+                      ]
+                  }
+              }
+          },
+          "materialTypes": [
+              {
+                  "materialTypeSpecific": {
+                      "display": "musik (cd)"
+                  }
+              }
+          ],
+          "mainLanguages": [
+              {
+                  "display": "engelsk",
+                  "isoCode": "eng"
+              }
+          ],
+          "subjects": {
+              "all": [
+                  {
+                      "display": "vokal"
+                  },
+                  {
+                      "display": "USA"
+                  },
+                  {
+                      "display": "1970'erne"
+                  }
+              ],
+              "dbcVerified": [
+                  {
+                      "display": "vokal"
+                  },
+                  {
+                      "display": "USA"
+                  },
+                  {
+                      "display": "1970'erne"
+                  }
+              ]
+          },
+          "fictionNonfiction": {
+              "display": "vides ikke",
+              "code": "NOT_SPECIFIED"
+          },
+          "dk5MainEntry": {
+              "display": "78.794:5 Rock'n roll. Rock. Folk"
+          },
+          "relations": {
+              "hasReview": [
+                  {
+                      "pid": "870971-anmeld:138074587"
+                  },
+                  {
+                      "pid": "870971-anmeld:23412608"
+                  }
+              ],
+              "hasAdaptation": []
+          }
+      }
+  }
+}

--- a/cypress/fixtures/material/open-order/fbi-api.json
+++ b/cypress/fixtures/material/open-order/fbi-api.json
@@ -33,7 +33,8 @@
                   "display": "engelsk",
                   "isoCode": "eng"
                 }
-              ]
+              ],
+              "notes": []
             },
             "titles": {
               "main": ["Duchess of Death"],
@@ -45,7 +46,9 @@
             },
             "materialTypes": [
               {
-                "materialTypeSpecific": { "display": "bog" }
+                "materialTypeSpecific": {
+                  "display": "bog"
+                }
               }
             ],
             "creators": [
@@ -69,14 +72,23 @@
             },
             "dateFirstEdition": null,
             "audience": {
-              "generalAudience": []
+              "generalAudience": [],
+              "ages": []
             },
+            "notes": [
+              {
+                "display": ["Med litteraturhenvisninger"]
+              }
+            ],
             "physicalDescriptions": [
               {
+                "summary": "xxxiii, 284 sider, 8 sider med tavler",
                 "numberOfPages": 325,
                 "playingTime": null
               }
             ],
+            "hostPublication": null,
+            "manifestationParts": null,
             "accessTypes": [
               {
                 "code": "PHYSICAL"
@@ -109,7 +121,8 @@
                 "display": "engelsk",
                 "isoCode": "eng"
               }
-            ]
+            ],
+            "notes": []
           },
           "titles": {
             "main": ["Duchess of Death"],
@@ -121,7 +134,9 @@
           },
           "materialTypes": [
             {
-              "materialTypeSpecific": { "display": "bog" }
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
             }
           ],
           "creators": [
@@ -145,14 +160,23 @@
           },
           "dateFirstEdition": null,
           "audience": {
-            "generalAudience": []
+            "generalAudience": [],
+            "ages": []
           },
+          "notes": [
+            {
+              "display": ["Med litteraturhenvisninger"]
+            }
+          ],
           "physicalDescriptions": [
             {
+              "summary": "xxxiii, 284 sider, 8 sider med tavler",
               "numberOfPages": 325,
               "playingTime": null
             }
           ],
+          "hostPublication": null,
+          "manifestationParts": null,
           "accessTypes": [
             {
               "code": "PHYSICAL"
@@ -184,7 +208,8 @@
                 "display": "engelsk",
                 "isoCode": "eng"
               }
-            ]
+            ],
+            "notes": []
           },
           "titles": {
             "main": ["Duchess of Death"],
@@ -196,7 +221,9 @@
           },
           "materialTypes": [
             {
-              "materialTypeSpecific": { "display": "bog" }
+              "materialTypeSpecific": {
+                "display": "bog"
+              }
             }
           ],
           "creators": [
@@ -220,14 +247,23 @@
           },
           "dateFirstEdition": null,
           "audience": {
-            "generalAudience": []
+            "generalAudience": [],
+            "ages": []
           },
+          "notes": [
+            {
+              "display": ["Med litteraturhenvisninger"]
+            }
+          ],
           "physicalDescriptions": [
             {
+              "summary": "xxxiii, 284 sider, 8 sider med tavler",
               "numberOfPages": 325,
               "playingTime": null
             }
           ],
+          "hostPublication": null,
+          "manifestationParts": null,
           "accessTypes": [
             {
               "code": "PHYSICAL"
@@ -252,7 +288,9 @@
       },
       "materialTypes": [
         {
-          "materialTypeSpecific": { "display": "bog" }
+          "materialTypeSpecific": {
+            "display": "bog"
+          }
         }
       ],
       "mainLanguages": [

--- a/cypress/fixtures/material/order-digital-copy/order-digital-fbi-api.json
+++ b/cypress/fixtures/material/order-digital-copy/order-digital-fbi-api.json
@@ -6,28 +6,23 @@
         "full": ["Faglig formidling er ikke kun skriveteknik"],
         "original": []
       },
-      "abstract": ["Om skriftlig formidling af faglig viden til ikke-fagfolk"],
-      "creators": [{ "display": "Leif Becker Jensen", "__typename": "Person" }],
+      "abstract": ["Om skriftlig formidling af faglig viden til ikke-fagfolk."],
+      "creators": [
+        {
+          "display": "Leif Becker Jensen",
+          "__typename": "Person"
+        }
+      ],
       "series": [
         {
           "title": "Skriftlig faglig formidling",
-          "isPopular": null,
+          "isPopular": false,
           "numberInSeries": null,
           "readThisFirst": null,
           "readThisWhenever": null
         }
       ],
       "seriesMembers": [
-        {
-          "workId": "work-of:870971-tsart:34310831",
-          "titles": {
-            "main": ["Skal det være så svært at lære at skrive godt?"],
-            "full": [
-              "Skal det være så svært at lære at skrive godt? : om at træne grundlæggende skrivekompetencer med udgangspunkt i en konkret tværfaglig skriveopgave i dansk og matematik"
-            ],
-            "original": []
-          }
-        },
         {
           "workId": "work-of:870971-tsart:34310858",
           "titles": {
@@ -49,6 +44,16 @@
           }
         },
         {
+          "workId": "work-of:870971-tsart:34310831",
+          "titles": {
+            "main": ["Skal det være så svært at lære at skrive godt?"],
+            "full": [
+              "Skal det være så svært at lære at skrive godt? : om at træne grundlæggende skrivekompetencer med udgangspunkt i en konkret tværfaglig skriveopgave i dansk og matematik"
+            ],
+            "original": []
+          }
+        },
+        {
           "workId": "work-of:870971-tsart:34310815",
           "titles": {
             "main": ["Faglig formidling er ikke kun skriveteknik"],
@@ -65,7 +70,15 @@
             "pid": "870971-tsart:34310815",
             "genreAndForm": [],
             "source": ["Tidsskriftsartikler"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
             "titles": {
               "main": ["Faglig formidling er ikke kun skriveteknik"],
               "original": []
@@ -75,37 +88,87 @@
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "artikel" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "artikel"
+                }
+              }
             ],
             "creators": [
-              { "display": "Leif Becker Jensen", "__typename": "Person" }
+              {
+                "display": "Leif Becker Jensen",
+                "__typename": "Person"
+              }
             ],
             "publisher": [],
             "identifiers": [],
             "contributors": [],
             "edition": {
               "summary": "2010",
-              "publicationYear": { "display": "2010" }
+              "publicationYear": {
+                "display": "2010"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["Med litteraturhenvisninger"]
+              }
+            ],
             "physicalDescriptions": [
-              { "numberOfPages": 6, "playingTime": null }
+              {
+                "summary": "S. 8-13: ill.",
+                "numberOfPages": 6,
+                "playingTime": null
+              }
             ],
-            "accessTypes": [{ "code": "PHYSICAL" }],
+            "hostPublication": {
+              "summary": "Dansk noter, Nr. 3 (2010)"
+            },
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
             "access": [
-              { "__typename": "DigitalArticleService", "issn": "01071424" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+              {
+                "__typename": "DigitalArticleService",
+                "issn": "01071424"
+              },
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
             ],
-            "shelfmark": { "postfix": "Faglig", "shelfmark": "19.1" },
-            "workYear": null
+            "shelfmark": {
+              "postfix": "Faglig",
+              "shelfmark": "19.1"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["ABU201042", "DAR201042"],
+              "otherCatalogues": []
+            }
           }
         ],
         "latest": {
           "pid": "870971-tsart:34310815",
           "genreAndForm": [],
           "source": ["Tidsskriftsartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
             "main": ["Faglig formidling er ikke kun skriveteknik"],
             "original": []
@@ -115,34 +178,86 @@
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            }
           ],
           "creators": [
-            { "display": "Leif Becker Jensen", "__typename": "Person" }
+            {
+              "display": "Leif Becker Jensen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2010",
-            "publicationYear": { "display": "2010" }
+            "publicationYear": {
+              "display": "2010"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 6, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "01071424" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["Med litteraturhenvisninger"]
+            }
           ],
-          "shelfmark": { "postfix": "Faglig", "shelfmark": "19.1" },
-          "workYear": null
+          "physicalDescriptions": [
+            {
+              "summary": "S. 8-13: ill.",
+              "numberOfPages": 6,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Dansk noter, Nr. 3 (2010)"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "01071424"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Faglig",
+            "shelfmark": "19.1"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201042", "DAR201042"],
+            "otherCatalogues": []
+          }
         },
         "bestRepresentation": {
           "pid": "870971-tsart:34310815",
           "genreAndForm": [],
           "source": ["Tidsskriftsartikler"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
           "titles": {
             "main": ["Faglig formidling er ikke kun skriveteknik"],
             "original": []
@@ -152,51 +267,134 @@
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "artikel" } }
+            {
+              "materialTypeSpecific": {
+                "display": "artikel"
+              }
+            }
           ],
           "creators": [
-            { "display": "Leif Becker Jensen", "__typename": "Person" }
+            {
+              "display": "Leif Becker Jensen",
+              "__typename": "Person"
+            }
           ],
           "publisher": [],
           "identifiers": [],
           "contributors": [],
           "edition": {
             "summary": "2010",
-            "publicationYear": { "display": "2010" }
+            "publicationYear": {
+              "display": "2010"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [{ "numberOfPages": 6, "playingTime": null }],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "01071424" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["Med litteraturhenvisninger"]
+            }
           ],
-          "shelfmark": { "postfix": "Faglig", "shelfmark": "19.1" },
-          "workYear": null
+          "physicalDescriptions": [
+            {
+              "summary": "S. 8-13: ill.",
+              "numberOfPages": 6,
+              "playingTime": null
+            }
+          ],
+          "hostPublication": {
+            "summary": "Dansk noter, Nr. 3 (2010)"
+          },
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "01071424"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Faglig",
+            "shelfmark": "19.1"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["ABU201042", "DAR201042"],
+            "otherCatalogues": []
+          }
         }
       },
-      "materialTypes": [{ "materialTypeSpecific": { "display": "artikel" } }],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
+      "materialTypes": [
+        {
+          "materialTypeSpecific": {
+            "display": "artikel"
+          }
+        }
+      ],
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
       "subjects": {
         "all": [
-          { "display": "formidling" },
-          { "display": "videnskab" },
-          { "display": "retorik" },
-          { "display": "forskning" },
-          { "display": "skriftlig fremstilling" }
+          {
+            "display": "formidling"
+          },
+          {
+            "display": "videnskab"
+          },
+          {
+            "display": "retorik"
+          },
+          {
+            "display": "forskning"
+          },
+          {
+            "display": "skriftlig fremstilling"
+          }
         ],
         "dbcVerified": [
-          { "display": "formidling" },
-          { "display": "videnskab" },
-          { "display": "retorik" },
-          { "display": "forskning" },
-          { "display": "skriftlig fremstilling" }
+          {
+            "display": "formidling"
+          },
+          {
+            "display": "videnskab"
+          },
+          {
+            "display": "retorik"
+          },
+          {
+            "display": "forskning"
+          },
+          {
+            "display": "skriftlig fremstilling"
+          }
         ]
       },
-      "fictionNonfiction": { "display": "faglitteratur", "code": "NONFICTION" },
-      "dk5MainEntry": { "display": "19.1 Forskningsteknik i alm." },
-      "relations": { "hasReview": [], "hasAdaptation": [] }
+      "fictionNonfiction": {
+        "display": "faglitteratur",
+        "code": "NONFICTION"
+      },
+      "dk5MainEntry": {
+        "display": "19.1 Forskningsteknik i alm."
+      },
+      "relations": {
+        "hasReview": [],
+        "hasAdaptation": []
+      }
     }
   }
 }

--- a/cypress/fixtures/material/periodical-fbi-api.json
+++ b/cypress/fixtures/material/periodical-fbi-api.json
@@ -2,7 +2,10 @@
   "data": {
     "work": {
       "workId": "work-of:870970-basis:06373674",
-      "titles": { "full": ["Alt for damerne"], "original": [] },
+      "titles": {
+        "full": ["Alt for damerne"],
+        "original": []
+      },
       "abstract": [],
       "creators": [],
       "series": [],
@@ -15,110 +18,317 @@
             "pid": "870970-basis:06373674",
             "genreAndForm": ["tidsskrift"],
             "source": ["Bibliotekskatalog"],
-            "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-            "titles": { "main": ["Alt for damerne"], "original": [] },
+            "languages": {
+              "main": [
+                {
+                  "display": "dansk",
+                  "isoCode": "dan"
+                }
+              ],
+              "notes": []
+            },
+            "titles": {
+              "main": ["Alt for damerne"],
+              "original": []
+            },
             "fictionNonfiction": {
               "display": "nonfiktion",
               "code": "NONFICTION"
             },
             "materialTypes": [
-              { "materialTypeSpecific": { "display": "tidsskrift" } }
+              {
+                "materialTypeSpecific": {
+                  "display": "tidsskrift"
+                }
+              }
             ],
             "creators": [],
             "publisher": ["Egmont Magasiner"],
-            "identifiers": [{ "value": "0002-6506" }],
+            "identifiers": [
+              {
+                "value": "0002-6506"
+              }
+            ],
             "contributors": [],
             "edition": {
               "summary": "1946",
-              "publicationYear": { "display": "1946" }
+              "publicationYear": {
+                "display": "1946"
+              }
             },
             "dateFirstEdition": null,
-            "audience": { "generalAudience": [] },
-            "physicalDescriptions": [],
-            "accessTypes": [{ "code": "PHYSICAL" }],
-            "access": [
-              { "__typename": "DigitalArticleService", "issn": "00026506" },
-              { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+            "audience": {
+              "generalAudience": [],
+              "ages": []
+            },
+            "notes": [
+              {
+                "display": ["[Nr. 1, 1946]-"]
+              },
+              {
+                "display": ["Ugentlig"]
+              },
+              {
+                "display": [
+                  "Tidligere udgivet: Kbh. : Gutenberghus Bladene",
+                  "Hertil findes tillæg",
+                  "Hertil findes årligt tillæg med titel: Skønhed"
+                ]
+              }
             ],
-            "shelfmark": { "postfix": "Alt", "shelfmark": "05.6" },
-            "workYear": null
+            "physicalDescriptions": [],
+            "hostPublication": null,
+            "manifestationParts": null,
+            "accessTypes": [
+              {
+                "code": "PHYSICAL"
+              }
+            ],
+            "access": [
+              {
+                "__typename": "DigitalArticleService",
+                "issn": "00026506"
+              },
+              {
+                "__typename": "InterLibraryLoan",
+                "loanIsPossible": true
+              }
+            ],
+            "shelfmark": {
+              "postfix": "Alt",
+              "shelfmark": "05.6"
+            },
+            "workYear": null,
+            "catalogueCodes": {
+              "nationalBibliography": ["DPF197680"],
+              "otherCatalogues": [
+                "DAT199834",
+                "DAT200523",
+                "DAT200945",
+                "DAT201246"
+              ]
+            }
           }
         ],
         "latest": {
           "pid": "870970-basis:06373674",
           "genreAndForm": ["tidsskrift"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Alt for damerne"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Alt for damerne"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "nonfiktion",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "tidsskrift" } }
+            {
+              "materialTypeSpecific": {
+                "display": "tidsskrift"
+              }
+            }
           ],
           "creators": [],
           "publisher": ["Egmont Magasiner"],
-          "identifiers": [{ "value": "0002-6506" }],
+          "identifiers": [
+            {
+              "value": "0002-6506"
+            }
+          ],
           "contributors": [],
           "edition": {
             "summary": "1946",
-            "publicationYear": { "display": "1946" }
+            "publicationYear": {
+              "display": "1946"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "00026506" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["[Nr. 1, 1946]-"]
+            },
+            {
+              "display": ["Ugentlig"]
+            },
+            {
+              "display": [
+                "Tidligere udgivet: Kbh. : Gutenberghus Bladene",
+                "Hertil findes tillæg",
+                "Hertil findes årligt tillæg med titel: Skønhed"
+              ]
+            }
           ],
-          "shelfmark": { "postfix": "Alt", "shelfmark": "05.6" },
-          "workYear": null
+          "physicalDescriptions": [],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "00026506"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Alt",
+            "shelfmark": "05.6"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DPF197680"],
+            "otherCatalogues": [
+              "DAT199834",
+              "DAT200523",
+              "DAT200945",
+              "DAT201246"
+            ]
+          }
         },
         "bestRepresentation": {
           "pid": "870970-basis:06373674",
           "genreAndForm": ["tidsskrift"],
           "source": ["Bibliotekskatalog"],
-          "languages": { "main": [{ "display": "dansk", "isoCode": "dan" }] },
-          "titles": { "main": ["Alt for damerne"], "original": [] },
+          "languages": {
+            "main": [
+              {
+                "display": "dansk",
+                "isoCode": "dan"
+              }
+            ],
+            "notes": []
+          },
+          "titles": {
+            "main": ["Alt for damerne"],
+            "original": []
+          },
           "fictionNonfiction": {
             "display": "nonfiktion",
             "code": "NONFICTION"
           },
           "materialTypes": [
-            { "materialTypeSpecific": { "display": "tidsskrift" } }
+            {
+              "materialTypeSpecific": {
+                "display": "tidsskrift"
+              }
+            }
           ],
           "creators": [],
           "publisher": ["Egmont Magasiner"],
-          "identifiers": [{ "value": "0002-6506" }],
+          "identifiers": [
+            {
+              "value": "0002-6506"
+            }
+          ],
           "contributors": [],
           "edition": {
             "summary": "1946",
-            "publicationYear": { "display": "1946" }
+            "publicationYear": {
+              "display": "1946"
+            }
           },
           "dateFirstEdition": null,
-          "audience": { "generalAudience": [] },
-          "physicalDescriptions": [],
-          "accessTypes": [{ "code": "PHYSICAL" }],
-          "access": [
-            { "__typename": "DigitalArticleService", "issn": "00026506" },
-            { "__typename": "InterLibraryLoan", "loanIsPossible": true }
+          "audience": {
+            "generalAudience": [],
+            "ages": []
+          },
+          "notes": [
+            {
+              "display": ["[Nr. 1, 1946]-"]
+            },
+            {
+              "display": ["Ugentlig"]
+            },
+            {
+              "display": [
+                "Tidligere udgivet: Kbh. : Gutenberghus Bladene",
+                "Hertil findes tillæg",
+                "Hertil findes årligt tillæg med titel: Skønhed"
+              ]
+            }
           ],
-          "shelfmark": { "postfix": "Alt", "shelfmark": "05.6" },
-          "workYear": null
+          "physicalDescriptions": [],
+          "hostPublication": null,
+          "manifestationParts": null,
+          "accessTypes": [
+            {
+              "code": "PHYSICAL"
+            }
+          ],
+          "access": [
+            {
+              "__typename": "DigitalArticleService",
+              "issn": "00026506"
+            },
+            {
+              "__typename": "InterLibraryLoan",
+              "loanIsPossible": true
+            }
+          ],
+          "shelfmark": {
+            "postfix": "Alt",
+            "shelfmark": "05.6"
+          },
+          "workYear": null,
+          "catalogueCodes": {
+            "nationalBibliography": ["DPF197680"],
+            "otherCatalogues": [
+              "DAT199834",
+              "DAT200523",
+              "DAT200945",
+              "DAT201246"
+            ]
+          }
         }
       },
       "materialTypes": [
-        { "materialTypeSpecific": { "display": "tidsskrift" } }
+        {
+          "materialTypeSpecific": {
+            "display": "tidsskrift"
+          }
+        }
       ],
-      "mainLanguages": [{ "display": "dansk", "isoCode": "dan" }],
-      "subjects": { "all": [], "dbcVerified": [] },
-      "fictionNonfiction": { "display": "nonfiktion", "code": "NONFICTION" },
+      "mainLanguages": [
+        {
+          "display": "dansk",
+          "isoCode": "dan"
+        }
+      ],
+      "subjects": {
+        "all": [],
+        "dbcVerified": []
+      },
+      "fictionNonfiction": {
+        "display": "nonfiktion",
+        "code": "NONFICTION"
+      },
       "dk5MainEntry": {
         "display": "05.6 Aviser. Periodica af blandet indhold. Danmark"
       },
-      "relations": { "hasReview": [], "hasAdaptation": [] }
+      "relations": {
+        "hasReview": [],
+        "hasAdaptation": []
+      }
     }
   }
 }

--- a/src/apps/favorites-list/favorites-list.test.ts
+++ b/src/apps/favorites-list/favorites-list.test.ts
@@ -63,7 +63,7 @@ describe("Favorites list", () => {
       .eq(0)
       .find("a")
       .should("have.attr", "href")
-      .should("include", "/work/work-of:870970-basis:51363035");
+      .should("include", "/work/work-of:870970-basis:20636866");
   });
   it("Favorites list paginates", () => {
     // 2.h it paginates

--- a/src/apps/material/__snapshots__/helper.ts.snap
+++ b/src/apps/material/__snapshots__/helper.ts.snap
@@ -16,7 +16,12 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
         },
       ],
       "audience": {
+        "ages": [],
         "generalAudience": [],
+      },
+      "catalogueCodes": {
+        "nationalBibliography": [],
+        "otherCatalogues": [],
       },
       "contributors": [],
       "creators": [
@@ -39,6 +44,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
       "genreAndForm": [
         "noveller",
       ],
+      "hostPublication": null,
       "identifiers": [
         {
           "value": "0-19-423069-4",
@@ -51,7 +57,9 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
             "isoCode": "eng",
           },
         ],
+        "notes": [],
       },
+      "manifestationParts": null,
       "materialTypes": [
         {
           "materialTypeSpecific": {
@@ -59,10 +67,12 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
           },
         },
       ],
+      "notes": [],
       "physicalDescriptions": [
         {
           "numberOfPages": 104,
           "playingTime": null,
+          "summary": "104 sider: ill.",
         },
       ],
       "pid": "870970-basis:23798255",
@@ -94,24 +104,6 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
           "origin": "link.overdrive.com",
           "url": "http://link.overdrive.com/?websiteID=100515&titleID=39136",
         },
-        {
-          "__typename": "AccessUrl",
-          "loginRequired": false,
-          "origin": "samples.overdrive.com",
-          "url": "https://samples.overdrive.com/?crid=9AB7D235-9D58-4180-8DF3-57A4A60CD51E&.epub-sample.overdrive.com",
-        },
-        {
-          "__typename": "AccessUrl",
-          "loginRequired": false,
-          "origin": "img1.od-cdn.com",
-          "url": "https://img1.od-cdn.com/ImageType-100/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg100.jpg",
-        },
-        {
-          "__typename": "AccessUrl",
-          "loginRequired": false,
-          "origin": "img1.od-cdn.com",
-          "url": "https://img1.od-cdn.com/ImageType-200/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg200.jpg",
-        },
       ],
       "accessTypes": [
         {
@@ -119,12 +111,17 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
         },
       ],
       "audience": {
+        "ages": [],
         "generalAudience": [
           "Text Difficulty 3 - Text Difficulty 5",
           "UG/Upper grades (9th-12)",
           "820. Lexile",
           "6.1. ATOS Level",
         ],
+      },
+      "catalogueCodes": {
+        "nationalBibliography": [],
+        "otherCatalogues": [],
       },
       "contributors": [],
       "creators": [
@@ -145,6 +142,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
         "display": "skønlitteratur",
       },
       "genreAndForm": [],
+      "hostPublication": null,
       "identifiers": [
         {
           "value": "9780553900330",
@@ -157,7 +155,9 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
             "isoCode": "eng",
           },
         ],
+        "notes": [],
       },
+      "manifestationParts": null,
       "materialTypes": [
         {
           "materialTypeSpecific": {
@@ -165,10 +165,18 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
           },
         },
       ],
+      "notes": [
+        {
+          "display": [
+            "Electronic reproduction. New York : Spectra, 2004. Requires the Libby app or a modern web browser",
+          ],
+        },
+      ],
       "physicalDescriptions": [
         {
           "numberOfPages": null,
           "playingTime": null,
+          "summary": "1 online resource",
         },
       ],
       "pid": "150061-ebog:ODN0000039136",
@@ -195,24 +203,6 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
           "origin": "link.overdrive.com",
           "url": "http://link.overdrive.com/?websiteID=100515&titleID=105225",
         },
-        {
-          "__typename": "AccessUrl",
-          "loginRequired": false,
-          "origin": "samples.overdrive.com",
-          "url": "https://samples.overdrive.com/?crid=A6AAE8CE-F944-44F3-960D-4E9A7715CDD5&.epub-sample.overdrive.com",
-        },
-        {
-          "__typename": "AccessUrl",
-          "loginRequired": false,
-          "origin": "img1.od-cdn.com",
-          "url": "https://img1.od-cdn.com/ImageType-100/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg100.jpg",
-        },
-        {
-          "__typename": "AccessUrl",
-          "loginRequired": false,
-          "origin": "img1.od-cdn.com",
-          "url": "https://img1.od-cdn.com/ImageType-200/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg200.jpg",
-        },
       ],
       "accessTypes": [
         {
@@ -220,10 +210,15 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
         },
       ],
       "audience": {
+        "ages": [],
         "generalAudience": [
           "Text Difficulty 3 - Text Difficulty 4",
           "820. Lexile",
         ],
+      },
+      "catalogueCodes": {
+        "nationalBibliography": [],
+        "otherCatalogues": [],
       },
       "contributors": [],
       "creators": [
@@ -248,6 +243,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
         "display": "vides ikke",
       },
       "genreAndForm": [],
+      "hostPublication": null,
       "identifiers": [
         {
           "value": "9780739346273",
@@ -260,7 +256,9 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
             "isoCode": "eng",
           },
         ],
+        "notes": [],
       },
+      "manifestationParts": null,
       "materialTypes": [
         {
           "materialTypeSpecific": {
@@ -268,10 +266,18 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
           },
         },
       ],
+      "notes": [
+        {
+          "display": [
+            "Unabridged",
+          ],
+        },
+      ],
       "physicalDescriptions": [
         {
           "numberOfPages": null,
           "playingTime": null,
+          "summary": "1 online resource (7 audio files) digital",
         },
       ],
       "pid": "150061-netlydbog:ODN0000105225",
@@ -305,6 +311,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
         },
       ],
       "audience": {
+        "ages": [],
         "generalAudience": [],
       },
       "catalogueCodes": {
@@ -339,6 +346,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
       "genreAndForm": [
         "noveller",
       ],
+      "hostPublication": null,
       "identifiers": [
         {
           "value": "9780230026810",
@@ -354,7 +362,9 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
             "isoCode": "eng",
           },
         ],
+        "notes": [],
       },
+      "manifestationParts": null,
       "materialTypes": [
         {
           "materialTypeSpecific": {
@@ -367,10 +377,18 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
           },
         },
       ],
+      "notes": [
+        {
+          "display": [
+            "Bogens originaludgave: 1950",
+          ],
+        },
+      ],
       "physicalDescriptions": [
         {
           "numberOfPages": 95,
           "playingTime": "2t., 31 min.",
+          "summary": "2 cd'er 1 bog 95 sider: ill. 2t., 31 min.",
         },
       ],
       "pid": "870970-basis:44504928",

--- a/src/apps/material/__vitest_data__/helper.ts
+++ b/src/apps/material/__vitest_data__/helper.ts
@@ -13,7 +13,8 @@ export default {
               display: "engelsk",
               isoCode: "eng"
             }
-          ]
+          ],
+          notes: []
         },
         titles: {
           main: ["I, Robot (Ved Tricia Reilly)"],
@@ -66,14 +67,23 @@ export default {
           year: 1950
         },
         audience: {
-          generalAudience: []
+          generalAudience: [],
+          ages: []
         },
+        notes: [
+          {
+            display: ["Bogens originaludgave: 1950"]
+          }
+        ],
         physicalDescriptions: [
           {
+            summary: "2 cd'er 1 bog 95 sider: ill. 2t., 31 min.",
             numberOfPages: 95,
             playingTime: "2t., 31 min."
           }
         ],
+        hostPublication: null,
+        manifestationParts: null,
         accessTypes: [
           {
             code: "PHYSICAL"
@@ -107,7 +117,8 @@ export default {
               display: "engelsk",
               isoCode: "eng"
             }
-          ]
+          ],
+          notes: []
         },
         titles: {
           main: ["I, Robot"],
@@ -150,14 +161,25 @@ export default {
             "UG/Upper grades (9th-12)",
             "820. Lexile",
             "6.1. ATOS Level"
-          ]
+          ],
+          ages: []
         },
+        notes: [
+          {
+            display: [
+              "Electronic reproduction. New York : Spectra, 2004. Requires the Libby app or a modern web browser"
+            ]
+          }
+        ],
         physicalDescriptions: [
           {
+            summary: "1 online resource",
             numberOfPages: null,
             playingTime: null
           }
         ],
+        hostPublication: null,
+        manifestationParts: null,
         accessTypes: [
           {
             code: "ONLINE"
@@ -169,28 +191,14 @@ export default {
             origin: "link.overdrive.com",
             url: "http://link.overdrive.com/?websiteID=100515&titleID=39136",
             loginRequired: false
-          },
-          {
-            __typename: "AccessUrl",
-            origin: "samples.overdrive.com",
-            url: "https://samples.overdrive.com/?crid=9AB7D235-9D58-4180-8DF3-57A4A60CD51E&.epub-sample.overdrive.com",
-            loginRequired: false
-          },
-          {
-            __typename: "AccessUrl",
-            origin: "img1.od-cdn.com",
-            url: "https://img1.od-cdn.com/ImageType-100/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg100.jpg",
-            loginRequired: false
-          },
-          {
-            __typename: "AccessUrl",
-            origin: "img1.od-cdn.com",
-            url: "https://img1.od-cdn.com/ImageType-200/0111-1/%7B9AB7D235-9D58-4180-8DF3-57A4A60CD51E%7DImg200.jpg",
-            loginRequired: false
           }
         ],
         shelfmark: null,
-        workYear: null
+        workYear: null,
+        catalogueCodes: {
+          nationalBibliography: [],
+          otherCatalogues: []
+        }
       },
       {
         pid: "150061-netlydbog:ODN0000105225",
@@ -202,7 +210,8 @@ export default {
               display: "engelsk",
               isoCode: "eng"
             }
-          ]
+          ],
+          notes: []
         },
         titles: {
           main: ["I, Robot"],
@@ -247,14 +256,23 @@ export default {
           generalAudience: [
             "Text Difficulty 3 - Text Difficulty 4",
             "820. Lexile"
-          ]
+          ],
+          ages: []
         },
+        notes: [
+          {
+            display: ["Unabridged"]
+          }
+        ],
         physicalDescriptions: [
           {
+            summary: "1 online resource (7 audio files) digital",
             numberOfPages: null,
             playingTime: null
           }
         ],
+        hostPublication: null,
+        manifestationParts: null,
         accessTypes: [
           {
             code: "ONLINE"
@@ -266,28 +284,14 @@ export default {
             origin: "link.overdrive.com",
             url: "http://link.overdrive.com/?websiteID=100515&titleID=105225",
             loginRequired: false
-          },
-          {
-            __typename: "AccessUrl",
-            origin: "samples.overdrive.com",
-            url: "https://samples.overdrive.com/?crid=A6AAE8CE-F944-44F3-960D-4E9A7715CDD5&.epub-sample.overdrive.com",
-            loginRequired: false
-          },
-          {
-            __typename: "AccessUrl",
-            origin: "img1.od-cdn.com",
-            url: "https://img1.od-cdn.com/ImageType-100/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg100.jpg",
-            loginRequired: false
-          },
-          {
-            __typename: "AccessUrl",
-            origin: "img1.od-cdn.com",
-            url: "https://img1.od-cdn.com/ImageType-200/1191-1/%7BA6AAE8CE-F944-44F3-960D-4E9A7715CDD5%7DImg200.jpg",
-            loginRequired: false
           }
         ],
         shelfmark: null,
-        workYear: null
+        workYear: null,
+        catalogueCodes: {
+          nationalBibliography: [],
+          otherCatalogues: []
+        }
       },
       {
         pid: "870970-basis:23798255",
@@ -299,7 +303,8 @@ export default {
               display: "engelsk",
               isoCode: "eng"
             }
-          ]
+          ],
+          notes: []
         },
         titles: {
           main: ["I, Robot (Oxford bookworms library, ved Rowena Akinyemi)"],
@@ -337,14 +342,19 @@ export default {
         },
         dateFirstEdition: null,
         audience: {
-          generalAudience: []
+          generalAudience: [],
+          ages: []
         },
+        notes: [],
         physicalDescriptions: [
           {
+            summary: "104 sider: ill.",
             numberOfPages: 104,
             playingTime: null
           }
         ],
+        hostPublication: null,
+        manifestationParts: null,
         accessTypes: [
           {
             code: "PHYSICAL"
@@ -360,7 +370,11 @@ export default {
           postfix: "Asimov",
           shelfmark: "83.8"
         },
-        workYear: null
+        workYear: null,
+        catalogueCodes: {
+          nationalBibliography: [],
+          otherCatalogues: []
+        }
       }
     ] as Manifestation[]
   }

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -130,6 +130,10 @@ export const getManifestationIsbn = (manifestation: Manifestation) => {
   return manifestation.identifiers?.[0]?.value ?? "";
 };
 
+export const getManifestationSource = (manifestation: Manifestation) => {
+  return manifestation.source ?? "";
+};
+
 export const getManifestationLanguages = (manifestation: Manifestation) => {
   const { languages } = manifestation;
 

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -6,7 +6,10 @@ import {
   flattenCreators
 } from "../../core/utils/helpers/general";
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
-import { ListData } from "../../components/material/MaterialDetailsList";
+import {
+  ListData,
+  ListItemType
+} from "../../components/material/MaterialDetailsList";
 import {
   HoldingsForBibliographicalRecordV3,
   HoldingsV3
@@ -216,7 +219,7 @@ export const getManifestationParts = (
   manifestation: Manifestation
 ): string[] => {
   return (
-    manifestation.manifestationParts?.parts?.map((item) => item.title) || []
+    manifestation.manifestationParts?.parts?.map((item) => item.title) || null
   );
 };
 
@@ -238,93 +241,75 @@ export const getDetailsListData = ({
   return [
     {
       label: t("detailsListLanguageText"),
-      value: getManifestationLanguages(manifestation ?? fallBackManifestation),
-      type: "standard"
+      value: getManifestationLanguages(manifestation ?? fallBackManifestation)
     },
     {
       label: t("detailsListPlayTimeText"),
-      value: getManifestationPlayingTime(
-        manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      value: getManifestationPlayingTime(manifestation ?? fallBackManifestation)
     },
     {
       label: t("detailsListEditionText"),
-      value: getManifestationEdition(manifestation ?? fallBackManifestation),
-      type: "standard"
+      value: getManifestationEdition(manifestation ?? fallBackManifestation)
     },
 
     {
       label: t("detailsListGenreAndFormText"),
       value: getManifestationGenreAndForm(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListOriginalTitleText"),
       value: getManifestationOriginalTitle(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListPublisherText"),
-      value: getManifestationPublisher(manifestation ?? fallBackManifestation),
-      type: "standard"
+      value: getManifestationPublisher(manifestation ?? fallBackManifestation)
     },
     {
       label: t("detailsListFirstEditionYearText"),
-      value: workFirstEditionYear,
-      type: "standard"
+      value: workFirstEditionYear
     },
     {
       label: t("detailsListTypeText"),
       value: getManifestationMaterialTypes(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListContributorsText"),
       value: getManifestationContributors(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListScopeText"),
       value: getManifestationNumberOfPages(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListAudienceText"),
-      value: getManifestationAudience(
-        manifestation ?? fallBackManifestation,
-        t
-      ),
-      type: "standard"
+      value: getManifestationAudience(manifestation ?? fallBackManifestation, t)
     },
     {
       label: t("detailsListPhysicalDescriptionText"),
       value: getManifestationPhysicalDescription(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListHostPublicationText"),
       value: getManifestationHostPublication(
         manifestation ?? fallBackManifestation
-      ),
-      type: "standard"
+      )
     },
     {
       label: t("detailsListPartsText"),
       value: getManifestationParts(manifestation ?? fallBackManifestation),
-      type: "list"
+      type: ListItemType.Link
     }
   ];
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -157,7 +157,15 @@ export const getManifestationOriginalTitle = (manifestation: Manifestation) => {
 export const getManifestationContributors = (manifestation: Manifestation) => {
   return (
     manifestation.contributors
-      .map((contributor) => contributor.display)
+      .map((contributor) => {
+        if (contributor.roles.length > 0) {
+          const roleNames = contributor.roles
+            .map((role) => role.function.singular)
+            .join(", ");
+          return `${contributor.display} (${roleNames})`;
+        }
+        return contributor.display;
+      })
       .join(" / ") ?? ""
   );
 };
@@ -236,7 +244,7 @@ export const getDetailsListData = ({
       value: getManifestationContributors(
         manifestation ?? fallBackManifestation
       ),
-      type: "link"
+      type: "standard"
     },
     {
       label: t("detailsListScopeText"),

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -219,7 +219,7 @@ export const getManifestationParts = (
   manifestation: Manifestation
 ): string[] => {
   return (
-    manifestation.manifestationParts?.parts?.map((item) => item.title) || null
+    manifestation.manifestationParts?.parts?.map((item) => item.title) || []
   );
 };
 

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -207,6 +207,12 @@ export const getManifestationPhysicalDescription = (
   return manifestation.physicalDescriptions?.[0]?.summary ?? "";
 };
 
+export const getManifestationHostPublication = (
+  manifestation: Manifestation
+) => {
+  return manifestation.hostPublication?.summary ?? "";
+};
+
 export const getDetailsListData = ({
   manifestation,
   work,
@@ -297,6 +303,13 @@ export const getDetailsListData = ({
     {
       label: t("detailsListPhysicalDescriptionText"),
       value: getManifestationPhysicalDescription(
+        manifestation ?? fallBackManifestation
+      ),
+      type: "standard"
+    },
+    {
+      label: t("detailsListHostPublicationText"),
+      value: getManifestationHostPublication(
         manifestation ?? fallBackManifestation
       ),
       type: "standard"

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -212,6 +212,13 @@ export const getManifestationHostPublication = (
 ) => {
   return manifestation.hostPublication?.summary ?? "";
 };
+export const getManifestationParts = (
+  manifestation: Manifestation
+): string[] => {
+  return (
+    manifestation.manifestationParts?.parts?.map((item) => item.title) || []
+  );
+};
 
 export const getDetailsListData = ({
   manifestation,
@@ -313,6 +320,11 @@ export const getDetailsListData = ({
         manifestation ?? fallBackManifestation
       ),
       type: "standard"
+    },
+    {
+      label: t("detailsListPartsText"),
+      value: getManifestationParts(manifestation ?? fallBackManifestation),
+      type: "list"
     }
   ];
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -131,11 +131,17 @@ export const getManifestationIsbn = (manifestation: Manifestation) => {
 };
 
 export const getManifestationLanguages = (manifestation: Manifestation) => {
-  return (
-    manifestation.languages?.main
-      ?.map((language) => language.display)
-      .join(", ") ?? ""
-  );
+  const { languages } = manifestation;
+
+  if (languages?.notes?.length) {
+    return languages.notes.join(", ");
+  }
+
+  // Return main languages if no notes or empty notes.
+  const mainLanguages = languages?.main
+    ?.map((language) => language.display)
+    .join(", ");
+  return mainLanguages ?? "";
 };
 
 export const getManifestationLanguageIsoCode = (

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -309,7 +309,7 @@ export const getDetailsListData = ({
     {
       label: t("detailsListPartsText"),
       value: getManifestationParts(manifestation ?? fallBackManifestation),
-      type: ListItemType.Link
+      type: ListItemType.List
     }
   ];
 };

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -191,6 +191,12 @@ export const getManifestationNotes = (manifestation: Manifestation) => {
   return manifestation.notes?.[0]?.display?.join(", ") ?? "";
 };
 
+export const getManifestationPhysicalDescription = (
+  manifestation: Manifestation
+) => {
+  return manifestation.physicalDescriptions?.[0]?.summary ?? "";
+};
+
 export const getDetailsListData = ({
   manifestation,
   work,
@@ -275,6 +281,13 @@ export const getDetailsListData = ({
       value: getManifestationAudience(
         manifestation ?? fallBackManifestation,
         t
+      ),
+      type: "standard"
+    },
+    {
+      label: t("detailsListPhysicalDescriptionText"),
+      value: getManifestationPhysicalDescription(
+        manifestation ?? fallBackManifestation
       ),
       type: "standard"
     }

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -187,6 +187,10 @@ export const getManifestationAuthors = (manifestation: Manifestation) => {
   return flattenCreators(manifestation.creators).join(", ") ?? "";
 };
 
+export const getManifestationNotes = (manifestation: Manifestation) => {
+  return manifestation.notes?.[0]?.display?.join(", ") ?? "";
+};
+
 export const getDetailsListData = ({
   manifestation,
   work,

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -109,8 +109,21 @@ export const getManifestationNumberOfPages = (manifestation: Manifestation) => {
     : "";
 };
 
-export const getManifestationAudience = (manifestation: Manifestation) => {
-  return manifestation.audience?.generalAudience[0] ?? "";
+export const getManifestationAudience = (
+  manifestation: Manifestation,
+  t: UseTextFunction
+) => {
+  const generalAudience = manifestation.audience?.generalAudience[0] ?? "";
+  const agesDisplay = manifestation.audience?.ages[0]?.display ?? "";
+  const formattedAges = agesDisplay
+    ? t("detailsListAgeRangeText", {
+        placeholders: { "@ageRange": agesDisplay }
+      })
+    : "";
+
+  return generalAudience && formattedAges
+    ? `${generalAudience}, ${formattedAges}`
+    : generalAudience || formattedAges;
 };
 
 export const getManifestationIsbn = (manifestation: Manifestation) => {
@@ -255,7 +268,10 @@ export const getDetailsListData = ({
     },
     {
       label: t("detailsListAudienceText"),
-      value: getManifestationAudience(manifestation ?? fallBackManifestation),
+      value: getManifestationAudience(
+        manifestation ?? fallBackManifestation,
+        t
+      ),
       type: "standard"
     }
   ];

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -217,9 +217,9 @@ export const getManifestationHostPublication = (
 };
 export const getManifestationParts = (
   manifestation: Manifestation
-): string[] => {
+): string[] | string => {
   return (
-    manifestation.manifestationParts?.parts?.map((item) => item.title) || []
+    manifestation.manifestationParts?.parts?.map((item) => item.title) || ""
   );
 };
 

--- a/src/apps/material/login-redirect.test.ts
+++ b/src/apps/material/login-redirect.test.ts
@@ -45,7 +45,7 @@ describe("Material", () => {
       .and("contain", "Reserve bog")
       .click();
 
-    cy.getBySel("reservation-modal-parallel").should("be.visible");
+    cy.getBySel("reservation-modal").should("be.visible");
   });
 
   beforeEach(() => {

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -263,6 +263,11 @@ export default {
       defaultValue: "Source",
       control: { type: "text" }
     },
+    detailsListPartsText: {
+      name: "Contents",
+      defaultValue: "Contents",
+      control: { type: "text" }
+    },
     editionText: {
       name: "Edition",
       defaultValue: "Edition",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -243,6 +243,11 @@ export default {
       defaultValue: "Authors",
       control: { type: "text" }
     },
+    detailsListNotesText: {
+      name: "Notes",
+      defaultValue: "Notes",
+      control: { type: "text" }
+    },
     editionText: {
       name: "Edition",
       defaultValue: "Edition",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -253,6 +253,11 @@ export default {
       defaultValue: "Dimensions",
       control: { type: "text" }
     },
+    detailsListSourceText: {
+      name: "Source",
+      defaultValue: "Source",
+      control: { type: "text" }
+    },
     editionText: {
       name: "Edition",
       defaultValue: "Edition",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -213,6 +213,11 @@ export default {
       defaultValue: "Audience",
       control: { type: "text" }
     },
+    detailsListAgeRangeText: {
+      name: "Age range",
+      defaultValue: "for @ageRange year olds",
+      control: { type: "text" }
+    },
     detailsListGenreAndFormText: {
       name: "Genre and form",
       defaultValue: "Genre",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -253,6 +253,11 @@ export default {
       defaultValue: "Dimensions",
       control: { type: "text" }
     },
+    detailsListHostPublicationText: {
+      name: "Host Publication",
+      defaultValue: "Host Publication",
+      control: { type: "text" }
+    },
     detailsListSourceText: {
       name: "Source",
       defaultValue: "Source",

--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -248,6 +248,11 @@ export default {
       defaultValue: "Notes",
       control: { type: "text" }
     },
+    detailsListPhysicalDescriptionText: {
+      name: "Dimensions",
+      defaultValue: "Dimensions",
+      control: { type: "text" }
+    },
     editionText: {
       name: "Edition",
       defaultValue: "Edition",

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -26,6 +26,7 @@ interface MaterialEntryTextProps {
   detailsListAuthorsText: string;
   detailsListNotesText: string;
   detailsListPhysicalDescriptionText: string;
+  detailsListSourceText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;
   detailsListFirstEditionYearText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -22,6 +22,7 @@ interface MaterialEntryTextProps {
   daysText: string;
   descriptionHeadlineText: string;
   detailsListAudienceText: string;
+  detailsListAgeRangeText: string;
   detailsListAuthorsText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -26,6 +26,7 @@ interface MaterialEntryTextProps {
   detailsListAuthorsText: string;
   detailsListNotesText: string;
   detailsListPhysicalDescriptionText: string;
+  detailsListHostPublicationText: string;
   detailsListSourceText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -25,6 +25,7 @@ interface MaterialEntryTextProps {
   detailsListAgeRangeText: string;
   detailsListAuthorsText: string;
   detailsListNotesText: string;
+  detailsListPhysicalDescriptionText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;
   detailsListFirstEditionYearText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -24,6 +24,7 @@ interface MaterialEntryTextProps {
   detailsListAudienceText: string;
   detailsListAgeRangeText: string;
   detailsListAuthorsText: string;
+  detailsListNotesText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;
   detailsListFirstEditionYearText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -28,6 +28,7 @@ interface MaterialEntryTextProps {
   detailsListPhysicalDescriptionText: string;
   detailsListHostPublicationText: string;
   detailsListSourceText: string;
+  detailsListPartsText: string;
   detailsListContributorsText: string;
   detailsListEditionText: string;
   detailsListFirstEditionYearText: string;

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -121,6 +121,274 @@ describe("Material", () => {
     cy.getBySel("material-details-disclosure").click();
   });
 
+  it("Renders the correct details for books", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/fbi-api.json"
+    });
+
+    cy.visit("/iframe.html?id=apps-material--default&viewMode=story&type=bog");
+    cy.wait("@getMaterial GraphQL operation");
+
+    cy.scrollTo("bottom");
+    cy.getBySel("material-details-disclosure").click();
+
+    cy.get('[data-cy="list-description"]').within(() => {
+      // Verify "Language" field and its value
+      cy.get(".list-description__item")
+        .contains("Language")
+        .next()
+        .should("contain.text", "dansk");
+
+      // Verify "Edition" field and its value
+      cy.get(".list-description__item")
+        .contains("Edition")
+        .next()
+        .should("contain.text", "1. udgave, 2016");
+
+      // Verify "Genre" field and its value
+      cy.get(".list-description__item")
+        .contains("Genre")
+        .next()
+        .should("contain.text", "roman / slægtsromaner");
+
+      // Verify "Original title" field and its value
+      cy.get(".list-description__item")
+        .contains("Original title")
+        .next()
+        .should("contain.text", "The seven sisters");
+
+      // Verify "Publisher" field and its value
+      cy.get(".list-description__item")
+        .contains("Publisher")
+        .next()
+        .should("contain.text", "Cicero");
+
+      // Verify "Type" field and its value
+      cy.get(".list-description__item")
+        .contains("Type")
+        .next()
+        .should("contain.text", "bog");
+
+      // Verify "Contributors" field and its value
+      cy.get(".list-description__item")
+        .contains("Contributors")
+        .next()
+        .should("contain.text", "Ulla Lauridsen (oversætter)");
+
+      // Verify "Scope" field and its value
+      cy.get(".list-description__item")
+        .contains("Scope")
+        .next()
+        .should("contain.text", "523");
+
+      // Verify "Dimensions" field and its value
+      cy.get(".list-description__item")
+        .contains("Dimensions")
+        .next()
+        .should("contain.text", "523 sider");
+    });
+
+    cy.getBySel("material-editions-disclosure").click();
+    cy.get(".material-manifestation-item__details").first().click();
+
+    cy.get('[data-cy="list-description"]').within(() => {
+      // Verify "Type" field and its value
+      cy.get(".list-description__item")
+        .contains("Type")
+        .next()
+        .should("contain.text", "bog");
+
+      // Verify "Language" field and its value
+      cy.get(".list-description__item")
+        .contains("Language")
+        .next()
+        .should("contain.text", "dansk");
+
+      // Verify "Genre" field and its value
+      cy.get(".list-description__item")
+        .contains("Genre")
+        .next()
+        .should("contain.text", "roman / slægtsromaner");
+
+      // Verify "Contributors" field and its value
+      cy.get(".list-description__item")
+        .contains("Contributors")
+        .next()
+        .should("contain.text", "Ulla Lauridsen (oversætter)");
+
+      // Verify "Original title" field and its value
+      cy.get(".list-description__item")
+        .contains("Original title")
+        .next()
+        .should("contain.text", "The seven sisters");
+
+      // Verify "ISBN" field and its value
+      cy.get(".list-description__item")
+        .contains("ISBN")
+        .next()
+        .should("contain.text", "9788763844116");
+
+      // Verify "Edition" field and its value
+      cy.get(".list-description__item")
+        .contains("Edition")
+        .next()
+        .should("contain.text", "1. udgave, 2016");
+
+      // Verify "Scope" field and its value
+      cy.get(".list-description__item")
+        .contains("Scope")
+        .next()
+        .should("contain.text", "523");
+
+      // Verify "Publisher" field and its value
+      cy.get(".list-description__item")
+        .contains("Publisher")
+        .next()
+        .should("contain.text", "Cicero");
+
+      // Verify "Authors" field and its value
+      cy.get(".list-description__item")
+        .contains("Authors")
+        .next()
+        .should("contain.text", "Lucinda Riley");
+
+      // Verify "Dimensions" field and its value
+      cy.get(".list-description__item")
+        .contains("Dimensions")
+        .next()
+        .should("contain.text", "523 sider");
+
+      // Verify "Source" field and its value
+      cy.get(".list-description__item")
+        .contains("Source")
+        .next()
+        .should("contain.text", "Bibliotekskatalog");
+    });
+  });
+
+  it("Renders the correct details for infomedia", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/infomedia-fbi-api.json"
+    });
+
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--infomedia&viewMode=story&type=artikel"
+    );
+    cy.wait("@getMaterial GraphQL operation");
+
+    cy.scrollTo("bottom");
+    cy.getBySel("material-details-disclosure").click();
+
+    cy.get('[data-cy="list-description"]').within(() => {
+      // Verify "Language" field and its value
+      cy.get(".list-description__item")
+        .contains("Language")
+        .next()
+        .should("contain.text", "dansk");
+
+      // Verify "Edition" field and its value
+      cy.get(".list-description__item")
+        .contains("Edition")
+        .next()
+        .should("contain.text", "2013");
+
+      // Verify "Type" field and its value
+      cy.get(".list-description__item")
+        .contains("Type")
+        .next()
+        .should("contain.text", "artikel");
+
+      // Verify "Scope" field and its value
+      cy.get(".list-description__item")
+        .contains("Scope")
+        .next()
+        .should("contain.text", "2");
+
+      // Verify "Dimensions" field and its value
+      cy.get(".list-description__item")
+        .contains("Dimensions")
+        .next()
+        .should("contain.text", "Sektion 3, s. 6-7: ill.");
+
+      // Verify "Host Publication" field and its value
+      cy.get(".list-description__item")
+        .contains("Host Publication")
+        .next()
+        .should("contain.text", "Politiken, 2013-09-19");
+    });
+  });
+
+  it("Renders the correct details for music", () => {
+    cy.interceptGraphql({
+      operationName: "getMaterial",
+      fixtureFilePath: "material/music-fbi-api.json"
+    });
+
+    cy.visit(
+      "/iframe.html?args=&id=apps-material--default&viewMode=story&type=musik+%28cd%29"
+    );
+    cy.wait("@getMaterial GraphQL operation");
+
+    cy.scrollTo("bottom");
+    cy.getBySel("material-details-disclosure").click();
+    cy.get('[data-cy="list-description"]').within(() => {
+      // Verify "Publisher" field and its value
+      cy.get(".list-description__item")
+        .contains("Publisher")
+        .next()
+        .should("contain.text", "Warner Bros.");
+
+      // Verify "Type" field and its value
+      cy.get(".list-description__item")
+        .contains("Type")
+        .next()
+        .should("contain.text", "musik (cd)");
+
+      // Verify "Contributors" field and its value
+      cy.get(".list-description__item")
+        .contains("Contributors")
+        .next()
+        .should(
+          "contain.text",
+          "Michael Bruce / Dennis Dunaway / Neal Smith / Glen Buxton"
+        );
+
+      // Verify "Dimensions" field and its value
+      cy.get(".list-description__item")
+        .contains("Dimensions")
+        .next()
+        .should("contain.text", "Stereo");
+
+      // Verify "Contents" field and its list values
+      cy.get(".list-description__item")
+        .contains("Contents")
+        .next()
+        .within(() => {
+          // Validate each list item in "Contents"
+          const contents = [
+            "Hello hooray",
+            "Raped and freezin'",
+            "Elected",
+            "Billion dollar babies",
+            "Unfinished sweet",
+            "No more Mr. Nice Guy",
+            "Generation landslide",
+            "Sick things",
+            "Mary Ann",
+            "I love the dead"
+          ];
+
+          contents.forEach((item, index) => {
+            cy.get(".list-description__value--list li")
+              .eq(index)
+              .should("have.text", item);
+          });
+        });
+    });
+  });
+
   it("Renders editions with a reservation button", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",

--- a/src/components/description-list/description-list.tsx
+++ b/src/components/description-list/description-list.tsx
@@ -12,7 +12,11 @@ const DescriptionList: React.FC<DescriptionListProps> = ({
   id
 }) => {
   return (
-    <dl id={id} className={`list-description ${classNames ?? ""}`}>
+    <dl
+      id={id}
+      className={`list-description ${classNames ?? ""}`}
+      data-cy="list-description"
+    >
       {data.map((item) => {
         const { label, value } = item;
         return (

--- a/src/components/find-on-shelf/mocked-data.ts
+++ b/src/components/find-on-shelf/mocked-data.ts
@@ -15,7 +15,7 @@ export const mockedManifestationData: Manifestation[] = [
     },
     fictionNonfiction: {
       display: "SKOENLITTERATUR",
-      code: "FICTION" as FictionNonfictionCode
+      code: FictionNonfictionCode.Fiction
     },
     materialTypes: [
       {
@@ -46,7 +46,14 @@ export const mockedManifestationData: Manifestation[] = [
     ],
     contributors: [
       {
-        display: "Ulla Lauridsen"
+        display: "Ulla Lauridsen",
+        roles: [
+          {
+            function: {
+              singular: "oversætter"
+            }
+          }
+        ]
       }
     ],
     edition: {
@@ -56,16 +63,19 @@ export const mockedManifestationData: Manifestation[] = [
       }
     },
     audience: {
-      generalAudience: []
+      generalAudience: [],
+      ages: []
     },
+    notes: [],
     physicalDescriptions: [
       {
-        numberOfPages: null
+        numberOfPages: null,
+        summary: ""
       }
     ],
     accessTypes: [
       {
-        code: "PHYSICAL" as AccessTypeCode
+        code: AccessTypeCode.Physical
       }
     ],
     access: [
@@ -121,10 +131,24 @@ export const mockedManifestationData: Manifestation[] = [
     ],
     contributors: [
       {
-        display: "Maria Stokholm"
+        display: "Maria Stokholm",
+        roles: [
+          {
+            function: {
+              singular: "indlæser"
+            }
+          }
+        ]
       },
       {
-        display: "Ulla Lauridsen"
+        display: "Ulla Lauridsen",
+        roles: [
+          {
+            function: {
+              singular: "oversætter"
+            }
+          }
+        ]
       }
     ],
     edition: {
@@ -134,11 +158,21 @@ export const mockedManifestationData: Manifestation[] = [
       }
     },
     audience: {
-      generalAudience: []
+      generalAudience: [],
+      ages: []
     },
+    notes: [
+      {
+        display: [
+          "Gengivelse af bogen",
+          "Indlæst efter 1. udgave. 2016. ISBN: 9788763844116"
+        ]
+      }
+    ],
     physicalDescriptions: [
       {
-        numberOfPages: null
+        numberOfPages: null,
+        summary: ""
       }
     ],
     accessTypes: [
@@ -203,8 +237,24 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
       }
     },
     audience: {
-      generalAudience: []
+      generalAudience: [],
+      ages: []
     },
+    notes: [
+      {
+        display: ["[Nr. 1, 1946]-"]
+      },
+      {
+        display: ["Ugentlig"]
+      },
+      {
+        display: [
+          "Tidligere udgivet: Kbh. : Gutenberghus Bladene",
+          "Hertil findes tillæg",
+          "Hertil findes årligt tillæg med titel: Skønhed"
+        ]
+      }
+    ],
     physicalDescriptions: [],
     accessTypes: [
       {

--- a/src/components/material/MaterialDetailsList.tsx
+++ b/src/components/material/MaterialDetailsList.tsx
@@ -2,11 +2,47 @@ import * as React from "react";
 import { FC } from "react";
 import DescriptionList from "../description-list/description-list";
 
-export type ListData = {
+// Enums for item types
+enum ListItemType {
+  Standard = "standard",
+  Link = "link",
+  List = "list"
+}
+
+interface IListDataItem {
   label: string;
-  value: string;
-  type: "standard" | "link";
-}[];
+  value: string | string[];
+  type: ListItemType;
+}
+
+type ListData = IListDataItem[];
+
+const ListItem = ({ value }: { value: string[] }) => (
+  <ul>
+    {value.map((item) => (
+      <li key={item}>{item}</li>
+    ))}
+  </ul>
+);
+
+interface MaterialDetailsListRowProps {
+  value: string | string[];
+  type: ListItemType;
+}
+
+const MaterialDetailsListRow: FC<MaterialDetailsListRowProps> = ({
+  type,
+  value
+}) => {
+  switch (type) {
+    case ListItemType.Link:
+      return <span className="link-tag pr-4">{value}</span>;
+    case ListItemType.List:
+      return Array.isArray(value) ? <ListItem value={value} /> : null;
+    default:
+      return <span>{value}</span>;
+  }
+};
 
 export interface MaterialDetailsListProps {
   className?: string;
@@ -23,13 +59,10 @@ const MaterialDetailsList: FC<MaterialDetailsListProps> = ({
     .filter((item) => item.value)
     .map((item) => {
       const { label, value, type } = item;
-      const rowValue =
-        type === "link" ? (
-          <span className="link-tag pr-4">{value}</span>
-        ) : (
-          <span>{value}</span>
-        );
-      return { label, value: rowValue };
+      return {
+        label,
+        value: <MaterialDetailsListRow type={type} value={value} />
+      };
     });
 
   return <DescriptionList id={id} data={listData} classNames={className} />;

--- a/src/components/material/MaterialDetailsList.tsx
+++ b/src/components/material/MaterialDetailsList.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import DescriptionList from "../description-list/description-list";
 
 // Enums for item types
-enum ListItemType {
+export enum ListItemType {
   Standard = "standard",
   Link = "link",
   List = "list"
@@ -12,18 +12,24 @@ enum ListItemType {
 interface IListDataItem {
   label: string;
   value: string | string[];
-  type: ListItemType;
+  type?: ListItemType;
 }
 
-type ListData = IListDataItem[];
+export type ListData = IListDataItem[];
 
-const ListItem = ({ value }: { value: string[] }) => (
-  <ul>
-    {value.map((item) => (
-      <li key={item}>{item}</li>
-    ))}
-  </ul>
-);
+const ListItem = ({ value }: { value: string[] }) => {
+  if (value.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul>
+      {value.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+};
 
 interface MaterialDetailsListRowProps {
   value: string | string[];

--- a/src/components/material/MaterialDetailsList.tsx
+++ b/src/components/material/MaterialDetailsList.tsx
@@ -33,7 +33,7 @@ const ListItem = ({ value }: { value: string[] }) => {
 
 interface MaterialDetailsListRowProps {
   value: string | string[];
-  type: ListItemType;
+  type?: ListItemType;
 }
 
 const MaterialDetailsListRow: FC<MaterialDetailsListRowProps> = ({

--- a/src/components/material/MaterialDetailsList.tsx
+++ b/src/components/material/MaterialDetailsList.tsx
@@ -23,7 +23,7 @@ const ListItem = ({ value }: { value: string[] }) => {
   }
 
   return (
-    <ul>
+    <ul className="list-description__value--list">
       {value.map((item) => (
         <li key={item}>{item}</li>
       ))}

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -51,73 +51,59 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
   const detailsListData: ListData = [
     {
       label: t("detailsListTypeText"),
-      value: getManifestationMaterialTypes(manifestation),
-      type: "standard"
+      value: getManifestationMaterialTypes(manifestation)
     },
     {
       label: t("detailsListLanguageText"),
-      value: getManifestationLanguages(manifestation),
-      type: "standard"
+      value: getManifestationLanguages(manifestation)
     },
     {
       label: t("detailsListGenreAndFormText"),
-      value: getManifestationGenreAndForm(manifestation),
-      type: "standard"
+      value: getManifestationGenreAndForm(manifestation)
     },
     {
       label: t("detailsListContributorsText"),
-      value: getManifestationContributors(manifestation),
-      type: "standard"
+      value: getManifestationContributors(manifestation)
     },
     {
       label: t("detailsListOriginalTitleText"),
-      value: getManifestationOriginalTitle(manifestation),
-      type: "standard"
+      value: getManifestationOriginalTitle(manifestation)
     },
     {
       label: t("detailsListIsbnText"),
-      value: getManifestationIsbn(manifestation),
-      type: "standard"
+      value: getManifestationIsbn(manifestation)
     },
     {
       label: t("detailsListEditionText"),
-      value: getManifestationEdition(manifestation),
-      type: "standard"
+      value: getManifestationEdition(manifestation)
     },
     {
       label: t("detailsListScopeText"),
-      value: getManifestationNumberOfPages(manifestation),
-      type: "standard"
+      value: getManifestationNumberOfPages(manifestation)
     },
     {
       label: t("detailsListPublisherText"),
-      value: getManifestationPublisher(manifestation),
-      type: "standard"
+      value: getManifestationPublisher(manifestation)
     },
     {
       label: t("detailsListAudienceText"),
-      value: getManifestationAudience(manifestation, t),
-      type: "standard"
+      value: getManifestationAudience(manifestation, t)
     },
     {
       label: t("detailsListAuthorsText"),
-      value: getManifestationAuthors(manifestation),
-      type: "standard"
+      value: getManifestationAuthors(manifestation)
     },
     {
       label: t("detailsListPhysicalDescriptionText"),
-      value: getManifestationPhysicalDescription(manifestation),
-      type: "standard"
+      value: getManifestationPhysicalDescription(manifestation)
     },
     {
       label: t("detailsListNotesText"),
-      value: getManifestationNotes(manifestation),
-      type: "standard"
+      value: getManifestationNotes(manifestation)
     },
     {
       label: t("detailsListSourceText"),
-      value: getManifestationSource(manifestation),
-      type: "standard"
+      value: getManifestationSource(manifestation)
     }
   ];
 

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -26,7 +26,8 @@ import {
   getManifestationNumberOfPages,
   getManifestationOriginalTitle,
   getManifestationPhysicalDescription,
-  getManifestationPublisher
+  getManifestationPublisher,
+  getManifestationSource
 } from "../../apps/material/helper";
 
 export interface MaterialMainfestationItemProps {
@@ -111,6 +112,11 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     {
       label: t("detailsListNotesText"),
       value: getManifestationNotes(manifestation),
+      type: "standard"
+    },
+    {
+      label: t("detailsListSourceText"),
+      value: getManifestationSource(manifestation),
       type: "standard"
     }
   ];

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -93,7 +93,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     },
     {
       label: t("detailsListAudienceText"),
-      value: getManifestationAudience(manifestation),
+      value: getManifestationAudience(manifestation, t),
       type: "standard"
     },
     {

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -64,7 +64,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     {
       label: t("detailsListContributorsText"),
       value: getManifestationContributors(manifestation),
-      type: "link"
+      type: "standard"
     },
     {
       label: t("detailsListOriginalTitleText"),

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -25,6 +25,7 @@ import {
   getManifestationNotes,
   getManifestationNumberOfPages,
   getManifestationOriginalTitle,
+  getManifestationPhysicalDescription,
   getManifestationPublisher
 } from "../../apps/material/helper";
 
@@ -100,6 +101,11 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     {
       label: t("detailsListAuthorsText"),
       value: getManifestationAuthors(manifestation),
+      type: "standard"
+    },
+    {
+      label: t("detailsListPhysicalDescriptionText"),
+      value: getManifestationPhysicalDescription(manifestation),
       type: "standard"
     },
     {

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -22,6 +22,7 @@ import {
   getManifestationLanguageIsoCode,
   getManifestationLanguages,
   getManifestationMaterialTypes,
+  getManifestationNotes,
   getManifestationNumberOfPages,
   getManifestationOriginalTitle,
   getManifestationPublisher
@@ -99,6 +100,11 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
     {
       label: t("detailsListAuthorsText"),
       value: getManifestationAuthors(manifestation),
+      type: "standard"
+    },
+    {
+      label: t("detailsListNotesText"),
+      value: getManifestationNotes(manifestation),
       type: "standard"
     }
   ];

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -103,6 +103,9 @@ fragment ManifestationsSimpleFields on Manifestation {
     numberOfPages
     playingTime
   }
+  hostPublication {
+    summary
+  }
   accessTypes {
     code
   }

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -70,6 +70,11 @@ fragment ManifestationsSimpleFields on Manifestation {
   }
   contributors {
     display
+    roles {
+      function {
+        singular
+      }
+    }
   }
   edition {
     summary

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -92,6 +92,9 @@ fragment ManifestationsSimpleFields on Manifestation {
       display
     }
   }
+  notes {
+    display
+  }
   physicalDescriptions {
     numberOfPages
     playingTime

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -96,6 +96,7 @@ fragment ManifestationsSimpleFields on Manifestation {
     display
   }
   physicalDescriptions {
+    summary
     numberOfPages
     playingTime
   }

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -88,6 +88,9 @@ fragment ManifestationsSimpleFields on Manifestation {
   }
   audience {
     generalAudience
+    ages {
+      display
+    }
   }
   physicalDescriptions {
     numberOfPages

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -106,6 +106,11 @@ fragment ManifestationsSimpleFields on Manifestation {
   hostPublication {
     summary
   }
+  manifestationParts {
+    parts {
+      title
+    }
+  }
   accessTypes {
     code
   }

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -95,6 +95,9 @@ fragment ManifestationsSimpleFields on Manifestation {
   notes {
     display
   }
+  languages {
+    notes
+  }
   physicalDescriptions {
     summary
     numberOfPages

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -354,6 +354,18 @@
             "deprecationReason": null
           },
           {
+            "name": "levelForChildren8to12",
+            "description": "Level of difficulty, illustrations, length, and realism in children's literature",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "LevelForAudience",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "libraryRecommendation",
             "description": "Appropriate audience as recommended by the library",
             "args": [],
@@ -768,6 +780,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "ACCESSTYPE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "AGES",
             "description": null,
             "isDeprecated": false,
@@ -852,6 +870,12 @@
             "deprecationReason": null
           },
           {
+            "name": "HOSTPUBLICATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ISSUE",
             "description": null,
             "isDeprecated": false,
@@ -864,7 +888,19 @@
             "deprecationReason": null
           },
           {
+            "name": "LET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "LIBRARYRECOMMENDATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LIX",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -876,7 +912,31 @@
             "deprecationReason": null
           },
           {
+            "name": "MEDIACOUNCILAGERESTRICTION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MOOD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "MUSICALENSEMBLEORCAST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NARRATIVETECHNIQUE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PEGI",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -889,6 +949,24 @@
           },
           {
             "name": "PRIMARYTARGET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PUBLICATIONYEAR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SERIES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SETTING",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -3651,6 +3729,65 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LevelForAudience",
+        "description": null,
+        "fields": [
+          {
+            "name": "difficulty",
+            "description": "Level expressed as integer on a scale from 1 to 5",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "illustrationsLevel",
+            "description": "Level expressed as integer on a scale from 1 to 5",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "length",
+            "description": "Level expressed as integer on a scale from 1 to 5",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "realisticVsFictional",
+            "description": "Level expressed as integer on a scale from 1 to 5",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -9888,6 +10025,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "SubjectWithRating",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "TimePeriod",
             "ofType": null
           }
@@ -10170,8 +10312,99 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "TOPIC_CHILDREN",
+            "description": "Subject describing selected topics for children, and a rating.",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SubjectWithRating",
+        "description": null,
+        "fields": [
+          {
+            "name": "display",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "language",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Language",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "local",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rating",
+            "description": "Expressed as integer on a scale from 1 to 5",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SubjectType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Subject",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/src/core/dbc-gateway/generated/graphql.tsx
+++ b/src/core/dbc-gateway/generated/graphql.tsx
@@ -86,6 +86,8 @@ export type Audience = {
   generalAudience: Array<Scalars["String"]>;
   /** LET number of this manifestion, defines the reability level, LET stands for læseegnethedstal */
   let?: Maybe<Scalars["String"]>;
+  /** Level of difficulty, illustrations, length, and realism in children's literature */
+  levelForChildren8to12?: Maybe<LevelForAudience>;
   /** Appropriate audience as recommended by the library */
   libraryRecommendation?: Maybe<Scalars["String"]>;
   /** Lix number of this manifestion, defines the reability level, Lix stands for læsbarhedsindex */
@@ -149,6 +151,7 @@ export type ComplexSearchFacetValue = {
 
 /** The supported facet fields */
 export enum ComplexSearchFacets {
+  Accesstype = "ACCESSTYPE",
   Ages = "AGES",
   Cataloguecode = "CATALOGUECODE",
   Contributor = "CONTRIBUTOR",
@@ -163,13 +166,23 @@ export enum ComplexSearchFacets {
   Generalaudience = "GENERALAUDIENCE",
   Generalmaterialtype = "GENERALMATERIALTYPE",
   Genreandform = "GENREANDFORM",
+  Hostpublication = "HOSTPUBLICATION",
   Issue = "ISSUE",
   Language = "LANGUAGE",
+  Let = "LET",
   Libraryrecommendation = "LIBRARYRECOMMENDATION",
+  Lix = "LIX",
   Mainlanguage = "MAINLANGUAGE",
+  Mediacouncilagerestriction = "MEDIACOUNCILAGERESTRICTION",
+  Mood = "MOOD",
   Musicalensembleorcast = "MUSICALENSEMBLEORCAST",
+  Narrativetechnique = "NARRATIVETECHNIQUE",
+  Pegi = "PEGI",
   Players = "PLAYERS",
   Primarytarget = "PRIMARYTARGET",
+  Publicationyear = "PUBLICATIONYEAR",
+  Series = "SERIES",
+  Setting = "SETTING",
   Specificmaterialtype = "SPECIFICMATERIALTYPE",
   Spokenlanguage = "SPOKENLANGUAGE",
   Subject = "SUBJECT",
@@ -611,6 +624,18 @@ export type Languages = {
   spoken?: Maybe<Array<Language>>;
   /** Subtitles in this manifestation */
   subtitles?: Maybe<Array<Language>>;
+};
+
+export type LevelForAudience = {
+  __typename?: "LevelForAudience";
+  /** Level expressed as integer on a scale from 1 to 5 */
+  difficulty?: Maybe<Scalars["Int"]>;
+  /** Level expressed as integer on a scale from 1 to 5 */
+  illustrationsLevel?: Maybe<Scalars["Int"]>;
+  /** Level expressed as integer on a scale from 1 to 5 */
+  length?: Maybe<Scalars["Int"]>;
+  /** Level expressed as integer on a scale from 1 to 5 */
+  realisticVsFictional?: Maybe<Scalars["Int"]>;
 };
 
 export type LinkCheckResponse = {
@@ -1468,8 +1493,20 @@ export enum SubjectType {
   Tempo = "TEMPO",
   TimePeriod = "TIME_PERIOD",
   Title = "TITLE",
-  Topic = "TOPIC"
+  Topic = "TOPIC",
+  /** Subject describing selected topics for children, and a rating. */
+  TopicChildren = "TOPIC_CHILDREN"
 }
+
+export type SubjectWithRating = Subject & {
+  __typename?: "SubjectWithRating";
+  display: Scalars["String"];
+  language?: Maybe<Language>;
+  local?: Maybe<Scalars["Boolean"]>;
+  /** Expressed as integer on a scale from 1 to 5 */
+  rating?: Maybe<Scalars["Int"]>;
+  type: SubjectType;
+};
 
 export type SubmitOrder = {
   __typename?: "SubmitOrder";
@@ -1845,8 +1882,22 @@ export type GetSmallWorkQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -1864,12 +1915,32 @@ export type GetSmallWorkQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -1902,14 +1973,6 @@ export type GetSmallWorkQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       }>;
       latest: {
         __typename?: "Manifestation";
@@ -1940,8 +2003,22 @@ export type GetSmallWorkQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -1959,12 +2036,32 @@ export type GetSmallWorkQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -1997,14 +2094,6 @@ export type GetSmallWorkQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       };
       bestRepresentation: {
         __typename?: "Manifestation";
@@ -2035,8 +2124,22 @@ export type GetSmallWorkQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2054,12 +2157,32 @@ export type GetSmallWorkQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -2092,14 +2215,6 @@ export type GetSmallWorkQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       };
     };
   } | null;
@@ -2283,6 +2398,7 @@ export type GetMaterialQuery = {
         | { __typename?: "Person"; display: string }
         | { __typename?: "Setting"; display: string }
         | { __typename?: "SubjectText"; display: string }
+        | { __typename?: "SubjectWithRating"; display: string }
         | { __typename?: "TimePeriod"; display: string }
       >;
       dbcVerified: Array<
@@ -2292,6 +2408,7 @@ export type GetMaterialQuery = {
         | { __typename?: "Person"; display: string }
         | { __typename?: "Setting"; display: string }
         | { __typename?: "SubjectText"; display: string }
+        | { __typename?: "SubjectWithRating"; display: string }
         | { __typename?: "TimePeriod"; display: string }
       >;
     };
@@ -2377,8 +2494,22 @@ export type GetMaterialQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2396,12 +2527,32 @@ export type GetMaterialQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -2434,14 +2585,6 @@ export type GetMaterialQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       }>;
       latest: {
         __typename?: "Manifestation";
@@ -2472,8 +2615,22 @@ export type GetMaterialQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2491,12 +2648,32 @@ export type GetMaterialQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -2529,14 +2706,6 @@ export type GetMaterialQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       };
       bestRepresentation: {
         __typename?: "Manifestation";
@@ -2567,8 +2736,22 @@ export type GetMaterialQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2586,12 +2769,32 @@ export type GetMaterialQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -2624,14 +2827,6 @@ export type GetMaterialQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       };
     };
   } | null;
@@ -2669,6 +2864,7 @@ export type GetMaterialGloballyQuery = {
         | { __typename?: "Person"; display: string }
         | { __typename?: "Setting"; display: string }
         | { __typename?: "SubjectText"; display: string }
+        | { __typename?: "SubjectWithRating"; display: string }
         | { __typename?: "TimePeriod"; display: string }
       >;
       dbcVerified: Array<
@@ -2678,6 +2874,7 @@ export type GetMaterialGloballyQuery = {
         | { __typename?: "Person"; display: string }
         | { __typename?: "Setting"; display: string }
         | { __typename?: "SubjectText"; display: string }
+        | { __typename?: "SubjectWithRating"; display: string }
         | { __typename?: "TimePeriod"; display: string }
       >;
     };
@@ -2763,8 +2960,22 @@ export type GetMaterialGloballyQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2782,12 +2993,32 @@ export type GetMaterialGloballyQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -2820,14 +3051,6 @@ export type GetMaterialGloballyQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       }>;
       latest: {
         __typename?: "Manifestation";
@@ -2858,8 +3081,22 @@ export type GetMaterialGloballyQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2877,12 +3114,32 @@ export type GetMaterialGloballyQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -2915,14 +3172,6 @@ export type GetMaterialGloballyQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       };
       bestRepresentation: {
         __typename?: "Manifestation";
@@ -2953,8 +3202,22 @@ export type GetMaterialGloballyQuery = {
         >;
         identifiers: Array<{ __typename?: "Identifier"; value: string }>;
         contributors: Array<
-          | { __typename?: "Corporation"; display: string }
-          | { __typename?: "Person"; display: string }
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
         >;
         edition?: {
           __typename?: "Edition";
@@ -2972,12 +3235,32 @@ export type GetMaterialGloballyQuery = {
         audience?: {
           __typename?: "Audience";
           generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
         } | null;
         physicalDescriptions: Array<{
           __typename?: "PhysicalDescription";
+          summary: string;
           numberOfPages?: number | null;
           playingTime?: string | null;
         }>;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
         accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
         access: Array<
           | {
@@ -3010,14 +3293,6 @@ export type GetMaterialGloballyQuery = {
           nationalBibliography: Array<string>;
           otherCatalogues: Array<string>;
         };
-        languages?: {
-          __typename?: "Languages";
-          main?: Array<{
-            __typename?: "Language";
-            display: string;
-            isoCode: string;
-          }> | null;
-        } | null;
       };
     };
   } | null;
@@ -3195,8 +3470,22 @@ export type RecommendFromFaustQuery = {
             >;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
-              | { __typename?: "Corporation"; display: string }
-              | { __typename?: "Person"; display: string }
+              | {
+                  __typename?: "Corporation";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
+              | {
+                  __typename?: "Person";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
             >;
             edition?: {
               __typename?: "Edition";
@@ -3214,12 +3503,32 @@ export type RecommendFromFaustQuery = {
             audience?: {
               __typename?: "Audience";
               generalAudience: Array<string>;
+              ages: Array<{ __typename?: "Range"; display: string }>;
+            } | null;
+            notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+            languages?: {
+              __typename?: "Languages";
+              notes?: Array<string> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
             physicalDescriptions: Array<{
               __typename?: "PhysicalDescription";
+              summary: string;
               numberOfPages?: number | null;
               playingTime?: string | null;
             }>;
+            hostPublication?: {
+              __typename?: "HostPublication";
+              summary: string;
+            } | null;
+            manifestationParts?: {
+              __typename?: "ManifestationParts";
+              parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+            } | null;
             accessTypes: Array<{
               __typename?: "AccessType";
               code: AccessTypeCode;
@@ -3255,14 +3564,6 @@ export type RecommendFromFaustQuery = {
               nationalBibliography: Array<string>;
               otherCatalogues: Array<string>;
             };
-            languages?: {
-              __typename?: "Languages";
-              main?: Array<{
-                __typename?: "Language";
-                display: string;
-                isoCode: string;
-              }> | null;
-            } | null;
           }>;
           latest: {
             __typename?: "Manifestation";
@@ -3293,8 +3594,22 @@ export type RecommendFromFaustQuery = {
             >;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
-              | { __typename?: "Corporation"; display: string }
-              | { __typename?: "Person"; display: string }
+              | {
+                  __typename?: "Corporation";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
+              | {
+                  __typename?: "Person";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
             >;
             edition?: {
               __typename?: "Edition";
@@ -3312,12 +3627,32 @@ export type RecommendFromFaustQuery = {
             audience?: {
               __typename?: "Audience";
               generalAudience: Array<string>;
+              ages: Array<{ __typename?: "Range"; display: string }>;
+            } | null;
+            notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+            languages?: {
+              __typename?: "Languages";
+              notes?: Array<string> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
             physicalDescriptions: Array<{
               __typename?: "PhysicalDescription";
+              summary: string;
               numberOfPages?: number | null;
               playingTime?: string | null;
             }>;
+            hostPublication?: {
+              __typename?: "HostPublication";
+              summary: string;
+            } | null;
+            manifestationParts?: {
+              __typename?: "ManifestationParts";
+              parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+            } | null;
             accessTypes: Array<{
               __typename?: "AccessType";
               code: AccessTypeCode;
@@ -3353,14 +3688,6 @@ export type RecommendFromFaustQuery = {
               nationalBibliography: Array<string>;
               otherCatalogues: Array<string>;
             };
-            languages?: {
-              __typename?: "Languages";
-              main?: Array<{
-                __typename?: "Language";
-                display: string;
-                isoCode: string;
-              }> | null;
-            } | null;
           };
           bestRepresentation: {
             __typename?: "Manifestation";
@@ -3391,8 +3718,22 @@ export type RecommendFromFaustQuery = {
             >;
             identifiers: Array<{ __typename?: "Identifier"; value: string }>;
             contributors: Array<
-              | { __typename?: "Corporation"; display: string }
-              | { __typename?: "Person"; display: string }
+              | {
+                  __typename?: "Corporation";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
+              | {
+                  __typename?: "Person";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
             >;
             edition?: {
               __typename?: "Edition";
@@ -3410,12 +3751,32 @@ export type RecommendFromFaustQuery = {
             audience?: {
               __typename?: "Audience";
               generalAudience: Array<string>;
+              ages: Array<{ __typename?: "Range"; display: string }>;
+            } | null;
+            notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+            languages?: {
+              __typename?: "Languages";
+              notes?: Array<string> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
             } | null;
             physicalDescriptions: Array<{
               __typename?: "PhysicalDescription";
+              summary: string;
               numberOfPages?: number | null;
               playingTime?: string | null;
             }>;
+            hostPublication?: {
+              __typename?: "HostPublication";
+              summary: string;
+            } | null;
+            manifestationParts?: {
+              __typename?: "ManifestationParts";
+              parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+            } | null;
             accessTypes: Array<{
               __typename?: "AccessType";
               code: AccessTypeCode;
@@ -3451,14 +3812,6 @@ export type RecommendFromFaustQuery = {
               nationalBibliography: Array<string>;
               otherCatalogues: Array<string>;
             };
-            languages?: {
-              __typename?: "Languages";
-              main?: Array<{
-                __typename?: "Language";
-                display: string;
-                isoCode: string;
-              }> | null;
-            } | null;
           };
         };
       };
@@ -3549,8 +3902,22 @@ export type SearchWithPaginationQuery = {
           >;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
-            | { __typename?: "Corporation"; display: string }
-            | { __typename?: "Person"; display: string }
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
           >;
           edition?: {
             __typename?: "Edition";
@@ -3568,12 +3935,32 @@ export type SearchWithPaginationQuery = {
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           physicalDescriptions: Array<{
             __typename?: "PhysicalDescription";
+            summary: string;
             numberOfPages?: number | null;
             playingTime?: string | null;
           }>;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
           accessTypes: Array<{
             __typename?: "AccessType";
             code: AccessTypeCode;
@@ -3609,14 +3996,6 @@ export type SearchWithPaginationQuery = {
             nationalBibliography: Array<string>;
             otherCatalogues: Array<string>;
           };
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
         }>;
         latest: {
           __typename?: "Manifestation";
@@ -3647,8 +4026,22 @@ export type SearchWithPaginationQuery = {
           >;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
-            | { __typename?: "Corporation"; display: string }
-            | { __typename?: "Person"; display: string }
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
           >;
           edition?: {
             __typename?: "Edition";
@@ -3666,12 +4059,32 @@ export type SearchWithPaginationQuery = {
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           physicalDescriptions: Array<{
             __typename?: "PhysicalDescription";
+            summary: string;
             numberOfPages?: number | null;
             playingTime?: string | null;
           }>;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
           accessTypes: Array<{
             __typename?: "AccessType";
             code: AccessTypeCode;
@@ -3707,14 +4120,6 @@ export type SearchWithPaginationQuery = {
             nationalBibliography: Array<string>;
             otherCatalogues: Array<string>;
           };
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
         };
         bestRepresentation: {
           __typename?: "Manifestation";
@@ -3745,8 +4150,22 @@ export type SearchWithPaginationQuery = {
           >;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
-            | { __typename?: "Corporation"; display: string }
-            | { __typename?: "Person"; display: string }
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
           >;
           edition?: {
             __typename?: "Edition";
@@ -3764,12 +4183,32 @@ export type SearchWithPaginationQuery = {
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           physicalDescriptions: Array<{
             __typename?: "PhysicalDescription";
+            summary: string;
             numberOfPages?: number | null;
             playingTime?: string | null;
           }>;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
           accessTypes: Array<{
             __typename?: "AccessType";
             code: AccessTypeCode;
@@ -3805,14 +4244,6 @@ export type SearchWithPaginationQuery = {
             nationalBibliography: Array<string>;
             otherCatalogues: Array<string>;
           };
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
         };
       };
     }>;
@@ -3950,8 +4381,22 @@ export type ComplexSearchWithPaginationQuery = {
           >;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
-            | { __typename?: "Corporation"; display: string }
-            | { __typename?: "Person"; display: string }
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
           >;
           edition?: {
             __typename?: "Edition";
@@ -3969,12 +4414,32 @@ export type ComplexSearchWithPaginationQuery = {
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           physicalDescriptions: Array<{
             __typename?: "PhysicalDescription";
+            summary: string;
             numberOfPages?: number | null;
             playingTime?: string | null;
           }>;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
           accessTypes: Array<{
             __typename?: "AccessType";
             code: AccessTypeCode;
@@ -4010,14 +4475,6 @@ export type ComplexSearchWithPaginationQuery = {
             nationalBibliography: Array<string>;
             otherCatalogues: Array<string>;
           };
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
         }>;
         latest: {
           __typename?: "Manifestation";
@@ -4048,8 +4505,22 @@ export type ComplexSearchWithPaginationQuery = {
           >;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
-            | { __typename?: "Corporation"; display: string }
-            | { __typename?: "Person"; display: string }
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
           >;
           edition?: {
             __typename?: "Edition";
@@ -4067,12 +4538,32 @@ export type ComplexSearchWithPaginationQuery = {
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           physicalDescriptions: Array<{
             __typename?: "PhysicalDescription";
+            summary: string;
             numberOfPages?: number | null;
             playingTime?: string | null;
           }>;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
           accessTypes: Array<{
             __typename?: "AccessType";
             code: AccessTypeCode;
@@ -4108,14 +4599,6 @@ export type ComplexSearchWithPaginationQuery = {
             nationalBibliography: Array<string>;
             otherCatalogues: Array<string>;
           };
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
         };
         bestRepresentation: {
           __typename?: "Manifestation";
@@ -4146,8 +4629,22 @@ export type ComplexSearchWithPaginationQuery = {
           >;
           identifiers: Array<{ __typename?: "Identifier"; value: string }>;
           contributors: Array<
-            | { __typename?: "Corporation"; display: string }
-            | { __typename?: "Person"; display: string }
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
           >;
           edition?: {
             __typename?: "Edition";
@@ -4165,12 +4662,32 @@ export type ComplexSearchWithPaginationQuery = {
           audience?: {
             __typename?: "Audience";
             generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
           } | null;
           physicalDescriptions: Array<{
             __typename?: "PhysicalDescription";
+            summary: string;
             numberOfPages?: number | null;
             playingTime?: string | null;
           }>;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
           accessTypes: Array<{
             __typename?: "AccessType";
             code: AccessTypeCode;
@@ -4206,14 +4723,6 @@ export type ComplexSearchWithPaginationQuery = {
             nationalBibliography: Array<string>;
             otherCatalogues: Array<string>;
           };
-          languages?: {
-            __typename?: "Languages";
-            main?: Array<{
-              __typename?: "Language";
-              display: string;
-              isoCode: string;
-            }> | null;
-          } | null;
         };
       };
     }>;
@@ -4355,8 +4864,22 @@ export type ManifestationsSimpleFragment = {
     >;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
-      | { __typename?: "Corporation"; display: string }
-      | { __typename?: "Person"; display: string }
+      | {
+          __typename?: "Corporation";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
+      | {
+          __typename?: "Person";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
     >;
     edition?: {
       __typename?: "Edition";
@@ -4374,12 +4897,32 @@ export type ManifestationsSimpleFragment = {
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
+      ages: Array<{ __typename?: "Range"; display: string }>;
+    } | null;
+    notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+    languages?: {
+      __typename?: "Languages";
+      notes?: Array<string> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
     } | null;
     physicalDescriptions: Array<{
       __typename?: "PhysicalDescription";
+      summary: string;
       numberOfPages?: number | null;
       playingTime?: string | null;
     }>;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      summary: string;
+    } | null;
+    manifestationParts?: {
+      __typename?: "ManifestationParts";
+      parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+    } | null;
     accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
     access: Array<
       | {
@@ -4409,14 +4952,6 @@ export type ManifestationsSimpleFragment = {
       nationalBibliography: Array<string>;
       otherCatalogues: Array<string>;
     };
-    languages?: {
-      __typename?: "Languages";
-      main?: Array<{
-        __typename?: "Language";
-        display: string;
-        isoCode: string;
-      }> | null;
-    } | null;
   }>;
   latest: {
     __typename?: "Manifestation";
@@ -4447,8 +4982,22 @@ export type ManifestationsSimpleFragment = {
     >;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
-      | { __typename?: "Corporation"; display: string }
-      | { __typename?: "Person"; display: string }
+      | {
+          __typename?: "Corporation";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
+      | {
+          __typename?: "Person";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
     >;
     edition?: {
       __typename?: "Edition";
@@ -4466,12 +5015,32 @@ export type ManifestationsSimpleFragment = {
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
+      ages: Array<{ __typename?: "Range"; display: string }>;
+    } | null;
+    notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+    languages?: {
+      __typename?: "Languages";
+      notes?: Array<string> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
     } | null;
     physicalDescriptions: Array<{
       __typename?: "PhysicalDescription";
+      summary: string;
       numberOfPages?: number | null;
       playingTime?: string | null;
     }>;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      summary: string;
+    } | null;
+    manifestationParts?: {
+      __typename?: "ManifestationParts";
+      parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+    } | null;
     accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
     access: Array<
       | {
@@ -4501,14 +5070,6 @@ export type ManifestationsSimpleFragment = {
       nationalBibliography: Array<string>;
       otherCatalogues: Array<string>;
     };
-    languages?: {
-      __typename?: "Languages";
-      main?: Array<{
-        __typename?: "Language";
-        display: string;
-        isoCode: string;
-      }> | null;
-    } | null;
   };
   bestRepresentation: {
     __typename?: "Manifestation";
@@ -4539,8 +5100,22 @@ export type ManifestationsSimpleFragment = {
     >;
     identifiers: Array<{ __typename?: "Identifier"; value: string }>;
     contributors: Array<
-      | { __typename?: "Corporation"; display: string }
-      | { __typename?: "Person"; display: string }
+      | {
+          __typename?: "Corporation";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
+      | {
+          __typename?: "Person";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
     >;
     edition?: {
       __typename?: "Edition";
@@ -4558,12 +5133,32 @@ export type ManifestationsSimpleFragment = {
     audience?: {
       __typename?: "Audience";
       generalAudience: Array<string>;
+      ages: Array<{ __typename?: "Range"; display: string }>;
+    } | null;
+    notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+    languages?: {
+      __typename?: "Languages";
+      notes?: Array<string> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
     } | null;
     physicalDescriptions: Array<{
       __typename?: "PhysicalDescription";
+      summary: string;
       numberOfPages?: number | null;
       playingTime?: string | null;
     }>;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      summary: string;
+    } | null;
+    manifestationParts?: {
+      __typename?: "ManifestationParts";
+      parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+    } | null;
     accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
     access: Array<
       | {
@@ -4593,14 +5188,6 @@ export type ManifestationsSimpleFragment = {
       nationalBibliography: Array<string>;
       otherCatalogues: Array<string>;
     };
-    languages?: {
-      __typename?: "Languages";
-      main?: Array<{
-        __typename?: "Language";
-        display: string;
-        isoCode: string;
-      }> | null;
-    } | null;
   };
 };
 
@@ -4663,8 +5250,22 @@ export type ManifestationsSimpleFieldsFragment = {
   >;
   identifiers: Array<{ __typename?: "Identifier"; value: string }>;
   contributors: Array<
-    | { __typename?: "Corporation"; display: string }
-    | { __typename?: "Person"; display: string }
+    | {
+        __typename?: "Corporation";
+        display: string;
+        roles: Array<{
+          __typename?: "Role";
+          function: { __typename?: "Translation"; singular: string };
+        }>;
+      }
+    | {
+        __typename?: "Person";
+        display: string;
+        roles: Array<{
+          __typename?: "Role";
+          function: { __typename?: "Translation"; singular: string };
+        }>;
+      }
   >;
   edition?: {
     __typename?: "Edition";
@@ -4679,12 +5280,32 @@ export type ManifestationsSimpleFieldsFragment = {
     display: string;
     year?: number | null;
   } | null;
-  audience?: { __typename?: "Audience"; generalAudience: Array<string> } | null;
+  audience?: {
+    __typename?: "Audience";
+    generalAudience: Array<string>;
+    ages: Array<{ __typename?: "Range"; display: string }>;
+  } | null;
+  notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+  languages?: {
+    __typename?: "Languages";
+    notes?: Array<string> | null;
+    main?: Array<{
+      __typename?: "Language";
+      display: string;
+      isoCode: string;
+    }> | null;
+  } | null;
   physicalDescriptions: Array<{
     __typename?: "PhysicalDescription";
+    summary: string;
     numberOfPages?: number | null;
     playingTime?: string | null;
   }>;
+  hostPublication?: { __typename?: "HostPublication"; summary: string } | null;
+  manifestationParts?: {
+    __typename?: "ManifestationParts";
+    parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+  } | null;
   accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
   access: Array<
     | {
@@ -4714,14 +5335,6 @@ export type ManifestationsSimpleFieldsFragment = {
     nationalBibliography: Array<string>;
     otherCatalogues: Array<string>;
   };
-  languages?: {
-    __typename?: "Languages";
-    main?: Array<{
-      __typename?: "Language";
-      display: string;
-      isoCode: string;
-    }> | null;
-  } | null;
 };
 
 export type ManifestationReviewFieldsFragment = {
@@ -4888,8 +5501,22 @@ export type WorkSmallFragment = {
       >;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
-        | { __typename?: "Corporation"; display: string }
-        | { __typename?: "Person"; display: string }
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
       >;
       edition?: {
         __typename?: "Edition";
@@ -4907,12 +5534,32 @@ export type WorkSmallFragment = {
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       physicalDescriptions: Array<{
         __typename?: "PhysicalDescription";
+        summary: string;
         numberOfPages?: number | null;
         playingTime?: string | null;
       }>;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
       accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
       access: Array<
         | {
@@ -4945,14 +5592,6 @@ export type WorkSmallFragment = {
         nationalBibliography: Array<string>;
         otherCatalogues: Array<string>;
       };
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
     }>;
     latest: {
       __typename?: "Manifestation";
@@ -4983,8 +5622,22 @@ export type WorkSmallFragment = {
       >;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
-        | { __typename?: "Corporation"; display: string }
-        | { __typename?: "Person"; display: string }
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
       >;
       edition?: {
         __typename?: "Edition";
@@ -5002,12 +5655,32 @@ export type WorkSmallFragment = {
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       physicalDescriptions: Array<{
         __typename?: "PhysicalDescription";
+        summary: string;
         numberOfPages?: number | null;
         playingTime?: string | null;
       }>;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
       accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
       access: Array<
         | {
@@ -5040,14 +5713,6 @@ export type WorkSmallFragment = {
         nationalBibliography: Array<string>;
         otherCatalogues: Array<string>;
       };
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
     };
     bestRepresentation: {
       __typename?: "Manifestation";
@@ -5078,8 +5743,22 @@ export type WorkSmallFragment = {
       >;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
-        | { __typename?: "Corporation"; display: string }
-        | { __typename?: "Person"; display: string }
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
       >;
       edition?: {
         __typename?: "Edition";
@@ -5097,12 +5776,32 @@ export type WorkSmallFragment = {
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       physicalDescriptions: Array<{
         __typename?: "PhysicalDescription";
+        summary: string;
         numberOfPages?: number | null;
         playingTime?: string | null;
       }>;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
       accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
       access: Array<
         | {
@@ -5135,14 +5834,6 @@ export type WorkSmallFragment = {
         nationalBibliography: Array<string>;
         otherCatalogues: Array<string>;
       };
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
     };
   };
 };
@@ -5173,6 +5864,7 @@ export type WorkMediumFragment = {
       | { __typename?: "Person"; display: string }
       | { __typename?: "Setting"; display: string }
       | { __typename?: "SubjectText"; display: string }
+      | { __typename?: "SubjectWithRating"; display: string }
       | { __typename?: "TimePeriod"; display: string }
     >;
     dbcVerified: Array<
@@ -5182,6 +5874,7 @@ export type WorkMediumFragment = {
       | { __typename?: "Person"; display: string }
       | { __typename?: "Setting"; display: string }
       | { __typename?: "SubjectText"; display: string }
+      | { __typename?: "SubjectWithRating"; display: string }
       | { __typename?: "TimePeriod"; display: string }
     >;
   };
@@ -5267,8 +5960,22 @@ export type WorkMediumFragment = {
       >;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
-        | { __typename?: "Corporation"; display: string }
-        | { __typename?: "Person"; display: string }
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
       >;
       edition?: {
         __typename?: "Edition";
@@ -5286,12 +5993,32 @@ export type WorkMediumFragment = {
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       physicalDescriptions: Array<{
         __typename?: "PhysicalDescription";
+        summary: string;
         numberOfPages?: number | null;
         playingTime?: string | null;
       }>;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
       accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
       access: Array<
         | {
@@ -5324,14 +6051,6 @@ export type WorkMediumFragment = {
         nationalBibliography: Array<string>;
         otherCatalogues: Array<string>;
       };
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
     }>;
     latest: {
       __typename?: "Manifestation";
@@ -5362,8 +6081,22 @@ export type WorkMediumFragment = {
       >;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
-        | { __typename?: "Corporation"; display: string }
-        | { __typename?: "Person"; display: string }
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
       >;
       edition?: {
         __typename?: "Edition";
@@ -5381,12 +6114,32 @@ export type WorkMediumFragment = {
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       physicalDescriptions: Array<{
         __typename?: "PhysicalDescription";
+        summary: string;
         numberOfPages?: number | null;
         playingTime?: string | null;
       }>;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
       accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
       access: Array<
         | {
@@ -5419,14 +6172,6 @@ export type WorkMediumFragment = {
         nationalBibliography: Array<string>;
         otherCatalogues: Array<string>;
       };
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
     };
     bestRepresentation: {
       __typename?: "Manifestation";
@@ -5457,8 +6202,22 @@ export type WorkMediumFragment = {
       >;
       identifiers: Array<{ __typename?: "Identifier"; value: string }>;
       contributors: Array<
-        | { __typename?: "Corporation"; display: string }
-        | { __typename?: "Person"; display: string }
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
       >;
       edition?: {
         __typename?: "Edition";
@@ -5476,12 +6235,32 @@ export type WorkMediumFragment = {
       audience?: {
         __typename?: "Audience";
         generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
       } | null;
       physicalDescriptions: Array<{
         __typename?: "PhysicalDescription";
+        summary: string;
         numberOfPages?: number | null;
         playingTime?: string | null;
       }>;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
       accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCode }>;
       access: Array<
         | {
@@ -5514,14 +6293,6 @@ export type WorkMediumFragment = {
         nationalBibliography: Array<string>;
         otherCatalogues: Array<string>;
       };
-      languages?: {
-        __typename?: "Languages";
-        main?: Array<{
-          __typename?: "Language";
-          display: string;
-          isoCode: string;
-        }> | null;
-      } | null;
     };
   };
 };
@@ -5715,6 +6486,11 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
   }
   contributors {
     display
+    roles {
+      function {
+        singular
+      }
+    }
   }
   edition {
     summary
@@ -5728,10 +6504,28 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
   }
   audience {
     generalAudience
+    ages {
+      display
+    }
+  }
+  notes {
+    display
+  }
+  languages {
+    notes
   }
   physicalDescriptions {
+    summary
     numberOfPages
     playingTime
+  }
+  hostPublication {
+    summary
+  }
+  manifestationParts {
+    parts {
+      title
+    }
   }
   accessTypes {
     code


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-543

#### Description

Adding metadata to material page details and editions/details:
* Author roles
* Audience
* Notes
* Physical Description
* Extended Language info
* Source
* Parts
* Host Publication

#### Screenshot of the result


<img width="780" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/70f71bda-6535-4760-bafd-096c5dc9e023">

<img width="646" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/2dfde312-da12-4601-afe4-d4aabe9aaf0e">

<img width="569" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/c2ab79fb-dcba-4d35-a755-7c7d56011ace">

#### Additional info

The corresponding PR adding translation strings in `dpl-cms` is https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1050

