### PR TITLE
DDFHER-67 - Add checkbox for `receiveSms` when creating user

### DIFF
--- a/src/apps/create-patron-user-info/UserInfo.tsx
+++ b/src/apps/create-patron-user-info/UserInfo.tsx
@@ -47,6 +47,7 @@ const UserInfo: FC<UserInfoProps> = ({ cpr, registerSuccessCallback }) => {
     set(copyUser, key, newValue);
     setPatron(copyUser);
   };
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
@@ -80,7 +81,7 @@ const UserInfo: FC<UserInfoProps> = ({ cpr, registerSuccessCallback }) => {
           </h1>
           <form onSubmit={(e) => handleSubmit(e)} ref={formRef}>
             <ContactInfoSection
-              showCheckboxes={false}
+              showCheckboxes={["phone"]}
               isDouble
               inLine
               changePatron={changePatron}

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -107,7 +107,7 @@ const PatronPage: FC = () => {
             changePatron={changePatron}
             patron={patron}
             inLine={false}
-            showCheckboxes
+            showCheckboxes={["email", "phone"]}
           />
         )}
         {patron?.resident && <StatusSection />}

--- a/src/apps/patron-page/PatronPageSkeleton.tsx
+++ b/src/apps/patron-page/PatronPageSkeleton.tsx
@@ -17,7 +17,7 @@ const PatronPageSkeleton: React.FC = () => {
         changePatron={() => {}}
         patron={null}
         inLine={false}
-        showCheckboxes
+        showCheckboxes={["email", "phone"]}
       />
     </form>
   );

--- a/src/components/contact-info-section/ContactInfoSection.tsx
+++ b/src/components/contact-info-section/ContactInfoSection.tsx
@@ -12,7 +12,7 @@ interface ContactInfoSectionProps {
   inLine?: boolean;
   isDouble?: boolean;
   changePatron: ChangePatronProps;
-  showCheckboxes: boolean;
+  showCheckboxes: ("email" | "phone")[];
   requiredFields?: ("email" | "phone")[];
 }
 
@@ -43,7 +43,9 @@ const ContactInfoSection: FC<ContactInfoSectionProps> = ({
           changePatron={changePatron}
           patron={patron}
           isRequired={requiredFields.includes("phone")}
-          showCheckboxes={showCheckboxes && textNotificationsEnabledConfig}
+          showCheckboxes={
+            showCheckboxes.includes("phone") && textNotificationsEnabledConfig
+          }
         />
         <ContactInfoEmail
           className={clsx(inputsClass, {
@@ -52,7 +54,7 @@ const ContactInfoSection: FC<ContactInfoSectionProps> = ({
           changePatron={changePatron}
           patron={patron}
           isRequired={requiredFields.includes("email")}
-          showCheckboxes={showCheckboxes}
+          showCheckboxes={showCheckboxes.includes("email")}
         />
       </ContactInfoInputs>
     </section>


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFHER-67

#### Description

This pull request enables users to subscribe to SMS notifications (`receiveSms`) if the library allows SMS notifications (`text-notifications-enabled-config`) during the user creation process. If the user opts in, their phone number will be displayed as "mobile (notif)" in Cicero; otherwise, it will continue to appear under "fastnet."

#### Test

Create an adult user at Copenhagen Library via Frontpage | DPL CMS

During user creation, there is now a checkbox below the phone number.

If this is checked, the number in Cicero will be listed as “mobile (notif)”, otherwise it will be listed as “fastnet”.

https://varnish.pr-1570.dpl-cms.dplplat01.dpl.reload.dk/

![image](https://github.com/user-attachments/assets/5fcbaee1-1494-4a04-921f-ad98e46c4ee1)

![image](https://github.com/user-attachments/assets/33328911-0e5a-48a2-aa0a-e5227d86a59f)

