### PR TITLE
Ensure creatorsToString() always returns a string

### DIFF
--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import dayjs from "dayjs";
-import { uniq } from "lodash";
+import { first, uniq } from "lodash";
 import { vi } from "vitest";
 import { CoverProps } from "../../../components/cover/cover";
 import { UseTextFunction } from "../text";
@@ -67,13 +67,18 @@ const getCreatorsFromManifestations = (manifestations: Manifestation[]) => {
   return Array.from(new Set(creators)) as string[];
 };
 
-export const creatorsToString = (creators: string[], t: UseTextFunction) => {
+export const creatorsToString = (
+  creators: string[],
+  t: UseTextFunction
+): string => {
   if (creators.length > 1) {
     const firstTwo = creators.slice(0, 2);
     return `${firstTwo.join(", ")} ${t("etAlText")}`;
   }
-
-  return creators[0];
+  if (creators.length === 1) {
+    return first(creators) as string;
+  }
+  return "";
 };
 
 export const getCreatorTextFromManifestations = (


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFNEXT-519

#### Description

The current implementation will return undefined if the creators array is empty. This causes other functions which expect a string (which is what TypeScript assumes) to fail.

Add a return type to the function to assert the intention of the function. We could also have allowed it to return undefined if the creators array is empty but that seems to be against the naming of the function, creatorsToString.

Add a check to handle single array and empty creators array separately. If there are no creators then return an empty string.

#### Additional comments or questions

You can test this by checking the Periodical story for the Material app before and after the change.