### PR TITLE
Remove reserve and find on shelf from articles

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -912,3 +912,8 @@ export const globalMaterial = Template.bind({});
 globalMaterial.args = {
   wid: "work-of:870970-basis:07185995"
 };
+
+export const digitalArticle = Template.bind({});
+digitalArticle.args = {
+  wid: "work-of:870971-tsart:36297484"
+};

--- a/src/components/material/material-buttons/helper.ts
+++ b/src/components/material/material-buttons/helper.ts
@@ -42,10 +42,24 @@ export const hasCorrectMaterialType = (
   });
 };
 
+// We need this e.g. for articles - the material type for articles has many definitions.
+export const hasCorrectPartialMaterialType = (
+  desiredPartialMaterialType: string,
+  manifestations: Manifestation[]
+) => {
+  return manifestations.some((manifestation) => {
+    return manifestation.materialTypes.some((type) =>
+      type.materialTypeSpecific.display
+        .toLowerCase()
+        .includes(desiredPartialMaterialType.toLowerCase())
+    );
+  });
+};
+
 export const isArticle = (manifestations: Manifestation[]) => {
-  return (
-    hasCorrectMaterialType(ManifestationMaterialType.article, manifestations) ||
-    hasCorrectMaterialType("avisartikel", manifestations)
+  return hasCorrectPartialMaterialType(
+    ManifestationMaterialType.article,
+    manifestations
   );
 };
 

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -8,6 +8,8 @@ export const enum ManifestationMaterialType {
   game = "playstation 5",
   animatedSeries = "tegneserie",
   article = "artikel",
+  paperArticle = "avisartikel",
+  onlineArticle = "artikel (online)",
   earticle = "artikel",
   boardGame = "spil",
   cdRom = "cd",


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-622

#### Description
There are many types of articles, and ALL of them need to always show the "see online" button on the material page and treat them as online materials. This PR adjusts the isArticle() helper function so that it searches for any material types containing the word "article" (in danish).

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/ba3aa125-59b9-462c-b77a-07b83ee36bf8)

#### Additional comments or questions
-
