### PR TITLE
Make it possible for availability labels to be non-interactive elements

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -912,3 +912,8 @@ export const globalMaterial = Template.bind({});
 globalMaterial.args = {
   wid: "work-of:870970-basis:07185995"
 };
+
+export const onlyOneEdition = Template.bind({});
+onlyOneEdition.args = {
+  wid: "work-of:870970-basis:52796202"
+};

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -23,6 +23,7 @@ export interface AvailabilityLabelProps {
   cursorPointer?: boolean;
   dataCy?: string;
   isbns: string[];
+  isVisualOnly?: boolean;
 }
 
 export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
@@ -35,7 +36,8 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
   handleSelectManifestation,
   cursorPointer = false,
   dataCy = "availability-label",
-  isbns
+  isbns,
+  isVisualOnly
 }) => {
   const { track } = useStatistics();
   const t = useText();
@@ -83,11 +85,23 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     cursorPointer
   });
 
-  return url && !handleSelectManifestation ? (
-    <LinkNoStyle className={parentClass} url={url} data-cy={dataCy}>
-      {availabilityLabel}
-    </LinkNoStyle>
-  ) : (
+  if (isVisualOnly) {
+    return (
+      <div className={parentClass} data-cy={dataCy}>
+        {availabilityLabel}
+      </div>
+    );
+  }
+
+  if (url && handleSelectManifestation) {
+    return (
+      <LinkNoStyle className={parentClass} url={url} data-cy={dataCy}>
+        {availabilityLabel}
+      </LinkNoStyle>
+    );
+  }
+
+  return (
     <button
       className={parentClass}
       type="button"

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -93,7 +93,7 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     );
   }
 
-  if (url && handleSelectManifestation) {
+  if (url && !handleSelectManifestation) {
     return (
       <LinkNoStyle className={parentClass} url={url} data-cy={dataCy}>
         {availabilityLabel}

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -40,6 +40,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
   return (
     <>
       {allMaterialTypes.map((materialType) => {
+        const isTheOnlyLabel = allMaterialTypes.length === 1;
         const manifestationsOfMaterialType =
           manifestationsByMaterialType[materialType];
         const faustIds = getAllFaustIds(manifestationsOfMaterialType).sort();
@@ -81,6 +82,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
                 : undefined
             }
             isbns={identifiers}
+            isVisualOnly={isTheOnlyLabel}
           />
         );
       })}

--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -116,6 +116,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           isbns={identifiers.map((identifier) => identifier.value)}
           accessTypes={accessTypesCodes}
           access={access}
+          isVisualOnly
         />
       </div>
       <div className="material-manifestation-item__cover">


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-581

#### Description
Make it possible for availability labels to be non-interactive elements, and use them like this on search result page for search result items that only have one material type + on material page in the top for materials that only have one material type + on material page in the "editions" disclosure for each item, as these availability labels don't serve an interactive function, but merely are visual labels.

#### Screenshot of the result
-

#### Additional comments or questions
-
