### PR TITLE
Improve `Cover` accessibility by adding `isHiddenFromScreenReaders` attribute to `Link` component - Ddfform 719 

### DIFF
--- a/src/components/atoms/links/Link.tsx
+++ b/src/components/atoms/links/Link.tsx
@@ -11,6 +11,7 @@ export interface LinkProps {
   dataCy?: string;
   ariaLabelledBy?: string;
   stopPropagation?: boolean;
+  isHiddenFromScreenReaders?: boolean;
 }
 
 const Link: React.FC<LinkProps> = ({
@@ -22,7 +23,8 @@ const Link: React.FC<LinkProps> = ({
   trackClick,
   dataCy,
   ariaLabelledBy,
-  stopPropagation = false
+  stopPropagation = false,
+  isHiddenFromScreenReaders
 }) => {
   const handleClick = getLinkHandler({
     type: "click",
@@ -51,6 +53,8 @@ const Link: React.FC<LinkProps> = ({
       onClick={handleClick}
       onKeyUp={handleKeyUp}
       aria-labelledby={ariaLabelledBy}
+      tabIndex={isHiddenFromScreenReaders ? -1 : 0}
+      aria-hidden={isHiddenFromScreenReaders}
     >
       {children}
     </a>

--- a/src/components/atoms/links/LinkNoStyle.tsx
+++ b/src/components/atoms/links/LinkNoStyle.tsx
@@ -9,6 +9,7 @@ export interface LinkNoStyleProps {
   trackClick?: () => Promise<unknown>;
   dataCy?: string;
   ariaLabelledBy?: string;
+  isHiddenFromScreenReaders?: boolean;
 }
 
 const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
@@ -18,7 +19,8 @@ const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
   className,
   trackClick,
   dataCy = "link-no-style",
-  ariaLabelledBy
+  ariaLabelledBy,
+  isHiddenFromScreenReaders
 }) => {
   return (
     <Link
@@ -28,6 +30,7 @@ const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
       trackClick={trackClick}
       dataCy={dataCy}
       ariaLabelledBy={ariaLabelledBy}
+      isHiddenFromScreenReaders={isHiddenFromScreenReaders}
     >
       {children}
     </Link>

--- a/src/components/cover/cover.tsx
+++ b/src/components/cover/cover.tsx
@@ -91,6 +91,7 @@ export const Cover = ({
         className={classes.wrapper}
         url={url}
         ariaLabelledBy={linkAriaLabelledBy}
+        isHiddenFromScreenReaders={!alt}
       >
         {coverSrc && (
           <CoverImage


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-719

#### Description

This pull request introduces the `isHiddenFromScreenReaders` attribute to the `Link` component.

To enhance accessibility, the `isHiddenFromScreenReaders` attribute has been implemented to manage the focusability of links. Links without meaningful content (such as those without text or images without alt text) should not be focusable.

I have included a check to ensure that if a `Cover` component does not have alt text, the associated wrapper link is not focusable by screen readers.

#### Test
http://varnish.pr-1338.dpl-cms.dplplat01.dpl.reload.dk/frontpage