### PR TITLE
Show currect status of advanced search dropdown

### DIFF
--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -32,7 +32,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
 }) => {
   const t = useText();
   const handleDropdownMenu = () => {
-    setIsHeaderDropdownOpen(!isHeaderDropdownOpen);
+    setIsHeaderDropdownOpen((prev) => !prev);
   };
 
   return (

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import searchIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/basic/icon-search.svg";
 import expandIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/ExpandMore.svg";
 import { UseComboboxPropGetters } from "downshift";
+import clsx from "clsx";
 import { useText } from "../../core/utils/text";
 import { redirectTo } from "../../core/utils/helpers/url";
 
@@ -87,7 +88,9 @@ const SearchBar: React.FC<SearchBarProps> = ({
         type="image"
         src={expandIcon}
         alt={t("searchHeaderDropdownText")}
-        className="header__menu-dropdown-icon"
+        className={clsx("header__menu-dropdown-icon", {
+          "header__menu-dropdown-icon--expanded": isHeaderDropdownOpen
+        })}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -106,6 +106,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         tabIndex={0}
         aria-label={t("searchHeaderDropdownText")}
         data-cy="search-header-dropdown-icon"
+        aria-expanded={isHeaderDropdownOpen}
       />
     </>
   );


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-636

#### Description
Animate advanced search header dropdown icon on click to indicate state and make it crisp.

#### Screenshot of the result
-

#### Additional comments or questions
[Sibling PR](https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/643)
