### PR TITLE
Handle opening hours with `end_time` "00:00"

### DIFF
--- a/src/apps/opening-hours-editor/EventForm.tsx
+++ b/src/apps/opening-hours-editor/EventForm.tsx
@@ -52,7 +52,7 @@ const EventForm: React.FC<EventFormProps> = ({
   const [startTime, setStartTime] = useState(initialStartTime);
   const [endTime, setEndTime] = useState(initialEndTime);
   const [category, setCategory] = useState(initialCategory);
-  const isSameTime = startTime === endTime;
+  const isSameTime = startTime === endTime && startTime !== "00:00";
   const [isRepeated, setIsRepeated] = useState(false);
   const [repeatedEndDate, setRepeatedEndDate] = useState<null | string>(null);
 

--- a/src/apps/opening-hours-editor/helper.ts
+++ b/src/apps/opening-hours-editor/helper.ts
@@ -12,6 +12,10 @@ const formatDateTimeString = (date: string, time: string): string => {
   return `${date}T${time}:00`;
 };
 
+const convertMidnightTo24 = (end_time: string) => {
+  return end_time === "00:00" ? "24:00" : end_time;
+};
+
 export const formatCmsEventsToFullCalendar = (
   data: DplOpeningHoursListGET200Item[]
 ): EventInput[] => {
@@ -21,7 +25,7 @@ export const formatCmsEventsToFullCalendar = (
         id: id.toString(),
         title: category.title,
         start: formatDateTimeString(date, start_time),
-        end: formatDateTimeString(date, end_time),
+        end: formatDateTimeString(date, convertMidnightTo24(end_time)),
         color: category.color,
         repetition
       };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFFORM-818


#### Description

This pull request addresses the issue of handling opening hours where the `end_time` is "00:00". This change is in response to the modifications made in https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1249.