### PR TITLE
Use Ereol url if available [DDFLSBP-698]

### DIFF
--- a/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineExternal.tsx
@@ -56,24 +56,23 @@ const MaterialButtonOnlineExternal: FC<MaterialButtonOnlineExternalProps> = ({
   );
   const t = useText();
   const { data, error } = useProxyUrlGET(
-    {
-      url: externalUrl
-    },
-    {
-      enabled: urlWasTranslated === null && externalUrl.length > 0
-    }
+    { url: externalUrl },
+    { enabled: urlWasTranslated === null && externalUrl.length > 0 }
   );
 
+  // Update translatedUrl and reset urlWasTranslated when externalUrl changes
   useEffect(() => {
-    if (urlWasTranslated) {
-      return;
-    }
+    setTranslatedUrl(new URL(externalUrl));
+    setUrlWasTranslated(null);
+  }, [externalUrl]);
 
-    if (!error && data?.data?.url) {
+  // Handle URL translation when data or error changes
+  useEffect(() => {
+    if (urlWasTranslated === false && !error && data?.data?.url) {
       setTranslatedUrl(new URL(data.data.url));
       setUrlWasTranslated(true);
     }
-  }, [data, error, translatedUrl, urlWasTranslated]);
+  }, [data, error, urlWasTranslated]);
 
   const label = (
     sourceName: AccessUrl["origin"],

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -38,7 +38,10 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
     });
   };
 
-  const accessElement = manifestations[0].access[0];
+  // Find 'Ereol' object or default to the first 'access' object
+  const accessElement =
+    manifestations[0].access.find((item) => item.__typename === "Ereol") ||
+    manifestations[0].access[0];
 
   // If the access type is an external type we'll show corresponding button.
   if (


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-698

#### Description

* We cannot always be certain that the `Ereol` object is located at index 0. To ensure we link to https://ereolen.dk whenever possible, we first attempt to find an `Ereol` object. If it's not found, we then default to using the object at index 0.

* Simplify the URL translation logic in MaterialButtonOnlineExternal to ensure rerendering on externalUrl changes by using a single state for translatedUrl and consolidating effects.

#### Screenshot of the result

![Skærmbillede 2024-06-27 kl  14 49 22](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/105956/5fb6ff3e-2ebf-40d5-a814-9827b971c6d6)

