### PR TITLE
Enhance `MaterialGrid` functionality to focus on next item after "show more" click

### DIFF
--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { WorkId } from "../../core/utils/types/ids";
 import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
 import { useText } from "../../core/utils/text";
@@ -9,6 +9,7 @@ import {
   calculateAmountToDisplay
 } from "./materiel-grid-util";
 import { DisplayMaterialType } from "../../core/utils/types/material-type";
+import MaterialListItem from "../../components/card-item-list/MaterialListItem";
 
 export type MaterialGridItemProps = {
   wid: WorkId;
@@ -26,6 +27,7 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
   selectedAmountOfMaterialsForDisplay
 }) => {
   const t = useText();
+  const firstNewItemRef = React.useRef<HTMLLIElement>(null);
 
   const initialMaximumDisplay = MaterialGridValidIncrements[0];
   const maximumCalculatedDisplay = calculateAmountToDisplay(
@@ -40,6 +42,13 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
     setCurrentMaterialsDisplayedMaterials
   ] = useState(initialMaximumDisplay);
 
+  // Focus on the first new item when the user clicks the "Show more" button
+  useEffect(() => {
+    if (firstNewItemRef.current) {
+      firstNewItemRef.current.focus();
+    }
+  }, [currentAmountOfDisplayedMaterials]);
+
   const [showAllMaterials, setShowAllMaterials] = useState(false);
 
   function handleShowAllMaterials() {
@@ -53,16 +62,19 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
       <ul className="material-grid__items">
         {materials
           .slice(0, currentAmountOfDisplayedMaterials)
-          .map((material) => {
+          .map((material, index) => {
             const { wid, materialType } = material;
             return (
-              <li key={wid}>
+              <MaterialListItem
+                key={wid}
+                ref={index === initialMaximumDisplay ? firstNewItemRef : null}
+              >
                 <RecommendedMaterial
                   partOfGrid
                   wid={wid}
                   materialType={materialType}
                 />
-              </li>
+              </MaterialListItem>
             );
           })}
       </ul>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-751


#### Description
This pull request ensures that the next item in the `MaterialGrid` receives focus after the "show more" button is clicked.


#### Screenshot of the result

https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/eaaf153c-a6f9-4303-a2d6-4647b0bcc7a4

