### PR TITLE
Set an empty alt tag on the ButtonTag close button.

### DIFF
--- a/src/components/Buttons/ButtonTag.tsx
+++ b/src/components/Buttons/ButtonTag.tsx
@@ -35,9 +35,8 @@ const ButtonTag: React.FunctionComponent<ButtonTagProps> = ({
       data-cy={dataCy}
     >
       {children}
-      {removable && (
-        <img className="tag-icon" src={iconCross} alt="close icon" />
-      )}
+      {/* No need for alt tag, because screen readers announce it as a toggle button. */}
+      {removable && <img className="tag-icon" src={iconCross} alt="" />}
     </button>
   );
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-582

#### Description
Because screen readers announce it as a toggle button, which is according to https://www.w3.org/Translations/WCAG21-da/#info-and-relationships

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
