### PR TITLE
Show "1 (item) home" in find-on-shelf modal on mobile instead of "1"

### DIFF
--- a/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
@@ -51,7 +51,10 @@ const FindOnShelfManifestationListItem: FC<
           : t("findOnShelfModalNoLocationSpecifiedText")}
       </span>
       <span className="find-on-shelf__item-count-text" role="cell">
-        {numberAvailable}
+        {numberAvailable}{" "}
+        <span className="hide-on-desktop">
+          {t("findOnShelfModalListItemCountText")}
+        </span>
       </span>
     </li>
   );


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-712

#### Description
Show "1 home" instead of "1" for how many specimens of a manifestation are home available - in find on shelf modal.

#### Screenshot of the result
-

#### Additional comments or questions
-
