### PR TITLE
Remove reservation text unnecessary info

### DIFF
--- a/src/components/material/StockAndReservationInfo.tsx
+++ b/src/components/material/StockAndReservationInfo.tsx
@@ -4,7 +4,7 @@ import { useText } from "../../core/utils/text";
 
 export interface StockAndReservationInfoProps {
   stockCount: number;
-  reservationCount: number;
+  reservationCount?: number;
   numberInQueue?: number;
 }
 
@@ -20,7 +20,7 @@ const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
   });
   const materialReservationInfoText = t("materialReservationInfoText", {
     count: reservationCount,
-    placeholders: { "@count": reservationCount }
+    placeholders: { "@count": reservationCount || 0 }
   });
 
   const numberInQueueText = numberInQueue
@@ -33,7 +33,7 @@ const StockAndReservationInfo: FC<StockAndReservationInfoProps> = ({
     <>
       {numberInQueueText && `${numberInQueueText} `}
       {materialsInStockInfoText && `${materialsInStockInfoText} `}
-      {materialReservationInfoText && materialReservationInfoText}
+      {!!reservationCount && materialReservationInfoText}
     </>
   );
 };

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -369,7 +369,6 @@ export const ReservationModalBody = ({
             branches
           )}
           holdings={holdings}
-          reservationCount={reservations}
           numberInQueue={reservationDetails.numberInQueue}
         />
       )}

--- a/src/components/reservation/ReservationSucces.tsx
+++ b/src/components/reservation/ReservationSucces.tsx
@@ -11,7 +11,6 @@ type ReservationSuccesProps = {
   preferredPickupBranch: string;
   modalId: string;
   numberInQueue?: number;
-  reservationCount: number;
   holdings: number;
 };
 
@@ -20,7 +19,6 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
   title,
   preferredPickupBranch,
   numberInQueue,
-  reservationCount,
   holdings
 }) => {
   const dispatch = useDispatch();
@@ -51,7 +49,6 @@ const ReservationSucces: React.FC<ReservationSuccesProps> = ({
         >
           <StockAndReservationInfo
             stockCount={holdings}
-            reservationCount={reservationCount}
             numberInQueue={numberInQueue}
           />
         </p>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-678

#### Description
Don't show reservation count in the "successful reservation" modal.

#### Screenshot of the result
-

#### Additional comments or questions
-
