### PR TITLE
Use FBS record for interlibrary loans and reservations where material cannot be found in FBI

### DIFF
--- a/src/apps/loan-list/list/loan-list.test.ts
+++ b/src/apps/loan-list/list/loan-list.test.ts
@@ -672,6 +672,84 @@ describe("Loan list", () => {
     );
   });
 
+  it("It shows interlibrary record when work is not found", () => {
+    cy.intercept("GET", "**/external/agencyid/patrons/patronid/loans/v2**", {
+      statusCode: 200,
+      body: [
+        {
+          isRenewable: true,
+          isLongtermLoan: false,
+          loanDetails: {
+            loanId: 956250509,
+            materialItemNumber: "3846990827",
+            recordId: "28843238",
+            periodical: null,
+            loanDate: "2022-10-14T16:43:25.325",
+            dueDate: "2022-10-28",
+            loanType: "loan",
+            ilBibliographicRecord: {
+              author: "Thorpe, D.R.",
+              bibliographicCategory: "mono",
+              edition: null,
+              isbn: "9781844135417",
+              issn: null,
+              language: "eng",
+              mediumType: "a xx",
+              periodicalNumber: null,
+              periodicalVolume: null,
+              placeOfPublication: "London",
+              publicationDate: "2011",
+              publicationDateOfComponent: null,
+              publisher: "Pimlico",
+              recordId: "2449448",
+              title: "Supermac : the life of Harold Macmillan"
+            },
+            materialGroup: {
+              name: "fon2",
+              description: "Flere CD-plader"
+            }
+          }
+        }
+      ]
+    }).as("physical_loans");
+
+    cy.intercept("GET", "**/v1/user/**", {
+      statusCode: 200,
+      body: {
+        reservations: [],
+        code: 101,
+        message: "OK"
+      }
+    }).as("digital_loans");
+
+    // No works are found. This should make the reservation use data from the
+    // ilBibliographicRecord property.
+    cy.intercept("POST", "**/next*/**", {
+      statusCode: 200,
+      body: {
+        data: {}
+      }
+    }).as("work_not_found");
+
+    cy.visit("/iframe.html?path=/story/apps-loan-list--loan-list-entry");
+
+    cy.get(".list-reservation-container")
+      .find(".list-reservation")
+      .get(".list-reservation__header")
+      // The title should be the one returned by ilBibliographicRecord property
+      // on the reservation.
+      .should("contain", "Supermac : the life of Harold Macmillan")
+      // Open the modal to see the details.
+      .click();
+
+    cy.getBySel("modal")
+      // Modal should be open.
+      .should("exist")
+      .find(".modal-details__title")
+      // Details should also contain the ilBibliographicRecord title.
+      .should("contain", "Supermac : the life of Harold Macmillan");
+  });
+
   it("Empty digital loan list", () => {
     cy.intercept("GET", "**/v1/user/**", {
       statusCode: 200,

--- a/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
+++ b/src/apps/loan-list/materials/selectable-material/selectable-material.tsx
@@ -109,11 +109,13 @@ const SelectableMaterial: FC<SelectableMaterialProps & MaterialProps> = ({
           role="button"
           tabIndex={0}
         >
-          <div className="list-materials__content-status">
-            <div className="status-label status-label--outline ">
-              {materialType}
+          {materialType && (
+            <div className="list-materials__content-status">
+              <div className="status-label status-label--outline ">
+                {materialType}
+              </div>
             </div>
-          </div>
+          )}
           {statusBadgeComponentMobile || null}
           <p className="list-materials__content__header mt-8" lang={lang || ""}>
             {title}

--- a/src/apps/loan-list/materials/stackable-material/material-info.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-info.tsx
@@ -50,13 +50,16 @@ const MaterialInfo: FC<MaterialInfoProps> = ({
         />
       </div>
       <div className="list-reservation__information">
-        {materialType && (
-          <div>
-            <div className="status-label status-label--outline">
-              {materialType}
+        {/* Add a div for material types even if there are none to ensure element alignment */}
+        <div>
+          {materialType && (
+            <div>
+              <div className="status-label status-label--outline">
+                {materialType}
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
         <div className="list-reservation__about">
           <button
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
+++ b/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
@@ -67,7 +67,7 @@ const fetchMaterial =
         } else if (item.details) {
           setMaterial(item.details);
         }
-      }, [manifestation]);
+      }, [manifestation, item.details]);
 
       // if the fallback component is provided we can show it while the data is loading
       if (isLoadingAnything) {

--- a/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
+++ b/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
@@ -64,6 +64,8 @@ const fetchMaterial =
       useEffect(() => {
         if (manifestation) {
           setMaterial(mapManifestationToBasicDetailsType(manifestation));
+        } else if (item.details) {
+          setMaterial(item.details);
         }
       }, [manifestation]);
 
@@ -73,7 +75,7 @@ const fetchMaterial =
       }
 
       // in cases where the material is not found we return null, else we would load forever
-      if (!manifestation) return null;
+      if (!material) return null;
 
       return (
         <Component

--- a/src/core/utils/helpers/list-mapper.ts
+++ b/src/core/utils/helpers/list-mapper.ts
@@ -280,8 +280,7 @@ export const mapFBSReservationGroupToReservationType = (
               authorsShort: ilBibliographicRecord.author,
               firstAuthor: ilBibliographicRecord.author,
               year: ilBibliographicRecord.publicationDate,
-              lang: ilBibliographicRecord.language,
-              isbn: ilBibliographicRecord.isbn
+              lang: ilBibliographicRecord.language
             }
           : null
       };

--- a/src/core/utils/helpers/list-mapper.ts
+++ b/src/core/utils/helpers/list-mapper.ts
@@ -68,7 +68,17 @@ export const mapFBSLoanToLoanType = (list: LoanV2[]): LoanType[] => {
       loanType: loanDetails.loanType,
       identifier: null,
       faust: (loanDetails.recordId as FaustId) || null,
-      loanId: loanDetails.loanId
+      loanId: loanDetails.loanId,
+      details: loanDetails.ilBibliographicRecord
+        ? {
+            title: loanDetails.ilBibliographicRecord.title,
+            authors: loanDetails.ilBibliographicRecord.author,
+            authorsShort: loanDetails.ilBibliographicRecord.author,
+            firstAuthor: loanDetails.ilBibliographicRecord.author,
+            year: loanDetails.ilBibliographicRecord.publicationDate,
+            lang: loanDetails.ilBibliographicRecord.language
+          }
+        : null
     };
   });
 };
@@ -249,7 +259,8 @@ export const mapFBSReservationGroupToReservationType = (
       pickupDeadline,
       pickupNumber,
       periodical,
-      records
+      records,
+      ilBibliographicRecord
     }) => {
       return {
         periodical: periodical?.displayText || "",
@@ -261,7 +272,18 @@ export const mapFBSReservationGroupToReservationType = (
         pickupBranch,
         pickupDeadline,
         pickupNumber,
-        reservationIds: values(records)
+        reservationIds: values(records),
+        details: ilBibliographicRecord
+          ? {
+              title: ilBibliographicRecord.title,
+              authors: ilBibliographicRecord.author,
+              authorsShort: ilBibliographicRecord.author,
+              firstAuthor: ilBibliographicRecord.author,
+              year: ilBibliographicRecord.publicationDate,
+              lang: ilBibliographicRecord.language,
+              isbn: ilBibliographicRecord.isbn
+            }
+          : null
       };
     }
   );

--- a/src/core/utils/types/list-type.ts
+++ b/src/core/utils/types/list-type.ts
@@ -1,5 +1,6 @@
 import { FaustId, LoanId } from "./ids";
 import { Nullable } from "./nullable";
+import { BasicDetailsType } from "./basic-details-type";
 
 export type ListIdsType = {
   faust: FaustId;
@@ -8,7 +9,13 @@ export type ListIdsType = {
   loanId: LoanId | null;
 };
 
-export type ListType = Nullable<Partial<ListIdsType>>;
+export type ListType = Nullable<
+  Partial<
+    ListIdsType & {
+      details: BasicDetailsType;
+    }
+  >
+>;
 
 export function listId(listItem: ListType): string {
   if (listItem?.reservationIds && listItem.reservationIds.length > 0) {


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFLSBP-595

#### Description

This PR extends list types used for reservations and loans with the possibility of attaching basic details. This is used when returning data from FBS.

These basic details can then be used as fallback information for physical materials in case these cannot be retrieved from FBI in the material fetch higher-order component.

Without this then the material will not be rendered at all.

One known situation where this occurs is interlibrary loans from the Royal Danish Library.

Add a test showing that this works.
