### PR TITLE
Fix/missing reservations

### DIFF
--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -13,9 +13,11 @@ import ArrowButton from "../../../../components/Buttons/ArrowButton";
 import { isDigital } from "../../utils/helpers";
 import { listId, ListType } from "../../../../core/utils/types/list-type";
 import SelectableMaterialSkeleton from "./selectable-material-skeleton";
+import { ILLBibliographicRecord } from "../../../../core/fbs/model";
 
 interface SelectableMaterialProps {
   identifier?: string | null;
+  ilBibliographicRecord?: ILLBibliographicRecord;
   disabled?: boolean;
   item?: ListType;
   onMaterialChecked?: (listItem: ListType) => void;
@@ -32,6 +34,7 @@ interface SelectableMaterialProps {
 
 const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
   material,
+  ilBibliographicRecord,
   disabled,
   onMaterialChecked,
   selected,
@@ -48,13 +51,23 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
   const t = useText();
 
   if (!item) return null;
-  const {
+  let {
     authorsShort = "",
     materialType,
     year = "",
     title = "",
     lang
   } = material || {};
+
+  // There is a chance material isn't provided, if corresponding reservation PID is
+  // incorrect (that's unfortunately possible). Then we use ilBibliographicRecord data.
+  if (!material) {
+    authorsShort = ilBibliographicRecord?.author || "";
+    materialType = "";
+    year = ilBibliographicRecord?.publicationDate || "";
+    title = ilBibliographicRecord?.title || "";
+    lang = ilBibliographicRecord?.language || "";
+  }
 
   // The reason why the handlers are used on multiple containers is because of multiple reasons:
   // * We cannot attach them to the li or the list-materials container because it prevents the checkbox from being checked.
@@ -110,9 +123,14 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
           tabIndex={0}
         >
           <div className="list-materials__content-status">
-            <div className="status-label status-label--outline ">
-              {materialType}
-            </div>
+            {materialType && materialType !== "" && (
+              <div className="status-label status-label--outline ">
+                {materialType}
+              </div>
+            )}
+            {(!materialType || materialType === "") && (
+              <span className="mt-8" />
+            )}
           </div>
           {statusBadgeComponentMobile || null}
           <p className="list-materials__content__header mt-8" lang={lang || ""}>

--- a/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
+++ b/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
@@ -8,12 +8,14 @@ import { Product } from "../../../../core/publizon/model";
 import { BasicDetailsType } from "../../../../core/utils/types/basic-details-type";
 import { mapManifestationToBasicDetailsType } from "../../../../core/utils/helpers/list-mapper";
 import { ListType } from "../../../../core/utils/types/list-type";
+import { ILLBibliographicRecord } from "../../../../core/fbs/model";
 
 export interface MaterialProps {
   material?: BasicDetailsType | null;
 }
 
 type InputProps = {
+  ilBibliographicRecord?: ILLBibliographicRecord;
   digitalMaterial?: Product | null;
   item?: ListType;
 };
@@ -72,8 +74,9 @@ const fetchMaterial =
         return FallbackComponent ? <FallbackComponent /> : null;
       }
 
-      // in cases where the material is not found we return null, else we would load forever
-      if (!manifestation) return null;
+      // In cases where the material is not found AND we don't have fallback data
+      // we return null, else we would load forever.
+      if (!manifestation && !props.ilBibliographicRecord) return null;
 
       return (
         <Component
@@ -81,6 +84,7 @@ const fetchMaterial =
           {...(props as P)}
           item={item}
           material={material}
+          ilBibliographicRecord={props.ilBibliographicRecord}
         />
       );
     }

--- a/src/components/GroupModal/GroupModalReservationsList.tsx
+++ b/src/components/GroupModal/GroupModalReservationsList.tsx
@@ -10,6 +10,7 @@ import {
 import StatusBadge from "../../apps/loan-list/materials/utils/status-badge";
 import { ListType } from "../../core/utils/types/list-type";
 import { getStatusText } from "../../apps/reservation-list/utils/helpers";
+import { ILLBibliographicRecord } from "../../core/fbs/model";
 
 export interface GroupModalReservationsListProps {
   materials: ReservationType[];
@@ -75,9 +76,7 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
           const selected = selectedMaterials?.some((selectedMaterial) =>
             isEqual(selectedMaterial, material)
           );
-
           const statusText: string = getStatusText(material, t);
-
           const statusBadgeComponent = statusText ? (
             <StatusBadge
               badgeDate={expiryDate}
@@ -100,6 +99,11 @@ const GroupModalReservationsList: FC<GroupModalReservationsListProps> = ({
                 disabled={false}
                 statusMessageComponentMobile={null}
                 statusMessageComponentDesktop={null}
+                // material.ilBibliographicRecord is of the ILLBibliographicRecord type,
+                // we just make it nullable in the code defining ReservationType.
+                ilBibliographicRecord={
+                  material.ilBibliographicRecord as ILLBibliographicRecord
+                }
               />
             )
           );

--- a/src/core/utils/helpers/list-mapper.ts
+++ b/src/core/utils/helpers/list-mapper.ts
@@ -249,7 +249,8 @@ export const mapFBSReservationGroupToReservationType = (
       pickupDeadline,
       pickupNumber,
       periodical,
-      records
+      records,
+      ilBibliographicRecord
     }) => {
       return {
         periodical: periodical?.displayText || "",
@@ -261,7 +262,8 @@ export const mapFBSReservationGroupToReservationType = (
         pickupBranch,
         pickupDeadline,
         pickupNumber,
-        reservationIds: values(records)
+        reservationIds: values(records),
+        ilBibliographicRecord
       };
     }
   );

--- a/src/core/utils/types/reservation-type.ts
+++ b/src/core/utils/types/reservation-type.ts
@@ -1,3 +1,4 @@
+import { ILLBibliographicRecord } from "../../fbs/model";
 import { ListType } from "./list-type";
 import { Nullable } from "./nullable";
 
@@ -14,6 +15,7 @@ interface Reservation extends ListType {
   title: string;
   periodical: string;
   reservationType: "normal" | "parallel" | "serial" | "inter_library";
+  ilBibliographicRecord?: ILLBibliographicRecord;
 }
 
 export type ReservationType = Nullable<Partial<Reservation>>;

--- a/src/core/utils/types/reservation-type.ts
+++ b/src/core/utils/types/reservation-type.ts
@@ -13,6 +13,7 @@ interface Reservation extends ListType {
   pickupBranch: string;
   title: string;
   periodical: string;
+  reservationType: "normal" | "parallel" | "serial" | "inter_library";
 }
 
 export type ReservationType = Nullable<Partial<Reservation>>;

--- a/src/core/utils/useGetReservationGroups.ts
+++ b/src/core/utils/useGetReservationGroups.ts
@@ -27,10 +27,12 @@ export type ReservationGroupDetails = Omit<
 };
 
 function groupReservations(data: ReservationDetailsV2[]) {
-  const reservationGroups = groupBy(
-    data,
-    (reservation) => reservation.transactionId
-  );
+  const reservationGroups = groupBy(data, (reservation) => {
+    if (reservation.reservationType === "parallel") {
+      return reservation.recordId;
+    }
+    return reservation.reservationId;
+  });
 
   const processedReserations = map(
     reservationGroups,


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFLSBP-595

#### Description
Show backup data from FBS to show all reservations, even those that don't have proper PID. We can't get the material type, but that's okay - we just don't show any label on these reservation items.

#### Screenshot of the result
Note missing reservation for Tue's colleague, Daniel's user:
![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/28546954/a8be42f6-50ee-44ba-94d8-13ae657d803e)

#### Additional comments or questions
-
