### PR TITLE
DDFFORM 520 material grid desc

### DIFF
--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import clsx from "clsx";
 import { useState, useEffect } from "react";
 import { WorkId } from "../../core/utils/types/ids";
 import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
@@ -19,11 +20,13 @@ export type MaterialGridItemProps = {
 export type MaterialGridProps = {
   materials: MaterialGridItemProps[];
   title?: string;
+  description?: string;
   selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
 };
 const MaterialGrid: React.FC<MaterialGridProps> = ({
   materials,
   title,
+  description,
   selectedAmountOfMaterialsForDisplay
 }) => {
   const t = useText();
@@ -56,9 +59,19 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
     setShowAllMaterials(!showAllMaterials);
   }
 
+  const titleClasses = clsx("material-grid__title", {
+    "material-grid__title--no-description": !description
+  });
   return (
     <div className="material-grid">
-      {title && <h2 className="material-grid__title">{title}</h2>}
+      {(title || description) && (
+        <div className="material-grid__text-wrapper">
+          {title && <h2 className={titleClasses}>{title}</h2>}
+          {description && (
+            <p className="material-grid__description">{description}</p>
+          )}
+        </div>
+      )}
       <ul className="material-grid__items">
         {materials
           .slice(0, currentAmountOfDisplayedMaterials)

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.dev.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.dev.tsx
@@ -17,8 +17,13 @@ export default {
   argTypes: {
     title: {
       name: "Title",
-
       defaultValue: "Recommended materials",
+      control: { type: "text" }
+    },
+    description: {
+      name: "Description",
+      defaultValue:
+        "This is a long description of the materials selected, or whatever else you want to put in here",
       control: { type: "text" }
     },
     cql: {

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.entry.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.entry.tsx
@@ -19,6 +19,7 @@ export interface MaterialGridAutomaticEntryProps
     MaterialGridAutomaticEntryConfigProps {
   cql: string;
   title?: string;
+  description?: string;
   selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
   buttonText: string;
 }
@@ -26,6 +27,7 @@ export interface MaterialGridAutomaticEntryProps
 const MaterialGridAutomaticEntry: React.FC<MaterialGridAutomaticEntryProps> = ({
   cql,
   title,
+  description,
   selectedAmountOfMaterialsForDisplay,
   buttonText
 }) => (
@@ -33,6 +35,7 @@ const MaterialGridAutomaticEntry: React.FC<MaterialGridAutomaticEntryProps> = ({
     <MaterialGridAutomatic
       cql={cql}
       title={title}
+      description={description}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
       buttonText={buttonText}
     />

--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -9,6 +9,7 @@ import { ValidSelectedIncrements } from "../materiel-grid-util";
 export type MaterialGridAutomaticProps = {
   cql: string;
   title?: string;
+  description?: string;
   selectedAmountOfMaterialsForDisplay: ValidSelectedIncrements;
   buttonText: string;
 };
@@ -16,6 +17,7 @@ export type MaterialGridAutomaticProps = {
 const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
   cql,
   title,
+  description,
   selectedAmountOfMaterialsForDisplay
 }) => {
   const cleanBranches = useGetCleanBranches();
@@ -43,6 +45,7 @@ const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
     <MaterialGrid
       title={title}
       materials={materials}
+      description={description}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
     />
   );

--- a/src/apps/material-grid/manual/MaterialGridManual.dev.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.dev.tsx
@@ -55,6 +55,12 @@ export default {
       defaultValue: "Recommended materials",
       control: { type: "text" }
     },
+    description: {
+      name: "Description",
+      defaultValue:
+        "This is a long description of the materials selected, or whatever else you want to put in here",
+      control: { type: "text" }
+    },
     buttonText: {
       name: "Button text",
       defaultValue: "Show all",

--- a/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.entry.tsx
@@ -19,11 +19,13 @@ export interface MaterialGridManualEntryProps
     MaterialGridManualEntryConfigProps {
   materials: string;
   title?: string;
+  description?: string;
 }
 
 const MaterialGridManualEntry: React.FC<MaterialGridManualEntryProps> = ({
   materials,
-  title
+  title,
+  description
 }) => {
   const parsedMaterialsString: MaterialGridItemProps[] = JSON.parse(materials);
   const parsedMaterials = parsedMaterialsString.map((work) => ({
@@ -33,7 +35,11 @@ const MaterialGridManualEntry: React.FC<MaterialGridManualEntryProps> = ({
 
   return (
     <GuardedApp app="material-grid-manual">
-      <MaterialGridManual materials={parsedMaterials} title={title} />
+      <MaterialGridManual
+        materials={parsedMaterials}
+        title={title}
+        description={description}
+      />
     </GuardedApp>
   );
 };

--- a/src/apps/material-grid/manual/MaterialGridManual.tsx
+++ b/src/apps/material-grid/manual/MaterialGridManual.tsx
@@ -5,11 +5,13 @@ import { calculateAmountToDisplay } from "../materiel-grid-util";
 export type MaterialGridManualProps = {
   materials: MaterialGridItemProps[];
   title?: string;
+  description?: string;
 };
 
 const MaterialGridManual: React.FC<MaterialGridManualProps> = ({
   materials,
-  title
+  title,
+  description
 }) => {
   const selectedAmountOfMaterialsForDisplay = calculateAmountToDisplay(
     materials.length
@@ -18,6 +20,7 @@ const MaterialGridManual: React.FC<MaterialGridManualProps> = ({
   return (
     <MaterialGrid
       title={title}
+      description={description}
       materials={materials}
       selectedAmountOfMaterialsForDisplay={selectedAmountOfMaterialsForDisplay}
     />


### PR DESCRIPTION
#### Link to issue

Jira ticket: [DDFFORM-520](https://reload.atlassian.net/browse/DDFFORM-520)

Design system PR: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/644
CMS pr: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1198

#### Description

This PR updates the react components material grid manual and automatic to take a new `description` prop, and display it if it is received. 



#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/13272656/8ac661fc-f258-47c1-9fcd-319490da901c)


[DDFFORM-520]: https://reload.atlassian.net/browse/DDFFORM-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ