### PR TITLE
Ddfform 787 fetch month range

### DIFF
--- a/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
@@ -63,9 +63,9 @@ const OpeningHoursEditor: React.FC<OpeningHoursEditorType> = ({
         ref={fullCalendarRef}
         plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
         headerToolbar={{
-          left: "title",
-          center: "prev,next today",
-          right: "dayGridMonth,timeGridWeek"
+          left: "dayGridMonth,timeGridWeek",
+          center: "title",
+          right: "prevCustom,nextCustom today"
         }}
         initialView="timeGridWeek"
         locale={da}

--- a/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
@@ -36,8 +36,14 @@ const OpeningHoursEditor: React.FC<OpeningHoursEditorType> = ({
   const fullCalendarRef = React.useRef<FullCalendar>(null);
   const fullCalendarApi = fullCalendarRef.current?.getApi();
 
-  const { events, handleEventAdd, handleEventEditing, handleEventRemove } =
-    useOpeningHoursEditor();
+  const {
+    events,
+    handleEventAdd,
+    handleEventEditing,
+    handleEventRemove,
+    navigateToPreviousMonthRange,
+    navigateToNextMonthRange
+  } = useOpeningHoursEditor(fullCalendarApi);
 
   const { dialogContent, openDialogWithContent, closeDialog, dialogRef } =
     useDialog({
@@ -97,6 +103,16 @@ const OpeningHoursEditor: React.FC<OpeningHoursEditorType> = ({
         height="auto"
         selectMirror
         allDaySlot={false}
+        customButtons={{
+          prevCustom: {
+            icon: "chevron-left",
+            click: navigateToPreviousMonthRange
+          },
+          nextCustom: {
+            icon: "chevron-right",
+            click: navigateToNextMonthRange
+          }
+        }}
       />
     </>
   );

--- a/src/apps/opening-hours-editor/helper.ts
+++ b/src/apps/opening-hours-editor/helper.ts
@@ -172,3 +172,9 @@ export const isOpeningHourWeeklyRepetition = (
     DplOpeningHoursListGET200ItemRepetitionType.weekly
   );
 };
+
+export const getThreeMonthRange = (date: Date) => {
+  const start = dayjs(date).subtract(1, "month").startOf("month").toDate();
+  const end = dayjs(date).add(1, "month").endOf("month").toDate();
+  return { start, end };
+};


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-787

#### Description
This pull request modifies the `useOpeningHoursEditor` hook to implement a 3-month interval. This change is necessary to show the minimum required opening hours in the monthly view by displaying the first and last dates of the previous and next months while still limiting the number of fetched opening hours.

Additionally, the title (week/month) is centralized for uniform placement of the previous and next buttons, regardless of the title length.


#### Screenshot of the result
<img width="1840" alt="Skærmbillede 2024-05-16 kl  20 46 55" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/fdc906c5-9d46-4a61-8656-0132bfd26853">
<img width="1840" alt="Skærmbillede 2024-05-16 kl  20 46 20" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/f3292674-a4f1-4306-a4e4-7746ed795f3c">
