### PR TITLE
DDFHER-90 - Refactor `getInstantLoanBranchHoldings` to use `materialGroup.name`

### DIFF
--- a/cypress/fixtures/material/instant-loan/holdings.json
+++ b/cypress/fixtures/material/instant-loan/holdings.json
@@ -24,7 +24,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -33,7 +33,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -59,7 +59,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -68,7 +68,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -77,7 +77,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -86,7 +86,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -95,7 +95,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -121,7 +121,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -130,7 +130,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -156,7 +156,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -165,7 +165,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -174,7 +174,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -183,7 +183,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -192,7 +192,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -201,7 +201,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -210,7 +210,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -236,7 +236,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -245,7 +245,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -254,7 +254,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -280,7 +280,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -289,7 +289,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -298,7 +298,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -307,7 +307,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -316,7 +316,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -325,7 +325,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -334,7 +334,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -343,7 +343,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -352,7 +352,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -361,7 +361,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -387,7 +387,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -396,7 +396,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -405,7 +405,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -414,7 +414,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -423,7 +423,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -432,7 +432,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -441,7 +441,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -450,7 +450,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -459,7 +459,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -468,7 +468,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -494,7 +494,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -503,7 +503,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -529,7 +529,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -538,7 +538,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -547,7 +547,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -573,7 +573,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -582,7 +582,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -608,7 +608,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -617,7 +617,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -626,7 +626,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -635,7 +635,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -644,7 +644,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -653,7 +653,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -662,7 +662,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -671,7 +671,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -680,7 +680,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -689,7 +689,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -698,7 +698,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -707,7 +707,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -716,7 +716,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -742,7 +742,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -751,7 +751,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -760,7 +760,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -769,7 +769,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -778,7 +778,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -787,7 +787,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -796,7 +796,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -822,7 +822,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -848,7 +848,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -857,7 +857,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -866,7 +866,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -875,7 +875,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -901,7 +901,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -910,7 +910,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -919,7 +919,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -945,7 +945,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -954,7 +954,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -980,7 +980,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -989,7 +989,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -998,7 +998,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1024,7 +1024,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1033,7 +1033,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1059,7 +1059,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1068,7 +1068,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1077,7 +1077,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1086,7 +1086,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1095,7 +1095,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1150,7 +1150,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1159,7 +1159,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1168,7 +1168,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1177,7 +1177,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1186,7 +1186,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1212,7 +1212,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1221,7 +1221,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1230,7 +1230,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1256,7 +1256,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1265,7 +1265,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1274,7 +1274,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1300,7 +1300,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1309,7 +1309,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1318,7 +1318,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1327,7 +1327,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1353,7 +1353,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1362,7 +1362,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1371,7 +1371,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1380,7 +1380,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1389,7 +1389,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1415,7 +1415,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1424,7 +1424,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1450,7 +1450,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1459,7 +1459,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1485,7 +1485,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1494,7 +1494,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1503,7 +1503,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1512,7 +1512,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1521,7 +1521,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1530,7 +1530,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1539,7 +1539,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1548,7 +1548,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1557,7 +1557,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1583,7 +1583,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1592,7 +1592,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1618,7 +1618,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1627,7 +1627,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1636,7 +1636,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1691,7 +1691,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1700,7 +1700,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1709,7 +1709,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1718,7 +1718,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1727,7 +1727,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1736,7 +1736,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1745,7 +1745,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1754,7 +1754,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1763,7 +1763,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1789,7 +1789,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1798,7 +1798,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "standard",
+              "name": "31 dages lånetid til alm lånere",
               "description": "31 dages lånetid til alm lånere"
             }
           }

--- a/cypress/fixtures/material/instant-loan/holdings.json
+++ b/cypress/fixtures/material/instant-loan/holdings.json
@@ -24,7 +24,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -33,7 +33,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -59,7 +59,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -68,7 +68,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -77,7 +77,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -86,7 +86,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -95,7 +95,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -121,7 +121,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -130,7 +130,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -156,7 +156,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -165,7 +165,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -174,7 +174,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -183,7 +183,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -192,7 +192,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -201,7 +201,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -210,7 +210,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -236,7 +236,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -245,7 +245,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -254,7 +254,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -280,7 +280,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -289,7 +289,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -298,7 +298,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -307,7 +307,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -316,7 +316,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -325,7 +325,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -334,7 +334,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -343,7 +343,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -352,7 +352,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -361,7 +361,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -387,7 +387,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -396,7 +396,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -405,7 +405,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -414,7 +414,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -423,7 +423,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -432,7 +432,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -441,7 +441,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -450,7 +450,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -459,7 +459,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -468,7 +468,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -494,7 +494,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -503,7 +503,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -529,7 +529,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -538,7 +538,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -547,7 +547,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -573,7 +573,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -582,7 +582,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -608,7 +608,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -617,7 +617,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -626,7 +626,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -635,7 +635,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -644,7 +644,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -653,7 +653,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -662,7 +662,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -671,7 +671,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -680,7 +680,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -689,7 +689,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -698,7 +698,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -707,7 +707,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -716,7 +716,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -742,7 +742,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -751,7 +751,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -760,7 +760,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -769,7 +769,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -778,7 +778,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -787,7 +787,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -796,7 +796,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -822,7 +822,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -848,7 +848,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -857,7 +857,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -866,7 +866,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -875,7 +875,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -901,7 +901,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -910,7 +910,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -919,7 +919,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -945,7 +945,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -954,7 +954,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -980,7 +980,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -989,7 +989,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -998,7 +998,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1024,7 +1024,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1033,7 +1033,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1059,7 +1059,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1068,7 +1068,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1077,7 +1077,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1086,7 +1086,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1095,7 +1095,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1150,7 +1150,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1159,7 +1159,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1168,7 +1168,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1177,7 +1177,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1186,7 +1186,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1212,7 +1212,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1221,7 +1221,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1230,7 +1230,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1256,7 +1256,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1265,7 +1265,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1274,7 +1274,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1300,7 +1300,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1309,7 +1309,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1318,7 +1318,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1327,7 +1327,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1353,7 +1353,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1362,7 +1362,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1371,7 +1371,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1380,7 +1380,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1389,7 +1389,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1415,7 +1415,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1424,7 +1424,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1450,7 +1450,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1459,7 +1459,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1485,7 +1485,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1494,7 +1494,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1503,7 +1503,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1512,7 +1512,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1521,7 +1521,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1530,7 +1530,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1539,7 +1539,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1548,7 +1548,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1557,7 +1557,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1583,7 +1583,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1592,7 +1592,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1618,7 +1618,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1627,7 +1627,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1636,7 +1636,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1691,7 +1691,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1700,7 +1700,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1709,7 +1709,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1718,7 +1718,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1727,7 +1727,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1736,7 +1736,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1745,7 +1745,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1754,7 +1754,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1763,7 +1763,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }
@@ -1789,7 +1789,7 @@
             "available": false,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           },
@@ -1798,7 +1798,7 @@
             "available": true,
             "periodical": null,
             "materialGroup": {
-              "name": "31 dages lånetid til alm lånere",
+              "name": "standard",
               "description": "31 dages lånetid til alm lånere"
             }
           }

--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -874,7 +874,7 @@ const meta: Meta<typeof MaterialEntry> = {
     instantLoanUnderlineDescriptionText:
       "Bogen er tilgængelig på disse biblioteker nær dig",
     instantLoanConfig:
-      '{ "threshold": "1", "matchStrings": ["31 dages lånetid til alm lånere"], "enabled": "true" }',
+      '{ "threshold": "1", "matchStrings": ["standard"], "enabled": "true" }',
     interestPeriodsConfig:
       '{ "interestPeriods":[ { "value":14, "label":"14 days" }, { "value":30, "label":"1 month" }, { "value":60, "label":"2 months" }, { "value":90, "label":"3 months" }, { "value":180, "label":"6 months" }, { "value":365, "label":"1 year" } ], "defaultInterestPeriod":{ "value":"14", "label":"14 days" } }',
     openOrderResponseTitleText: "Order from another library:",

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -237,12 +237,11 @@ export const getInstantLoanBranchHoldings = (
   const filteredMaterials = consolidatedHoldings(filteredBranchHoldings)
     .map(({ branch, materials }) => {
       const filtered = materials.filter(({ materialGroup, available }) => {
-        // if a material group description contains any of the instant loan strings
+        // if a material group name contains any of the instant loan strings
         // and is available, it is an instant loan.
         return (
           instantLoanStrings.some(
-            (instantLoanString) =>
-              instantLoanString === materialGroup.description
+            (instantLoanString) => instantLoanString === materialGroup.name
           ) && available
         );
       });

--- a/src/tests/unit/__vitest_data__/instant-loan.ts
+++ b/src/tests/unit/__vitest_data__/instant-loan.ts
@@ -12,8 +12,8 @@ const branchHoldings: HoldingsV3[] = [
         available: true,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am supposed to be matched"
+          name: "I am supposed to be matched",
+          description: undefined
         }
       },
       {
@@ -21,8 +21,8 @@ const branchHoldings: HoldingsV3[] = [
         available: false,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am supposed to be matched" // But am not available
+          name: "I am supposed to be matched", // But am not available
+          description: undefined
         }
       },
       {
@@ -30,8 +30,8 @@ const branchHoldings: HoldingsV3[] = [
         available: false,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am NOT supposed to be matched"
+          name: "I am NOT supposed to be matched",
+          description: "I am NOT supposed to be matched" // Description is optional and can be undefined
         }
       }
     ]
@@ -47,8 +47,8 @@ const branchHoldings: HoldingsV3[] = [
         available: true,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am supposed to be matched"
+          name: "I am supposed to be matched",
+          description: undefined
         }
       },
       {
@@ -56,8 +56,8 @@ const branchHoldings: HoldingsV3[] = [
         available: false,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am also supposed to be matched"
+          name: "I am also supposed to be matched",
+          description: undefined
         }
       },
       {
@@ -65,8 +65,8 @@ const branchHoldings: HoldingsV3[] = [
         available: false,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am NOT supposed to be matched"
+          name: "I am NOT supposed to be matched",
+          description: undefined
         }
       }
     ]
@@ -82,8 +82,8 @@ const branchHoldings: HoldingsV3[] = [
         available: true,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am supposed to be matched"
+          name: "I am supposed to be matched",
+          description: undefined
         }
       },
       {
@@ -91,8 +91,8 @@ const branchHoldings: HoldingsV3[] = [
         available: true,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am also supposed to be matched"
+          name: "I am also supposed to be matched",
+          description: "I am also supposed to be matched" // Description is optional and can be undefined
         }
       }
     ]
@@ -108,8 +108,8 @@ const branchHoldings: HoldingsV3[] = [
         available: false,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am NOT supposed to be matched"
+          name: "I am NOT supposed to be matched",
+          description: undefined
         }
       }
     ]
@@ -125,8 +125,8 @@ const branchHoldings: HoldingsV3[] = [
         available: true,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am supposed to be matched"
+          name: "I am supposed to be matched",
+          description: undefined
         }
       }
     ]
@@ -142,8 +142,8 @@ const branchHoldings: HoldingsV3[] = [
         available: true,
         periodical: undefined,
         materialGroup: {
-          name: "standard",
-          description: "I am supposed to be matched"
+          name: "I am supposed to be matched",
+          description: undefined
         }
       }
     ]

--- a/src/tests/unit/instant-loan.test.ts
+++ b/src/tests/unit/instant-loan.test.ts
@@ -27,7 +27,7 @@ test("getInstantLoanBranchHoldings should return materials grouped by branches f
   expect(result[0].branch.title).toBe("Åby");
   expect(result[0].materials).toHaveLength(2);
   expect(result[0].materials[0].available).toBe(true);
-  expect(result[0].materials[0].materialGroup.description).toBe(
+  expect(result[0].materials[0].materialGroup.name).toBe(
     "I am supposed to be matched"
   );
 
@@ -39,7 +39,7 @@ test("getInstantLoanBranchHoldings should return materials grouped by branches f
   expect(result[1].branch.title).toBe("Sabro");
   expect(result[1].materials).toHaveLength(1);
   expect(result[1].materials[0].available).toBe(true);
-  expect(result[1].materials[0].materialGroup.description).toBe(
+  expect(result[1].materials[0].materialGroup.name).toBe(
     "I am supposed to be matched"
   );
 
@@ -50,11 +50,11 @@ test("getInstantLoanBranchHoldings should return materials grouped by branches f
   expect(result[2].branch.title).toBe("Hasle");
   expect(result[2].materials).toHaveLength(2);
   expect(result[2].materials[0].available).toBe(true);
-  expect(result[2].materials[0].materialGroup.description).toBe(
+  expect(result[2].materials[0].materialGroup.name).toBe(
     "I am supposed to be matched"
   );
   expect(result[2].materials[1].available).toBe(true);
-  expect(result[2].materials[1].materialGroup.description).toBe(
+  expect(result[2].materials[1].materialGroup.name).toBe(
     "I am also supposed to be matched"
   );
 });


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-90

#### Description

This pull request refactors the `getInstantLoanBranchHoldings` method to use `materialGroup.name` instead of `.description`. This change addresses the issue where `.description` is an optional field, potentially leading to inconsistencies or missing data during the execution of this method.


#### Test 
https://varnish.pr-1608.dpl-cms.dplplat01.dpl.reload.dk/

![image](https://github.com/user-attachments/assets/3cc2b192-03b1-48c4-be08-d365252f23dd)
