### PR TITLE
Handle zero hits in `MaterialGrid`

### DIFF
--- a/src/apps/material-grid/MaterialGrid.tsx
+++ b/src/apps/material-grid/MaterialGrid.tsx
@@ -59,6 +59,12 @@ const MaterialGrid: React.FC<MaterialGridProps> = ({
     setShowAllMaterials(!showAllMaterials);
   }
 
+  if (!materials.length) {
+    // eslint-disable-next-line no-console
+    console.warn(`No materials to show for MaterialGrid: ${title}`);
+    return null;
+  }
+
   const titleClasses = clsx("material-grid__title", {
     "material-grid__title--no-description": !description
   });


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-835


#### Description

Introduced a guard check to ensure the `MaterialGrid` component is not rendered if there are no materials + logging the information to the console for debugging purposes.



#### Screenshots
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/44dd8c6d-284b-4e34-986c-09155843f03f">

#### Test
https://varnish.pr-1436.dpl-cms.dplplat01.dpl.reload.dk/test-material-grid-automatic-har-0-hits