### PR TITLE
DDFFORM 883 deleting materialsearch

### DIFF
--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -1,20 +1,20 @@
-import * as React from "react";
 import clsx from "clsx";
-import { useState, useEffect } from "react";
-import { WorkId } from "../../core/utils/types/ids";
-import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
+import * as React from "react";
+import { useEffect, useState } from "react";
+import MaterialListItem from "../../components/card-item-list/MaterialListItem";
 import { useText } from "../../core/utils/text";
+import { WorkId } from "../../core/utils/types/ids";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
+import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
 import {
   MaterialGridValidIncrements,
   ValidSelectedIncrements,
   calculateAmountToDisplay
 } from "./materiel-grid-util";
-import { DisplayMaterialType } from "../../core/utils/types/material-type";
-import MaterialListItem from "../../components/card-item-list/MaterialListItem";
 
 export type MaterialGridItemProps = {
   wid: WorkId;
-  materialType?: DisplayMaterialType;
+  materialType?: ManifestationMaterialType;
 };
 
 export type MaterialGridProps = {

--- a/src/apps/material-search/Errors/HiddenInputsNotFoundError.tsx
+++ b/src/apps/material-search/Errors/HiddenInputsNotFoundError.tsx
@@ -2,18 +2,20 @@ import React from "react";
 import { useText } from "../../../core/utils/text";
 import MaterialSearchBaseError from "./MaterialSearchBaseError";
 
-const WorkNotFoundError: React.FC = () => {
+const HiddenInputsNotFoundError: React.FC = () => {
   const t = useText();
 
   return (
-    <MaterialSearchBaseError headingText={t("materialSearchErrorHeaderText")}>
+    <MaterialSearchBaseError
+      headingText={t("materialSearchErrorHiddenInputsNotFoundHeadingText")}
+    >
       <div className="material-search__error-content">
         <p className="material-search__error-description">
-          {t("materialSearchErrorWorkNotFoundText")}
+          {t("materialSearchErrorHiddenInputsNotFoundDescriptionText")}
         </p>
       </div>
     </MaterialSearchBaseError>
   );
 };
 
-export default WorkNotFoundError;
+export default HiddenInputsNotFoundError;

--- a/src/apps/material-search/Errors/MaterialSearchBaseError.tsx
+++ b/src/apps/material-search/Errors/MaterialSearchBaseError.tsx
@@ -1,21 +1,20 @@
 import WarningIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/basic/icon-warning.svg";
 import React from "react";
-import { useText } from "../../../core/utils/text";
 
 interface MaterialSearchBaseErrorProps {
-  children: React.ReactNode;
+  headingText: string;
+  children?: React.ReactNode;
 }
 
 const MaterialSearchBaseError: React.FC<MaterialSearchBaseErrorProps> = ({
+  headingText,
   children
 }) => {
-  const t = useText();
-
   return (
     <div className="material-search__error">
       <div className="material-search__error-header">
         <img src={WarningIcon} className="material-search__error-icon" alt="" />
-        <div>{t("materialSearchErrorHeaderText")}</div>
+        <h3 className="material-search__error-header-text">{headingText}</h3>
       </div>
       {children}
     </div>

--- a/src/apps/material-search/Errors/MaterialSearchBaseError.tsx
+++ b/src/apps/material-search/Errors/MaterialSearchBaseError.tsx
@@ -1,0 +1,25 @@
+import WarningIcon from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/basic/icon-warning.svg";
+import React from "react";
+import { useText } from "../../../core/utils/text";
+
+interface MaterialSearchBaseErrorProps {
+  children: React.ReactNode;
+}
+
+const MaterialSearchBaseError: React.FC<MaterialSearchBaseErrorProps> = ({
+  children
+}) => {
+  const t = useText();
+
+  return (
+    <div className="material-search__error">
+      <div className="material-search__error-header">
+        <img src={WarningIcon} className="material-search__error-icon" alt="" />
+        <div>{t("materialSearchErrorHeaderText")}</div>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default MaterialSearchBaseError;

--- a/src/apps/material-search/Errors/MaterialTypeNotFoundError.tsx
+++ b/src/apps/material-search/Errors/MaterialTypeNotFoundError.tsx
@@ -28,7 +28,7 @@ const MaterialTypeNotFoundError: React.FC<MaterialTypeNotFoundErrorProps> = ({
   const authors = creatorsToString(flattenCreators(creators), t);
 
   return (
-    <MaterialSearchBaseError>
+    <MaterialSearchBaseError headingText={t("materialSearchErrorHeaderText")}>
       <div className="material-search__error-content">
         <p className="material-search__error-description">
           {t("materialSearchErrorMaterialTypeNotFoundText")}

--- a/src/apps/material-search/Errors/MaterialTypeNotFoundError.tsx
+++ b/src/apps/material-search/Errors/MaterialTypeNotFoundError.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  creatorsToString,
+  flattenCreators
+} from "../../../core/utils/helpers/general";
+import { constructMaterialUrl } from "../../../core/utils/helpers/url";
+import { useText } from "../../../core/utils/text";
+import { Work } from "../../../core/utils/types/entities";
+import { useUrls } from "../../../core/utils/url";
+import MaterialSearchBaseError from "./MaterialSearchBaseError";
+
+interface MaterialTypeNotFoundErrorProps {
+  work: Work;
+}
+
+const MaterialTypeNotFoundError: React.FC<MaterialTypeNotFoundErrorProps> = ({
+  work: {
+    titles: { full: fullTitle },
+    creators,
+    workId: wid
+  }
+}) => {
+  const u = useUrls();
+  const t = useText();
+  const materialUrl = u("materialUrl");
+
+  const url = constructMaterialUrl(materialUrl, wid);
+  const authors = creatorsToString(flattenCreators(creators), t);
+
+  return (
+    <MaterialSearchBaseError>
+      <div className="material-search__error-content">
+        <p className="material-search__error-description">
+          {t("materialSearchErrorMaterialTypeNotFoundText")}
+        </p>
+        <div className="material-search__error-material-content">
+          <div className="material-search__error-item">
+            <span className="material-search__error-term">
+              {t("materialSearchErrorTitleText")}:
+            </span>
+            <span className="material-search__error-detail">{fullTitle}</span>
+          </div>
+          <div className="material-search__error-item">
+            <span className="material-search__error-term">
+              {t("materialSearchErrorAuthorText")}:
+            </span>
+            <span className="material-search__error-detail">{authors}</span>
+          </div>
+          <div className="material-search__error-item">
+            <span className="material-search__error-term">
+              {t("materialSearchErrorLinkText")}:
+            </span>
+            <a
+              href={url.href}
+              target="_blank"
+              className="material-search__error-link"
+              rel="noreferrer noopener"
+            >
+              {url.href}
+            </a>
+          </div>
+        </div>
+      </div>
+    </MaterialSearchBaseError>
+  );
+};
+
+export default MaterialTypeNotFoundError;

--- a/src/apps/material-search/Errors/WorkNotFoundError.tsx
+++ b/src/apps/material-search/Errors/WorkNotFoundError.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useText } from "../../../core/utils/text";
+import MaterialSearchBaseError from "./MaterialSearchBaseError";
+
+const WorkNotFoundError: React.FC = () => {
+  const t = useText();
+
+  return (
+    <MaterialSearchBaseError>
+      <div className="material-search__error-content">
+        <p className="material-search__error-description">
+          {t("materialSearchErrorWorkNotFoundText")}
+        </p>
+      </div>
+    </MaterialSearchBaseError>
+  );
+};
+
+export default WorkNotFoundError;

--- a/src/apps/material-search/Errors/errorState.ts
+++ b/src/apps/material-search/Errors/errorState.ts
@@ -1,0 +1,7 @@
+const enum ErrorState {
+  NoError = "NoError",
+  WorkError = "WorkError",
+  MaterialTypeError = "MaterialTypeError"
+}
+
+export default ErrorState;

--- a/src/apps/material-search/Errors/errorState.ts
+++ b/src/apps/material-search/Errors/errorState.ts
@@ -1,7 +1,8 @@
 const enum ErrorState {
   NoError = "NoError",
   WorkError = "WorkError",
-  MaterialTypeError = "MaterialTypeError"
+  MaterialTypeError = "MaterialTypeError",
+  hiddenInputsNotFoundError = "hiddenInputsNotFoundError"
 }
 
 export default ErrorState;

--- a/src/apps/material-search/MaterialSearch.dev.tsx
+++ b/src/apps/material-search/MaterialSearch.dev.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ComponentMeta } from "@storybook/react";
 import React from "react";
 import globalConfigArgs from "../../core/storybook/globalConfigArgs";
 import globalTextArgs, {
@@ -9,29 +9,82 @@ import MaterialSearch, {
   MaterialSearchEntryProps,
   MaterialSearchEntryTextProps
 } from "./MaterialSearch.entry";
-import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 
 // Can't use useId() here since this is not inside a functional component.
-const uniqueIdentifier = Math.floor(Math.random() * 10000);
+const uniqueIdentifierValue = Math.floor(Math.random() * 10000);
 
-const defaultValuePreselectedWorkId =
-  "work-of:800010-katalog:99122475830405763";
-const defaultValuePreselectedMaterialType = "lydbog (cd-mp3)";
+const previouslySelectedWorkId = "work-of:800010-katalog:99122475830405763";
+const previouslySelectedMaterialType = "lydbog (cd-mp3)";
+
+interface MaterialSearchHiddenInputsProps
+  extends MaterialSearchEntryProps,
+    MaterialSearchEntryTextProps,
+    GlobalEntryTextProps {
+  defaultWorkId: string;
+  defaultMaterialType: string;
+  uniqueIdentifier: string;
+}
+
+const MaterialSearchHiddenInputs = ({
+  defaultWorkId,
+  defaultMaterialType,
+  uniqueIdentifier,
+  ...args
+}: MaterialSearchHiddenInputsProps) => {
+  return (
+    <div className="material-search">
+      <span>
+        Input fields only shown in storybook. They are used to reflect how the
+        hidden workId and materialType fields are updated.
+      </span>
+      <div className="material-search__inputs-container">
+        <label
+          className="material-search__label"
+          htmlFor="material-search-input"
+        >
+          Work id
+          <input
+            data-field-input-work-id={uniqueIdentifier}
+            type="text"
+            placeholder="Enter search terms"
+            className="material-search__input"
+            tabIndex={-1}
+            defaultValue={defaultWorkId}
+          />
+        </label>
+        <label
+          className="material-search__label"
+          htmlFor="material-type-selector"
+        >
+          Material type
+          <input
+            data-field-input-material-type-id={uniqueIdentifier}
+            type="text"
+            className="material-search__selector"
+            tabIndex={-1}
+            defaultValue={defaultMaterialType}
+          />
+        </label>
+      </div>
+      <MaterialSearch uniqueIdentifier={uniqueIdentifier} {...args} />
+    </div>
+  );
+};
 
 export default {
   title: "Apps / Material Search",
-  component: MaterialSearch,
+  component: MaterialSearchHiddenInputs,
   argTypes: {
     uniqueIdentifier: {
-      defaultValue: uniqueIdentifier,
+      defaultValue: uniqueIdentifierValue,
       control: { type: "number" }
     },
     previouslySelectedWorkId: {
-      defaultValue: defaultValuePreselectedWorkId,
+      defaultValue: previouslySelectedWorkId,
       control: { type: "text" }
     },
     previouslySelectedMaterialType: {
-      defaultValue: defaultValuePreselectedMaterialType,
+      defaultValue: previouslySelectedMaterialType,
       control: { type: "text" }
     },
     etAlText: {
@@ -157,54 +210,36 @@ export default {
     ...serviceUrlArgs,
     ...globalConfigArgs
   }
-} as ComponentMeta<typeof MaterialSearch>;
+} as ComponentMeta<typeof MaterialSearchHiddenInputs>;
 
-export const Default: ComponentStory<typeof MaterialSearch> = (
-  args: MaterialSearchEntryProps &
-    MaterialSearchEntryTextProps &
-    GlobalEntryTextProps
-) => (
-  <div className="material-search">
-    <span>
-      Input fields only shown in storybook. They are used to reflect how the
-      hidden workId and materialType fields are updated.
-    </span>
-    <div className="material-search__inputs-container">
-      <label className="material-search__label" htmlFor="material-search-input">
-        Work id
-        <input
-          data-field-input-work-id={uniqueIdentifier}
-          type="text"
-          placeholder="Enter search terms"
-          className="material-search__input"
-          tabIndex={-1}
-          defaultValue={defaultValuePreselectedWorkId}
-        />
-      </label>
-      <label
-        className="material-search__label"
-        htmlFor="material-type-selector"
-      >
-        Material type
-        <input
-          data-field-input-material-type-id={uniqueIdentifier}
-          type="text"
-          className="material-search__selector"
-          tabIndex={-1}
-          defaultValue={defaultValuePreselectedMaterialType}
-        />
-      </label>
-    </div>
-    <MaterialSearch {...args} />
-  </div>
+const createStory =
+  (defaultWorkId: string, defaultMaterialType: string) =>
+  (
+    args: MaterialSearchEntryProps &
+      MaterialSearchEntryTextProps &
+      GlobalEntryTextProps
+  ) =>
+    (
+      <MaterialSearchHiddenInputs
+        defaultWorkId={defaultWorkId}
+        defaultMaterialType={defaultMaterialType}
+        {...args}
+      />
+    );
+
+export const Default = createStory("", "");
+
+export const WithPreviouslySelectedValues = createStory(
+  previouslySelectedWorkId,
+  previouslySelectedMaterialType
 );
 
-export const materialWithInvalidType = Default.bind({});
-materialWithInvalidType.args = {
-  previouslySelectedMaterialType: "playstation 5" as ManifestationMaterialType
-};
+export const materialWithInvalidType = createStory(
+  previouslySelectedWorkId,
+  "invalid-type"
+);
 
-export const materialWithInvalidWorkId = Default.bind({});
-materialWithInvalidWorkId.args = {
-  previouslySelectedWorkId: "work-of:222222-katalog:33332313"
-};
+export const materialWithInvalidWorkId = createStory(
+  "invalid-work-id",
+  previouslySelectedMaterialType
+);

--- a/src/apps/material-search/MaterialSearch.dev.tsx
+++ b/src/apps/material-search/MaterialSearch.dev.tsx
@@ -144,6 +144,15 @@ export default {
         "The material that was previously selected is no longer available in the system. Either delete this entry or search for a new material to replace it.",
       control: { type: "text" }
     },
+    materialSearchErrorHiddenInputsNotFoundHeadingText: {
+      defaultValue: "Error retrieving saved data. Inputs not found.",
+      control: { type: "text" }
+    },
+    materialSearchErrorHiddenInputsNotFoundDescriptionText: {
+      defaultValue:
+        "Something went wrong when trying to find the previously saved values. Please try again. If the problem persists, something could be wrong with the app.",
+      control: { type: "text" }
+    },
     ...globalTextArgs,
     ...serviceUrlArgs,
     ...globalConfigArgs

--- a/src/apps/material-search/MaterialSearch.dev.tsx
+++ b/src/apps/material-search/MaterialSearch.dev.tsx
@@ -9,9 +9,14 @@ import MaterialSearch, {
   MaterialSearchEntryProps,
   MaterialSearchEntryTextProps
 } from "./MaterialSearch.entry";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 
 // Can't use useId() here since this is not inside a functional component.
 const uniqueIdentifier = Math.floor(Math.random() * 10000);
+
+const defaultValuePreselectedWorkId =
+  "work-of:800010-katalog:99122475830405763";
+const defaultValuePreselectedMaterialType = "bog";
 
 export default {
   title: "Apps / Material Search",
@@ -22,15 +27,19 @@ export default {
       control: { type: "number" }
     },
     previouslySelectedWorkId: {
-      defaultValue: "work-of:870970-basis:134320257",
+      defaultValue: defaultValuePreselectedWorkId,
       control: { type: "text" }
     },
     previouslySelectedMaterialType: {
-      defaultValue: "bog",
+      defaultValue: defaultValuePreselectedMaterialType,
       control: { type: "text" }
     },
     etAlText: {
       defaultValue: "et al.",
+      control: { type: "text" }
+    },
+    materialUrl: {
+      defaultValue: "/work/:workid",
       control: { type: "text" }
     },
     materialSearchSearchInputText: {
@@ -109,6 +118,32 @@ export default {
       defaultValue: "Work ID",
       control: { type: "text" }
     },
+    materialSearchErrorTitleText: {
+      defaultValue: "Title",
+      control: { type: "text" }
+    },
+    materialSearchErrorAuthorText: {
+      defaultValue: "Author",
+      control: { type: "text" }
+    },
+    materialSearchErrorLinkText: {
+      defaultValue: "Link",
+      control: { type: "text" }
+    },
+    materialSearchErrorHeaderText: {
+      defaultValue: "This material needs to be updated.",
+      control: { type: "text" }
+    },
+    materialSearchErrorMaterialTypeNotFoundText: {
+      defaultValue:
+        "The currently selected type of the material is no longer available in the system. As a result of this, the link is likely broken. Use the title or link underneath to find and update the material and its type, or replace / delete it.",
+      control: { type: "text" }
+    },
+    materialSearchErrorWorkNotFoundText: {
+      defaultValue:
+        "The material that was previously selected is no longer available in the system. Either delete this entry or search for a new material to replace it.",
+      control: { type: "text" }
+    },
     ...globalTextArgs,
     ...serviceUrlArgs,
     ...globalConfigArgs
@@ -134,6 +169,7 @@ export const Default: ComponentStory<typeof MaterialSearch> = (
           placeholder="Enter search terms"
           className="material-search__input"
           tabIndex={-1}
+          defaultValue={defaultValuePreselectedWorkId}
         />
       </label>
       <label
@@ -146,6 +182,7 @@ export const Default: ComponentStory<typeof MaterialSearch> = (
           type="text"
           className="material-search__selector"
           tabIndex={-1}
+          defaultValue={defaultValuePreselectedMaterialType}
         />
       </label>
     </div>
@@ -153,4 +190,12 @@ export const Default: ComponentStory<typeof MaterialSearch> = (
   </div>
 );
 
-export const materialWithoutType = Default.bind({});
+export const materialWithInvalidType = Default.bind({});
+materialWithInvalidType.args = {
+  previouslySelectedMaterialType: "playstation 5" as ManifestationMaterialType
+};
+
+export const materialWithInvalidWorkId = Default.bind({});
+materialWithInvalidWorkId.args = {
+  previouslySelectedWorkId: "work-of:222222-katalog:33332313"
+};

--- a/src/apps/material-search/MaterialSearch.dev.tsx
+++ b/src/apps/material-search/MaterialSearch.dev.tsx
@@ -16,7 +16,7 @@ const uniqueIdentifier = Math.floor(Math.random() * 10000);
 
 const defaultValuePreselectedWorkId =
   "work-of:800010-katalog:99122475830405763";
-const defaultValuePreselectedMaterialType = "bog";
+const defaultValuePreselectedMaterialType = "lydbog (cd-mp3)";
 
 export default {
   title: "Apps / Material Search",

--- a/src/apps/material-search/MaterialSearch.entry.tsx
+++ b/src/apps/material-search/MaterialSearch.entry.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
 import { withConfig } from "../../core/utils/config";
 import { withText } from "../../core/utils/text";
-import { WorkId } from "../../core/utils/types/ids";
 import { withUrls } from "../../core/utils/url";
 import MaterialSearch from "./MaterialSearch";
-import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 
 export interface MaterialSearchEntryTextProps {
   materialSearchSearchInputText: string;
@@ -36,23 +34,13 @@ export interface MaterialSearchEntryTextProps {
 }
 
 export interface MaterialSearchEntryProps {
-  previouslySelectedWorkId: WorkId | null;
-  previouslySelectedMaterialType: ManifestationMaterialType | null;
   uniqueIdentifier: string;
 }
 
 const MaterialSearchEntry: React.FC<
   MaterialSearchEntryProps & MaterialSearchEntryTextProps & GlobalEntryTextProps
-> = ({
-  previouslySelectedWorkId,
-  previouslySelectedMaterialType,
-  uniqueIdentifier
-}) => (
-  <MaterialSearch
-    previouslySelectedWorkId={previouslySelectedWorkId}
-    previouslySelectedMaterialType={previouslySelectedMaterialType}
-    uniqueIdentifier={uniqueIdentifier}
-  />
+> = ({ uniqueIdentifier }) => (
+  <MaterialSearch uniqueIdentifier={uniqueIdentifier} />
 );
 
 export default withConfig(withUrls(withText(MaterialSearchEntry)));

--- a/src/apps/material-search/MaterialSearch.entry.tsx
+++ b/src/apps/material-search/MaterialSearch.entry.tsx
@@ -31,6 +31,8 @@ export interface MaterialSearchEntryTextProps {
   materialSearchErrorHeaderText: string;
   materialSearchErrorMaterialTypeNotFoundText: string;
   materialSearchErrorWorkNotFoundText: string;
+  materialSearchErrorHiddenInputsNotFoundHeadingText: string;
+  materialSearchErrorHiddenInputsNotFoundDescriptionText: string;
 }
 
 export interface MaterialSearchEntryProps {

--- a/src/apps/material-search/MaterialSearch.entry.tsx
+++ b/src/apps/material-search/MaterialSearch.entry.tsx
@@ -25,6 +25,12 @@ export interface MaterialSearchEntryTextProps {
   materialSearchPreviewPublicationYearText: string;
   materialSearchPreviewSourceText: string;
   materialSearchPreviewWorkIdText: string;
+  materialSearchErrorTitleText: string;
+  materialSearchErrorAuthorText: string;
+  materialSearchErrorLinkText: string;
+  materialSearchErrorHeaderText: string;
+  materialSearchErrorMaterialTypeNotFoundText: string;
+  materialSearchErrorWorkNotFoundText: string;
 }
 
 export interface MaterialSearchEntryProps {

--- a/src/apps/material-search/MaterialSearch.tsx
+++ b/src/apps/material-search/MaterialSearch.tsx
@@ -1,24 +1,20 @@
-import React, { FC } from "react";
-import { WorkId } from "../../core/utils/types/ids";
+import React, { FC, useEffect } from "react";
 import { ManifestationMaterialType } from "../../core/utils/types/material-type";
+import HiddenInputsNotFoundError from "./Errors/HiddenInputsNotFoundError";
+import ErrorState from "./Errors/errorState";
 import MaterialSearchInputs from "./MaterialSearchInputs";
 import MaterialSearchList from "./MaterialSearchList";
 import MaterialSearchPreview from "./MaterialSearchPreview";
 import useGetMaterialListSearch from "./useGetMaterialListSearch";
 import useGetSelectedWork from "./useGetSelectedWork";
+import useGetHiddenInputs from "./useGetHiddenInputs";
 import useUpdateFields from "./useUpdateFields";
 
 type MaterialSearchProps = {
-  previouslySelectedWorkId: WorkId | null;
-  previouslySelectedMaterialType: ManifestationMaterialType | null;
   uniqueIdentifier: string;
 };
 
-const MaterialSearch: FC<MaterialSearchProps> = ({
-  previouslySelectedWorkId,
-  previouslySelectedMaterialType,
-  uniqueIdentifier
-}) => {
+const MaterialSearch: FC<MaterialSearchProps> = ({ uniqueIdentifier }) => {
   const {
     availableMaterialTypes,
     work,
@@ -28,10 +24,7 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
     selectedMaterialType,
     setSelectedMaterialType,
     errorState
-  } = useGetSelectedWork({
-    previouslySelectedWorkId,
-    previouslySelectedMaterialType
-  });
+  } = useGetSelectedWork();
 
   const {
     searchInput,
@@ -48,6 +41,32 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
     uniqueIdentifier
   });
 
+  const {
+    workIdElement,
+    materialTypeElement,
+    errorState: hiddenInputErrorState
+  } = useGetHiddenInputs(uniqueIdentifier);
+
+  useEffect(() => {
+    if (workIdElement && workIdElement.value) {
+      setSelectedWorkId(workIdElement?.value);
+    }
+
+    if (materialTypeElement && materialTypeElement.value) {
+      setSelectedMaterialType(
+        materialTypeElement?.value as ManifestationMaterialType
+      );
+    }
+  }, [
+    workIdElement,
+    materialTypeElement,
+    setSelectedWorkId,
+    setSelectedMaterialType
+  ]);
+
+  if (hiddenInputErrorState === ErrorState.hiddenInputsNotFoundError) {
+    return <HiddenInputsNotFoundError />;
+  }
   return (
     <div className="material-search">
       <MaterialSearchInputs

--- a/src/apps/material-search/MaterialSearch.tsx
+++ b/src/apps/material-search/MaterialSearch.tsx
@@ -1,12 +1,12 @@
 import React, { FC, useEffect } from "react";
 import { WorkId } from "../../core/utils/types/ids";
-import MaterialSearchList from "./MaterialSearchList";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import MaterialSearchInputs from "./MaterialSearchInputs";
+import MaterialSearchList from "./MaterialSearchList";
 import MaterialSearchPreview from "./MaterialSearchPreview";
 import useGetMaterialListSearch from "./useGetMaterialListSearch";
 import useGetSelectedWork from "./useGetSelectedWork";
 import useUpdateFields from "./useUpdateFields";
-import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 
 type MaterialSearchProps = {
   previouslySelectedWorkId: WorkId | null;
@@ -26,8 +26,13 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
     selectedWorkId,
     setSelectedWorkId,
     selectedMaterialType,
-    setSelectedMaterialType
-  } = useGetSelectedWork();
+    setSelectedMaterialType,
+    workError,
+    workErrorHasBeenChecked
+  } = useGetSelectedWork({
+    previouslySelectedWorkId,
+    previouslySelectedMaterialType
+  });
 
   const {
     searchInput,
@@ -45,17 +50,25 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
   });
 
   useEffect(() => {
-    if (previouslySelectedWorkId) {
+    if (workError || workErrorHasBeenChecked || !isSelectedWorkLoading) return;
+    if (previouslySelectedWorkId && !workErrorHasBeenChecked) {
       handleUpdateWorkId(previouslySelectedWorkId);
     }
-    if (previouslySelectedMaterialType && previouslySelectedWorkId) {
+    if (
+      previouslySelectedMaterialType &&
+      previouslySelectedWorkId &&
+      !workErrorHasBeenChecked
+    ) {
       handleUpdateMaterialType(previouslySelectedMaterialType);
     }
   }, [
     previouslySelectedWorkId,
     previouslySelectedMaterialType,
     handleUpdateWorkId,
-    handleUpdateMaterialType
+    handleUpdateMaterialType,
+    workError,
+    workErrorHasBeenChecked,
+    isSelectedWorkLoading
   ]);
 
   return (
@@ -73,6 +86,7 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
         work={work}
         isLoading={isSelectedWorkLoading}
         selectedMaterialType={selectedMaterialType}
+        workError={workError}
       />
       <MaterialSearchList
         data={searchListData}

--- a/src/apps/material-search/MaterialSearch.tsx
+++ b/src/apps/material-search/MaterialSearch.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import { WorkId } from "../../core/utils/types/ids";
 import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import MaterialSearchInputs from "./MaterialSearchInputs";
@@ -27,8 +27,7 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
     setSelectedWorkId,
     selectedMaterialType,
     setSelectedMaterialType,
-    workError,
-    workErrorHasBeenChecked
+    errorState
   } = useGetSelectedWork({
     previouslySelectedWorkId,
     previouslySelectedMaterialType
@@ -49,28 +48,6 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
     uniqueIdentifier
   });
 
-  useEffect(() => {
-    if (workError || workErrorHasBeenChecked || !isSelectedWorkLoading) return;
-    if (previouslySelectedWorkId && !workErrorHasBeenChecked) {
-      handleUpdateWorkId(previouslySelectedWorkId);
-    }
-    if (
-      previouslySelectedMaterialType &&
-      previouslySelectedWorkId &&
-      !workErrorHasBeenChecked
-    ) {
-      handleUpdateMaterialType(previouslySelectedMaterialType);
-    }
-  }, [
-    previouslySelectedWorkId,
-    previouslySelectedMaterialType,
-    handleUpdateWorkId,
-    handleUpdateMaterialType,
-    workError,
-    workErrorHasBeenChecked,
-    isSelectedWorkLoading
-  ]);
-
   return (
     <div className="material-search">
       <MaterialSearchInputs
@@ -86,7 +63,7 @@ const MaterialSearch: FC<MaterialSearchProps> = ({
         work={work}
         isLoading={isSelectedWorkLoading}
         selectedMaterialType={selectedMaterialType}
-        workError={workError}
+        errorState={errorState}
       />
       <MaterialSearchList
         data={searchListData}

--- a/src/apps/material-search/MaterialSearchPreview.tsx
+++ b/src/apps/material-search/MaterialSearchPreview.tsx
@@ -10,21 +10,21 @@ import { ManifestationMaterialType } from "../../core/utils/types/material-type"
 import { getManifestationBasedOnType } from "../material/helper";
 import MaterialTypeNotFoundError from "./Errors/MaterialTypeNotFoundError";
 import WorkNotFoundError from "./Errors/WorkNotFoundError";
+import ErrorState from "./Errors/errorState";
 import MaterialSearchLoading from "./MaterialSearchLoading";
-import { WorkErrorType } from "./useGetSelectedWork";
 
 type MaterialSearchPreviewProps = {
   work: Work | null;
   selectedMaterialType: ManifestationMaterialType | null;
   isLoading: boolean;
-  workError: WorkErrorType;
+  errorState: ErrorState;
 };
 
 const MaterialSearchPreview: FC<MaterialSearchPreviewProps> = ({
   work,
   selectedMaterialType,
   isLoading,
-  workError
+  errorState
 }) => {
   const t = useText();
 
@@ -55,11 +55,11 @@ const MaterialSearchPreview: FC<MaterialSearchPreviewProps> = ({
       </div>
     );
   }
-  if (workError === "work-not-found") {
+  if (errorState === ErrorState.WorkError) {
     return <WorkNotFoundError />;
   }
 
-  if (work && workError === "material-type-not-found") {
+  if (work && errorState === ErrorState.MaterialTypeError) {
     return <MaterialTypeNotFoundError work={work} />;
   }
 

--- a/src/apps/material-search/MaterialSearchPreview.tsx
+++ b/src/apps/material-search/MaterialSearchPreview.tsx
@@ -6,34 +6,44 @@ import {
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { Manifestation, Work } from "../../core/utils/types/entities";
-import { getManifestationsFromType } from "../material/helper";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
+import { getManifestationBasedOnType } from "../material/helper";
+import MaterialTypeNotFoundError from "./Errors/MaterialTypeNotFoundError";
+import WorkNotFoundError from "./Errors/WorkNotFoundError";
 import MaterialSearchLoading from "./MaterialSearchLoading";
+import { WorkErrorType } from "./useGetSelectedWork";
 
 type MaterialSearchPreviewProps = {
   work: Work | null;
-  selectedMaterialType: string | null;
+  selectedMaterialType: ManifestationMaterialType | null;
   isLoading: boolean;
+  workError: WorkErrorType;
 };
 
 const MaterialSearchPreview: FC<MaterialSearchPreviewProps> = ({
   work,
   selectedMaterialType,
-  isLoading
+  isLoading,
+  workError
 }) => {
   const t = useText();
+
   const [materialForDisplay, setMaterialForDisplay] =
     useState<Manifestation | null>(null);
 
   useEffect(() => {
-    if (work) {
-      const matchedManifestations = selectedMaterialType
-        ? getManifestationsFromType(selectedMaterialType, work)
-        : [work.manifestations.bestRepresentation];
+    if (!work) return;
 
-      setMaterialForDisplay(matchedManifestations[0]);
-    } else {
-      setMaterialForDisplay(null);
+    if (!selectedMaterialType) {
+      setMaterialForDisplay(work.manifestations.bestRepresentation);
+      return;
     }
+
+    const manifestation = getManifestationBasedOnType(
+      work,
+      selectedMaterialType
+    );
+    setMaterialForDisplay(manifestation);
   }, [work, selectedMaterialType]);
 
   if (isLoading) {
@@ -44,6 +54,13 @@ const MaterialSearchPreview: FC<MaterialSearchPreviewProps> = ({
         </div>
       </div>
     );
+  }
+  if (workError === "work-not-found") {
+    return <WorkNotFoundError />;
+  }
+
+  if (work && workError === "material-type-not-found") {
+    return <MaterialTypeNotFoundError work={work} />;
   }
 
   if (!work || !materialForDisplay) {

--- a/src/apps/material-search/useGetHiddenInputs.tsx
+++ b/src/apps/material-search/useGetHiddenInputs.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from "react";
+import ErrorState from "./Errors/errorState";
+
+interface HiddenInputsResult {
+  workIdElement: HTMLInputElement | null;
+  materialTypeElement: HTMLInputElement | null;
+  errorState: ErrorState;
+}
+
+const useGetHiddenInputs = (uniqueIdentifier: string): HiddenInputsResult => {
+  const [workIdElement, setWorkIdElement] = useState<HTMLInputElement | null>(
+    null
+  );
+  const [materialTypeElement, setMaterialTypeElement] =
+    useState<HTMLInputElement | null>(null);
+  const [errorState, setErrorState] = useState<ErrorState>(ErrorState.NoError);
+
+  useEffect(() => {
+    const workElement = document.querySelector(
+      `[data-field-input-work-id="${uniqueIdentifier}"]`
+    ) as HTMLInputElement | null;
+    const materialElement = document.querySelector(
+      `[data-field-input-material-type-id="${uniqueIdentifier}"]`
+    ) as HTMLInputElement | null;
+
+    if (!workElement) {
+      // eslint-disable-next-line no-console
+      console.debug(
+        `Could not find input for work ID with unique identifier: ${uniqueIdentifier}`
+      );
+      setErrorState(ErrorState.hiddenInputsNotFoundError);
+    } else {
+      setWorkIdElement(workElement);
+    }
+
+    if (!materialElement) {
+      // eslint-disable-next-line no-console
+      console.debug(
+        `Could not find input for material type with unique identifier: ${uniqueIdentifier}`
+      );
+      setErrorState(ErrorState.hiddenInputsNotFoundError);
+    } else {
+      setMaterialTypeElement(materialElement);
+    }
+
+    if (workElement && materialElement) {
+      setErrorState(ErrorState.NoError);
+    }
+  }, [uniqueIdentifier]);
+
+  return { workIdElement, materialTypeElement, errorState };
+};
+
+export default useGetHiddenInputs;

--- a/src/apps/material-search/useGetSelectedWork.ts
+++ b/src/apps/material-search/useGetSelectedWork.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useGetMaterialQuery } from "../../core/dbc-gateway/generated/graphql";
 import { getMaterialTypes } from "../../core/utils/helpers/general";
 import { Work } from "../../core/utils/types/entities";
@@ -36,7 +36,11 @@ const useGetSelectedWork = ({
 
   const [errorState, setErrorState] = useState<ErrorState>(ErrorState.NoError);
 
-  const { data, isLoading: isSelectedWorkLoading } = useGetMaterialQuery(
+  const {
+    data,
+    isLoading: isSelectedWorkLoading,
+    refetch
+  } = useGetMaterialQuery(
     { wid: selectedWorkId },
     {
       enabled: !!selectedWorkId && selectedWorkId.length > 0,
@@ -65,6 +69,12 @@ const useGetSelectedWork = ({
       }
     }
   );
+
+  useEffect(() => {
+    if (selectedWorkId) {
+      refetch();
+    }
+  }, [selectedWorkId, selectedMaterialType, refetch]);
 
   const work = (data?.work as Work) ?? null;
 

--- a/src/apps/material-search/useGetSelectedWork.ts
+++ b/src/apps/material-search/useGetSelectedWork.ts
@@ -5,27 +5,78 @@ import { Work } from "../../core/utils/types/entities";
 import { WorkId } from "../../core/utils/types/ids";
 import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 
+export type WorkErrorType = "work-not-found" | "material-type-not-found" | null;
+
 interface UseGetSelectedMaterialReturn {
   work: Work | null;
   selectedWorkId: WorkId | string;
   selectedMaterialType: ManifestationMaterialType | null;
   availableMaterialTypes: ManifestationMaterialType[] | null;
   isSelectedWorkLoading: boolean;
+  workError: WorkErrorType;
+  workErrorHasBeenChecked: boolean;
   setSelectedWorkId: (wid: WorkId | string) => void;
   setSelectedMaterialType: (
     materialType: ManifestationMaterialType | null
   ) => void;
 }
 
-const useGetSelectedWork = (): UseGetSelectedMaterialReturn => {
-  const [selectedWorkId, setSelectedWorkId] = useState<WorkId | string>("");
+interface UseGetSelectedMaterialProps {
+  previouslySelectedWorkId: WorkId | null;
+  previouslySelectedMaterialType: ManifestationMaterialType | null;
+}
+
+const useGetSelectedWork = ({
+  previouslySelectedWorkId,
+  previouslySelectedMaterialType
+}: UseGetSelectedMaterialProps): UseGetSelectedMaterialReturn => {
+  const [selectedWorkId, setSelectedWorkId] = useState<string>(
+    previouslySelectedWorkId ?? ""
+  );
   const [selectedMaterialType, setSelectedMaterialType] =
-    useState<ManifestationMaterialType | null>(null);
+    useState<ManifestationMaterialType | null>(previouslySelectedMaterialType);
+
+  const [workError, setWorkError] = useState<WorkErrorType>(null);
+  const [workErrorHasBeenChecked, setErrorHasBeenChecked] = useState(false);
 
   const { data, isLoading: isSelectedWorkLoading } = useGetMaterialQuery(
     { wid: selectedWorkId },
     {
-      enabled: !!selectedWorkId
+      enabled: !!selectedWorkId,
+      onSuccess: (responseData) => {
+        if (!previouslySelectedWorkId) return;
+
+        if (workErrorHasBeenChecked) {
+          setWorkError(null);
+          return;
+        }
+
+        if (!responseData.work) {
+          setErrorHasBeenChecked(true);
+          setWorkError("work-not-found");
+          return;
+        }
+
+        if (previouslySelectedMaterialType && responseData.work) {
+          const work = responseData.work as Work;
+
+          const availableMaterialTypes = work
+            ? getMaterialTypes(work.manifestations.all, false)
+            : null;
+
+          if (
+            availableMaterialTypes &&
+            !availableMaterialTypes.includes(previouslySelectedMaterialType)
+          ) {
+            setErrorHasBeenChecked(true);
+            setWorkError("material-type-not-found");
+            return;
+          }
+        }
+
+        setErrorHasBeenChecked(true);
+        setWorkError(null);
+      }
     }
   );
 
@@ -39,10 +90,12 @@ const useGetSelectedWork = (): UseGetSelectedMaterialReturn => {
     work,
     availableMaterialTypes,
     selectedWorkId,
+    workErrorHasBeenChecked,
     setSelectedMaterialType,
     isSelectedWorkLoading,
     setSelectedWorkId,
-    selectedMaterialType
+    selectedMaterialType,
+    workError
   };
 };
 

--- a/src/apps/material-search/useGetSelectedWork.ts
+++ b/src/apps/material-search/useGetSelectedWork.ts
@@ -19,20 +19,10 @@ interface UseGetSelectedMaterialReturn {
   ) => void;
 }
 
-interface UseGetSelectedMaterialProps {
-  previouslySelectedWorkId: WorkId | null;
-  previouslySelectedMaterialType: ManifestationMaterialType | null;
-}
-
-const useGetSelectedWork = ({
-  previouslySelectedWorkId,
-  previouslySelectedMaterialType
-}: UseGetSelectedMaterialProps): UseGetSelectedMaterialReturn => {
-  const [selectedWorkId, setSelectedWorkId] = useState<string>(
-    previouslySelectedWorkId ?? ""
-  );
+const useGetSelectedWork = (): UseGetSelectedMaterialReturn => {
+  const [selectedWorkId, setSelectedWorkId] = useState<string>("");
   const [selectedMaterialType, setSelectedMaterialType] =
-    useState<ManifestationMaterialType | null>(previouslySelectedMaterialType);
+    useState<ManifestationMaterialType | null>(null);
 
   const [errorState, setErrorState] = useState<ErrorState>(ErrorState.NoError);
 

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -539,7 +539,7 @@ export const useGetHoldings = ({
 
 export const getManifestationBasedOnType = (
   work: Work,
-  materialType: DisplayMaterialType
+  materialType: ManifestationMaterialType
 ): Manifestation => {
   const { bestRepresentation, all } = work.manifestations;
 

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -1,42 +1,39 @@
-import { compact, groupBy, uniqBy, uniq, head, first } from "lodash";
+import { compact, first, groupBy, head, uniq, uniqBy } from "lodash";
 import { UseQueryOptions } from "react-query";
-import {
-  getManifestationType,
-  orderManifestationsByYear,
-  flattenCreators
-} from "../../core/utils/helpers/general";
 import { ManifestationHoldings } from "../../components/find-on-shelf/types";
 import {
   ListData,
   ListItemType
 } from "../../components/material/MaterialDetailsList";
 import {
-  HoldingsForBibliographicalRecordV3,
-  HoldingsV3
-} from "../../core/fbs/model";
-import { UseTextFunction } from "../../core/utils/text";
-import { Manifestation, Work } from "../../core/utils/types/entities";
-import { FaustId } from "../../core/utils/types/ids";
-import {
-  DisplayMaterialType,
-  ManifestationMaterialType
-} from "../../core/utils/types/material-type";
+  hasCorrectAccessType,
+  isArticle
+} from "../../components/material/material-buttons/helper";
 import {
   AccessTypeCode,
   WorkType
 } from "../../core/dbc-gateway/generated/graphql";
 import {
-  hasCorrectAccessType,
-  isArticle
-} from "../../components/material/material-buttons/helper";
-import { UseConfigFunction } from "../../core/utils/config";
-import {
   getAvailabilityV3,
   getHoldingsV3,
   useGetHoldingsV3
 } from "../../core/fbs/fbs";
-import vitestData from "./__vitest_data__/helper";
+import {
+  HoldingsForBibliographicalRecordV3,
+  HoldingsV3
+} from "../../core/fbs/model";
+import { UseConfigFunction } from "../../core/utils/config";
+import {
+  flattenCreators,
+  getManifestationType,
+  orderManifestationsByYear
+} from "../../core/utils/helpers/general";
 import { constructModalId } from "../../core/utils/helpers/modal-helpers";
+import { UseTextFunction } from "../../core/utils/text";
+import { Manifestation, Work } from "../../core/utils/types/entities";
+import { FaustId } from "../../core/utils/types/ids";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
+import vitestData from "./__vitest_data__/helper";
 
 export const getWorkManifestation = (
   work: Work,
@@ -549,11 +546,11 @@ export const getManifestationBasedOnType = (
   if (materialType === bestRepresentationMaterialType) {
     return bestRepresentation;
   }
-
   // Filters and sorts the manifestations if the best representation does not match.
+  const sortedManifestations = getManifestationsOrderByTypeAndYear(all);
   const filteredAndSortedManifestations = filterManifestationsByType(
     materialType,
-    all
+    sortedManifestations
   );
   const newestFilteredAndSortedManifestation = first(
     filteredAndSortedManifestations

--- a/src/apps/recommendation/recommendation.entry.tsx
+++ b/src/apps/recommendation/recommendation.entry.tsx
@@ -4,13 +4,13 @@ import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
 import { withConfig } from "../../core/utils/config";
 import { withText } from "../../core/utils/text";
 import { WorkId } from "../../core/utils/types/ids";
-import { DisplayMaterialType } from "../../core/utils/types/material-type";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import { withUrls } from "../../core/utils/url";
 import Recommendation from "./recommendation";
 
 export interface RecommendationEntryProps extends GlobalEntryTextProps {
   wid: WorkId;
-  materialType?: DisplayMaterialType;
+  materialType?: ManifestationMaterialType;
   positionImageRight?: boolean;
 }
 

--- a/src/apps/recommendation/recommendation.tsx
+++ b/src/apps/recommendation/recommendation.tsx
@@ -5,14 +5,14 @@ import Link from "../../components/atoms/links/Link";
 import { useGetMaterialQuery } from "../../core/dbc-gateway/generated/graphql";
 import { constructMaterialUrl } from "../../core/utils/helpers/url";
 import { WorkId } from "../../core/utils/types/ids";
-import { DisplayMaterialType } from "../../core/utils/types/material-type";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import { useUrls } from "../../core/utils/url";
 import RecommendedMaterial from "../recommended-material/RecommendedMaterial";
 import RecommendationMaterialSkeleton from "./RecommendationSkeleton";
 
 export type RecommendationProps = {
   wid: WorkId;
-  materialType?: DisplayMaterialType;
+  materialType?: ManifestationMaterialType;
   positionImageRight?: boolean;
 };
 

--- a/src/apps/recommended-material/RecommendedMaterial.entry.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.entry.tsx
@@ -4,13 +4,13 @@ import { GlobalEntryTextProps } from "../../core/storybook/globalTextArgs";
 import { withConfig } from "../../core/utils/config";
 import { withText } from "../../core/utils/text";
 import { WorkId } from "../../core/utils/types/ids";
-import { DisplayMaterialType } from "../../core/utils/types/material-type";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import { withUrls } from "../../core/utils/url";
 import RecommendedMaterial from "./RecommendedMaterial";
 
 export interface RecommendedMaterialEntryProps {
   wid: WorkId;
-  materialType?: DisplayMaterialType;
+  materialType?: ManifestationMaterialType;
 }
 
 const RecommendedMaterialEntry: React.FC<

--- a/src/apps/recommended-material/RecommendedMaterial.tsx
+++ b/src/apps/recommended-material/RecommendedMaterial.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import clsx from "clsx";
-import { useDispatch } from "react-redux";
+import * as React from "react";
 import { useQueryClient } from "react-query";
+import { useDispatch } from "react-redux";
 import ButtonFavourite, {
   ButtonFavouriteId
 } from "../../components/button-favourite/button-favourite";
@@ -17,16 +17,16 @@ import { constructMaterialUrl } from "../../core/utils/helpers/url";
 import { useText } from "../../core/utils/text";
 import { Work } from "../../core/utils/types/entities";
 
+import Link from "../../components/atoms/links/Link";
 import { WorkId } from "../../core/utils/types/ids";
-import { DisplayMaterialType } from "../../core/utils/types/material-type";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import { useUrls } from "../../core/utils/url";
 import { getManifestationBasedOnType } from "../material/helper";
 import RecommendedMaterialSkeleton from "./RecommendedMaterialSkeleton";
-import Link from "../../components/atoms/links/Link";
 
 export type RecommendedMaterialProps = {
   wid: WorkId;
-  materialType?: DisplayMaterialType;
+  materialType?: ManifestationMaterialType;
   partOfGrid?: boolean;
 };
 

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -35,23 +35,3 @@ export type AutosuggestCategoryList = {
 };
 
 export default {};
-
-export type DisplayMaterialType =
-  | "bog"
-  | "billedbog"
-  | "billedbog (online)"
-  | "e-bog"
-  | "cd"
-  | "podcast"
-  | "musik (online)"
-  | "film"
-  | "film (online)"
-  | "lydbog"
-  | "lydbog (online)"
-  | "lydbog (cd-mp3)"
-  | "artikel"
-  | "artikel (online)"
-  | "tegneserie"
-  | "tegneserie (online)"
-  | "tidsskrift"
-  | "tidsskrift (online)";


### PR DESCRIPTION
- **Add error hiddenInputsNotFound.**
- **Rewrite retrieval and usage of selectedWorkId and materialType.**
- **Update / Refactor materialSearch story to reflect changes in the approach of retrieving the workId and type through the DOM.**

#### Link to issue

Jira Ticket: [DDFFORM-883](https://reload.atlassian.net/browse/DDFFORM-883)

Related tickets: 

#### Description

This PR attempts to update the logic for retrieving dpl_fbi_work_id saved values, and use it in the materialSearch app. 

The PR builds ontop of [DDFFORM-900](https://reload.atlassian.net/browse/DDFFORM-900). 

The saved values in drupal are now retrieving using JS instead of being passed a prop. 
This is due to an issue, where formState is not correctly moving the app "value" associated with field, which means that if an entry is deleted from i.e. material-grid, then the rerendered fields could be displaying an incorrect selected material. 

This new logic is added in a new hook. 

Additionally i have added an error that will be displayed, if either of the hiddin fields cannot be found for whatever reason. 

Comment on whether this is fine, needs or story, or should be removed entirely. 

#### Screenshot of the result

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/13272656/a5afec3c-cb90-4d51-acd9-e2753e0f46a0)

![image](https://github.com/danskernesdigitalebibliotek/dpl-react/assets/13272656/ffd09a59-06df-428e-86f5-81e23e8a70b3)


#### Additional comments or questions

It is important that you test this out in Drupal. You are welcome to test in react, but mostly drupal. 


With this change, as well as [DDFFORM-914](https://reload.atlassian.net/browse/DDFFORM-914)
and [DDFFORM-900](https://reload.atlassian.net/browse/DDFFORM-900), it should be possible to: 


- Create multiple recommendations that will in any variation, keep displaying the correct material that was selected for that field. 

- Create a material grid on the same page that will do the same. 

- Delete any entry in any order, and see that the correct field item and app is being deleted, and not an incorrect one. 

- Save the items with incorrect ids/types ( find the selected and uncheck display:none; for the fields_container ), and when reopening this seeing all individual applications display the appropriate error. 

[DDFFORM-883]: https://reload.atlassian.net/browse/DDFFORM-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-900]: https://reload.atlassian.net/browse/DDFFORM-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDFFORM-914]: https://reload.atlassian.net/browse/DDFFORM-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ