### PR TITLE
Fix/failing work page

### DIFF
--- a/src/apps/material/material.dev.tsx
+++ b/src/apps/material/material.dev.tsx
@@ -917,3 +917,8 @@ export const digitalArticle = Template.bind({});
 digitalArticle.args = {
   wid: "work-of:870971-tsart:36297484"
 };
+
+export const inLargeSameSeriesAndIrregularFaustId = Template.bind({});
+inLargeSameSeriesAndIrregularFaustId.args = {
+  wid: "work-of:150086-netmusik:BIS-2067"
+};

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -148,10 +148,10 @@ export const usePrevious = <Type>(value: Type) => {
 
 export const convertPostIdToFaustId = (postId: Pid) => {
   // We have seen post ids containing both letters and numbers
-  // in the last part after the colon.
+  // in the last part after the colon, but it can also have a dash.
   // We are about to have clarified what the proper name of the element.
   // But for now we will call it faustId.
-  const matches = postId.match(/^[0-9]+-[a-z]+:([a-zA-Z0-9]+)$/);
+  const matches = postId.match(/^[0-9]+-[a-z]+:([a-zA-Z0-9-]+)$/);
   if (matches?.[1]) {
     return matches?.[1] as FaustId;
   }

--- a/src/core/utils/types/ids.ts
+++ b/src/core/utils/types/ids.ts
@@ -1,6 +1,6 @@
 import { DigitalArticleService } from "../../dbc-gateway/generated/graphql";
 
-export type FaustId = `${number}`;
+export type FaustId = `${string}`;
 export type Pid = `${number}-${string}:${FaustId}`;
 export type WorkId = `work-of:${number}-${string}:${FaustId}`;
 export type GuardedAppId =


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-617

#### Description
This PR fixes a specific case for the work with work ID of `work-of:150086-netmusik:BIS-2067`. It was happening because we didn't know that a FaustId can also contain dashes apart from numbers and letters.

#### Screenshot of the result
-

#### Additional comments or questions
-
