### PR TITLE
Integrate `handleDateSet` into `useOpeningHoursEditor` hook

### DIFF
--- a/orval.config.ts
+++ b/orval.config.ts
@@ -132,6 +132,9 @@ export default defineConfig({
           // proxy-url:GET query. This lets us call it conditionally.
           "proxy-url:GET": {
             requestOptions: false
+          },
+          "dpl_opening_hours_list:GET": {
+            requestOptions: false
           }
         }
       },

--- a/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
@@ -36,8 +36,13 @@ const OpeningHoursEditor: React.FC<OpeningHoursEditorType> = ({
   const fullCalendarRef = React.useRef<FullCalendar>(null);
   const fullCalendarApi = fullCalendarRef.current?.getApi();
 
-  const { events, handleEventAdd, handleEventEditing, handleEventRemove } =
-    useOpeningHoursEditor();
+  const {
+    events,
+    handleEventAdd,
+    handleEventEditing,
+    handleEventRemove,
+    handleDatesSet
+  } = useOpeningHoursEditor();
 
   const { dialogContent, openDialogWithContent, closeDialog, dialogRef } =
     useDialog({
@@ -97,6 +102,7 @@ const OpeningHoursEditor: React.FC<OpeningHoursEditorType> = ({
         height="auto"
         selectMirror
         allDaySlot={false}
+        datesSet={handleDatesSet}
       />
     </>
   );

--- a/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/OpeningHoursEditor.tsx
@@ -62,9 +62,9 @@ const OpeningHoursEditor: React.FC<OpeningHoursEditorType> = ({
         ref={fullCalendarRef}
         plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
         headerToolbar={{
-          left: "title",
-          center: "prev,next today",
-          right: "dayGridMonth,timeGridWeek"
+          left: "dayGridMonth,timeGridWeek",
+          center: "title",
+          right: "prev,next today"
         }}
         initialView="timeGridWeek"
         locale={da}

--- a/src/apps/opening-hours-editor/useOpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/useOpeningHoursEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { EventInput } from "@fullcalendar/core";
+import { DatesSetArg, EventInput } from "@fullcalendar/core";
 import { useQueryClient } from "react-query";
-import { formatCmsEventsToFullCalendar } from "./helper";
+import { formatCmsEventsToFullCalendar, getStringForDateInput } from "./helper";
 import {
   getDplOpeningHoursListGETQueryKey,
   useDplOpeningHoursCreatePOST,
@@ -21,9 +21,16 @@ const useOpeningHoursEditor = () => {
   const openingHoursBranchId = config("openingHoursBranchIdConfig", {
     transformer: "stringToNumber"
   });
+  const [datesSet, setDatseSet] = useState<null | DatesSetArg>(null);
   const queryClient = useQueryClient();
   const { data: openingHoursData } = useDplOpeningHoursListGET({
-    branch_id: openingHoursBranchId
+    branch_id: openingHoursBranchId,
+    ...(datesSet
+      ? {
+          from_date: getStringForDateInput(datesSet.start),
+          to_date: getStringForDateInput(datesSet.end)
+        }
+      : {})
   });
   const { mutate: removeOpeningHours } = useDplOpeningHoursDeleteDELETE();
   const { mutate: createOpeningHours } = useDplOpeningHoursCreatePOST();
@@ -36,6 +43,10 @@ const useOpeningHoursEditor = () => {
       setEvents(formattedEvents);
     }
   }, [openingHoursData]);
+
+  const handleDatesSet = (datesInView: DatesSetArg) => {
+    setDatseSet(datesInView);
+  };
 
   const onSuccess = () => {
     queryClient.invalidateQueries(
@@ -124,7 +135,8 @@ const useOpeningHoursEditor = () => {
     events,
     handleEventAdd,
     handleEventRemove,
-    handleEventEditing
+    handleEventEditing,
+    handleDatesSet
   };
 };
 

--- a/src/apps/opening-hours-editor/useOpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/useOpeningHoursEditor.tsx
@@ -23,15 +23,16 @@ const useOpeningHoursEditor = () => {
   });
   const [datesSet, setDatseSet] = useState<null | DatesSetArg>(null);
   const queryClient = useQueryClient();
-  const { data: openingHoursData } = useDplOpeningHoursListGET({
-    branch_id: openingHoursBranchId,
-    ...(datesSet
-      ? {
-          from_date: getStringForDateInput(datesSet.start),
-          to_date: getStringForDateInput(datesSet.end)
-        }
-      : {})
-  });
+  const { data: openingHoursData } = useDplOpeningHoursListGET(
+    {
+      branch_id: openingHoursBranchId,
+      ...(datesSet && {
+        from_date: getStringForDateInput(datesSet.start),
+        to_date: getStringForDateInput(datesSet.end)
+      })
+    },
+    { enabled: !!datesSet }
+  );
   const { mutate: removeOpeningHours } = useDplOpeningHoursDeleteDELETE();
   const { mutate: createOpeningHours } = useDplOpeningHoursCreatePOST();
   const { mutate: updateOpeningHours } = useDplOpeningHoursUpdatePATCH();

--- a/src/core/dpl-cms/dpl-cms.ts
+++ b/src/core/dpl-cms/dpl-cms.ts
@@ -248,16 +248,12 @@ export const getDplOpeningHoursListGETQueryOptions = <
   TError = ErrorType<void>
 >(
   params: DplOpeningHoursListGETParams,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof dplOpeningHoursListGET>>,
-      TError,
-      TData
-    >;
-  }
+  queryOptions?: UseQueryOptions<
+    Awaited<ReturnType<typeof dplOpeningHoursListGET>>,
+    TError,
+    TData
+  >
 ) => {
-  const { query: queryOptions } = options ?? {};
-
   const queryKey =
     queryOptions?.queryKey ?? getDplOpeningHoursListGETQueryKey(params);
 
@@ -285,21 +281,19 @@ export const useDplOpeningHoursListGET = <
   TError = ErrorType<void>
 >(
   params: DplOpeningHoursListGETParams,
-  options?: {
-    query?: UseQueryOptions<
-      Awaited<ReturnType<typeof dplOpeningHoursListGET>>,
-      TError,
-      TData
-    >;
-  }
+  queryOptions?: UseQueryOptions<
+    Awaited<ReturnType<typeof dplOpeningHoursListGET>>,
+    TError,
+    TData
+  >
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getDplOpeningHoursListGETQueryOptions(params, options);
+  const options = getDplOpeningHoursListGETQueryOptions(params, queryOptions);
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
+  const query = useQuery(options) as UseQueryResult<TData, TError> & {
     queryKey: QueryKey;
   };
 
-  query.queryKey = queryOptions.queryKey;
+  query.queryKey = options.queryKey;
 
   return query;
 };

--- a/src/core/dpl-cms/model/eventsGET200ItemImage.ts
+++ b/src/core/dpl-cms/model/eventsGET200ItemImage.ts
@@ -10,6 +10,6 @@
  * The main image for the event.
  */
 export type EventsGET200ItemImage = {
-  /** An absolute url for the image. */
+  /** An absolute url for the image. This is a link to the original, unaltered file, so the size, aspect ratio, and file format will be different from event to event. */
   url: string;
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-787


#### Description
This pull request enhances the fetching mechanism for opening hours in the admin area, ensuring that we only retrieve the necessary data for the current view.

The `datesSet` method from FullCalendar, which provides the currently displayed dates and updates with navigation button clicks, is now utilized. This ensures we fetch only the relevant opening hours for the current view.

<s>Initially, I attempted to use the `enabled` property in the options object of `useDplOpeningHoursListGET` but encountered the following error: "Object literal may only specify known properties, and 'enabled' does not exist in type '{ query?: UseQueryOptions<DplOpeningHoursListGET200Item[] | null, void, DplOpeningHoursListGET200Item[] | null, QueryKey> | undefined; }'."
I suspect this issue is related to the operations in dplCms within orval.config.ts.

As a workaround, I implemented a ternary operator in `useDplOpeningHoursListGET` that conditionally sets `from_date` and `to_date` only when `datesSet is available.</s>

Integrated `dpl_opening_hours_list:GET? in `orval.config`. This enhancement enables the use of the enabled option in `useDplOpeningHoursListGET`, allowing the fetching of opening hours only when `datesSet` is not `null`.

Rearranged headerToolbar layout in FullCalendar. The title (week/month) is now centralized for consistent positioning of the previous and next buttons, regardless of the title length. This addresses the issue where navigating through the month was difficult when the buttons changed positions.


#### Local test from samsø 
https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/ad8ae9af-9783-446e-be5a-d47f6fd104e7

