### PR TITLE
Number advanced search text field labels from 1 upwards

### DIFF
--- a/src/apps/advanced-search/AdvancedSearchRow.tsx
+++ b/src/apps/advanced-search/AdvancedSearchRow.tsx
@@ -123,7 +123,7 @@ const AdvancedSearchRow: React.FC<AdvancedSearchRowProps> = ({
           className="hide-visually"
         >
           {t("advancedSearchInputLabelText", {
-            placeholders: { "@inputNumber": rowIndex }
+            placeholders: { "@inputNumber": rowIndex + 1 }
           })}
         </label>
         <input


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-669

#### Description
Number advanced search text field labels from 1 upwards instead from 0.

#### Screenshot of the result
-

#### Additional comments or questions
-
