### PR TITLE
Ddfform 802 sort openning hours

### DIFF
--- a/src/apps/opening-hours/OpeningHoursHelpers.ts
+++ b/src/apps/opening-hours/OpeningHoursHelpers.ts
@@ -80,9 +80,19 @@ export const groupOpeningHoursByWeekday = (
   const daysWithOpeningHours: GroupedOpeningHours = allDays.map((day) => {
     return {
       dateTime: day,
-      openingHourEntries: openingHours.filter((individualOpeningHour) =>
-        dayjs(individualOpeningHour.date).isSame(day, "day")
-      )
+      openingHourEntries: openingHours
+        .filter((individualOpeningHour) =>
+          dayjs(individualOpeningHour.date).isSame(day, "day")
+        )
+        .sort((a, b) => {
+          // The array is primarily sorted by the start_time property of each object.
+          const startTimeComparison = a.start_time.localeCompare(b.start_time);
+          if (startTimeComparison !== 0) {
+            return startTimeComparison;
+          }
+          // If two objects have the same start_time, they are then sorted by the end_time property.
+          return a.end_time.localeCompare(b.end_time);
+        })
     };
   });
 

--- a/src/apps/opening-hours/OpeningHoursHelpers.ts
+++ b/src/apps/opening-hours/OpeningHoursHelpers.ts
@@ -80,7 +80,6 @@ export const groupOpeningHoursByWeekday = (
   const daysWithOpeningHours: GroupedOpeningHours = allDays.map((day) => {
     return {
       dateTime: day,
-      date: day,
       openingHourEntries: openingHours.filter((individualOpeningHour) =>
         dayjs(individualOpeningHour.date).isSame(day, "day")
       )


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-802

#### Description

This pull request implements sorting for opening hours.

Ensure that opening hours are sorted in the correct chronological order based on `start_time` and `end_time` when `start_time` is identical:


Additionally, I identified a redundant date value from `groupOpeningHoursByWeekday` that was duplicated by the `dateTime` value.


#### Test on:
http://varnish.pr-1211.dpl-cms.dplplat01.dpl.reload.dk/test-raekkefolge-af-abningstider


#### Screenshot of the result
<img width="665" alt="image" src="https://github.com/danskernesdigitalebibliotek/dpl-react/assets/49920322/12cfca6a-da50-49a5-b035-6f6d47015bd8">
