### PR TITLE
Fix/fake paralelle reservations

### DIFF
--- a/src/core/utils/types/reservation-type.ts
+++ b/src/core/utils/types/reservation-type.ts
@@ -13,6 +13,7 @@ interface Reservation extends ListType {
   pickupBranch: string;
   title: string;
   periodical: string;
+  reservationType: "normal" | "parallel" | "serial" | "inter_library";
 }
 
 export type ReservationType = Nullable<Partial<Reservation>>;

--- a/src/core/utils/useGetReservationGroups.ts
+++ b/src/core/utils/useGetReservationGroups.ts
@@ -27,10 +27,12 @@ export type ReservationGroupDetails = Omit<
 };
 
 function groupReservations(data: ReservationDetailsV2[]) {
-  const reservationGroups = groupBy(
-    data,
-    (reservation) => reservation.transactionId
-  );
+  const reservationGroups = groupBy(data, (reservation) => {
+    if (reservation.reservationType === "parallel") {
+      return reservation.recordId;
+    }
+    return reservation.reservationId;
+  });
 
   const processedReserations = map(
     reservationGroups,


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-740

#### Description
Only group parallel reservations into groups of reservations, not all with the same transaction ID. Those can still be separate
reservations.


#### Screenshot of the result
-

#### Additional comments or questions
-
