### PR TITLE
Add stopPropagation to HorizontalTermLine links [DDFLSBP-670]

### DIFF
--- a/src/components/horizontal-term-line/HorizontalTermLine.tsx
+++ b/src/components/horizontal-term-line/HorizontalTermLine.tsx
@@ -42,7 +42,7 @@ const HorizontalTermLine: React.FC<HorizontalTermLineProps> = ({
         const { term, url } = item;
         return (
           <span key={term}>
-            <Link href={url} className="link-tag">
+            <Link href={url} className="link-tag" stopPropagation>
               {term}
             </Link>
           </span>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-670

#### Description

Add stopPropagation to HorizontalTermLine links to prevent confusion in the CardListItem context
