### PR TITLE
Add links from dashboard

### DIFF
--- a/src/apps/dashboard/dashboard-notification-list/NotificationColumn.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/NotificationColumn.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import EmptyList from "../../../components/empty-list/empty-list";
 import Notifications, { NotificationMaterialsList } from "./Notifications";
 import NotificationSkeleton from "../dashboard-notification/notification-skeleton";
+import Link from "../../../components/atoms/links/Link";
 
 export interface NotificationColumnProps {
   materials: NotificationMaterialsList[];
@@ -9,6 +10,8 @@ export interface NotificationColumnProps {
   header: string;
   emptyListText: string;
   isLoading?: boolean;
+  linkText?: string;
+  linkUrl?: URL;
 }
 
 const NotificationColumn: FC<NotificationColumnProps> = ({
@@ -16,7 +19,9 @@ const NotificationColumn: FC<NotificationColumnProps> = ({
   materialsCount,
   emptyListText,
   header,
-  isLoading = false
+  isLoading = false,
+  linkText,
+  linkUrl
 }) => {
   return (
     <div className="status-userprofile__column my-64">
@@ -38,6 +43,14 @@ const NotificationColumn: FC<NotificationColumnProps> = ({
       )}
       {materialsCount !== 0 && (
         <Notifications materials={materials} showStatusLabel />
+      )}
+      {linkText && linkUrl && (
+        <div className="mt-8">
+          <Link href={linkUrl} className="link-tag link-tag link-filters__tag">
+            {linkText}
+          </Link>
+          <span className="link-filters__counter">{materialsCount}</span>
+        </div>
       )}
     </div>
   );

--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -25,6 +25,7 @@ import {
   getModalIds
 } from "../../../core/utils/helpers/modal-helpers";
 import { ListType } from "../../../core/utils/types/list-type";
+import { useUrls } from "../../../core/utils/url";
 
 export interface DashboardNotificationListProps {
   pageSize: number;
@@ -36,6 +37,9 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
   columns
 }) => {
   const t = useText();
+  const u = useUrls();
+  const physicalLoansUrl = u("physicalLoansUrl");
+  const reservationsUrl = u("reservationsUrl");
   const {
     all: {
       reservations,
@@ -215,6 +219,8 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
               header={t("physicalLoansText")}
               emptyListText={t("noPhysicalLoansText")}
               isLoading={isLoadingLoans || isLoadingLoansPhysical}
+              linkText={t("dashboardLoansLinkText")}
+              linkUrl={physicalLoansUrl}
             />
             <NotificationColumn
               materials={dashboardNotificationsReservations}
@@ -222,6 +228,8 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
               header={t("reservationsText")}
               emptyListText={t("noReservationsText")}
               isLoading={isLoadingReservations}
+              linkText={t("dashboardReservationsLinkText")}
+              linkUrl={reservationsUrl}
             />
           </>
         )}

--- a/src/apps/dashboard/dashboard.dev.tsx
+++ b/src/apps/dashboard/dashboard.dev.tsx
@@ -157,6 +157,14 @@ export default {
     expirationWarningDaysBeforeConfig: {
       defaultValue: "6",
       control: { type: "text" }
+    },
+    dashboardLoansLinkText: {
+      defaultValue: "All loans",
+      control: { type: "text" }
+    },
+    dashboardReservationsLinkText: {
+      defaultValue: "All reservations",
+      control: { type: "text" }
     }
   },
   component: DashBoard

--- a/src/apps/dashboard/dashboard.entry.tsx
+++ b/src/apps/dashboard/dashboard.entry.tsx
@@ -58,6 +58,8 @@ export interface DashBoardProps {
   totalAmountFeeText: string;
   totalOwedText: string;
   yourProfileText: string;
+  dashboardLoansLinkText: string;
+  dashboardReservationsLinkText: string;
 }
 
 const DashboardEntry: FC<


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-546

#### Description
This PR adds a text link at the bottom of each notification column on the dashboard. This fixes broken user journey paths - now there is a link to loan and reservation page.

#### Screenshot of the result
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/54864bb7-412c-4e77-a56e-2555b5504145)

#### Additional comments or questions
[Sibling PR](https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1185)