### PR TITLE
DDFHER-89 - Ensure consistent sorting for loans

### DIFF
--- a/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
+++ b/src/apps/dashboard/dashboard-notification-list/dashboard-notification-list.tsx
@@ -49,17 +49,12 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
     }
   } = useReservations();
   const {
-    all: { loans, isLoading: isLoadingLoans },
+    all: { loans, soonOverdue, farFromOverdue, isLoading: isLoadingLoans },
     fbs: {
       overdue: loansOverduePhysical,
       soonOverdue: loansSoonOverduePhysical,
       farFromOverdue: loansFarFromOverduePhysical,
       isLoading: isLoadingLoansPhysical
-    },
-    publizon: {
-      soonOverdue: loansSoonOverdueDigital,
-      farFromOverdue: loansFarFromOverdueDigital,
-      isLoading: isLoadingLoansDigital
     }
   } = useLoans();
 
@@ -125,16 +120,12 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           break;
 
         case soon:
-          setLoansToDisplay(
-            loansSoonOverduePhysical.concat(loansSoonOverdueDigital)
-          );
+          setLoansToDisplay(soonOverdue);
           setModalHeader(t("loansSoonOverdueText"));
           break;
 
         case longer:
-          setLoansToDisplay(
-            loansFarFromOverduePhysical.concat(loansFarFromOverdueDigital)
-          );
+          setLoansToDisplay(farFromOverdue);
           setModalHeader(t("loansNotOverdueText"));
           break;
 
@@ -143,16 +134,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
       }
       open(constructModalId(dueDateModal as string, [dueDateInput]));
     },
-    [
-      dueDateModal,
-      open,
-      loansFarFromOverduePhysical,
-      loansOverduePhysical,
-      loansSoonOverduePhysical,
-      loansSoonOverdueDigital,
-      loansFarFromOverdueDigital,
-      t
-    ]
+    [open, dueDateModal, loansOverduePhysical, t, soonOverdue, farFromOverdue]
   );
 
   const dashboardNotificationsLoan = [
@@ -169,8 +151,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           : openDueDateModal(yesterday)
     },
     {
-      listLength:
-        loansSoonOverduePhysical.length + loansSoonOverdueDigital.length,
+      listLength: soonOverdue.length,
       badge: t("statusBadgeWarningText"),
       header: t("loansSoonOverdueText"),
       color: "warning",
@@ -182,8 +163,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
           : openDueDateModal(soon)
     },
     {
-      listLength:
-        loansFarFromOverduePhysical.length + loansFarFromOverdueDigital.length,
+      listLength: farFromOverdue.length,
       header: t("loansNotOverdueText"),
       dataCy: "loans-not-overdue",
       color: "neutral",
@@ -231,11 +211,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
               materialsCount={loans.length}
               header={t("physicalLoansText")}
               emptyListText={t("noPhysicalLoansText")}
-              isLoading={
-                isLoadingLoans ||
-                isLoadingLoansPhysical ||
-                isLoadingLoansDigital
-              }
+              isLoading={isLoadingLoans || isLoadingLoansPhysical}
               linkText={t("dashboardLoansLinkText")}
               linkUrl={physicalLoansUrl}
             />
@@ -259,10 +235,7 @@ const DashboardNotificationList: FC<DashboardNotificationListProps> = ({
             ...dashboardNotificationsReservations
           ]}
           isLoading={
-            isLoadingLoans ||
-            isLoadingLoansPhysical ||
-            isLoadingLoansDigital ||
-            isLoadingReservations
+            isLoadingLoans || isLoadingLoansPhysical || isLoadingReservations
           }
         />
       )}

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -3,7 +3,8 @@ import { useSelector } from "react-redux";
 import dayjs from "dayjs";
 import {
   getAmountOfRenewableLoans,
-  getScrollClass
+  getScrollClass,
+  sortByDueDate
 } from "../../../core/utils/helpers/general";
 import { getUrlQueryParam } from "../../../core/utils/helpers/url";
 import { useText } from "../../../core/utils/text";
@@ -55,12 +56,14 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const [modalLoan, setModalLoan] = useState<LoanType | null>(null);
   const {
     fbs: {
-      loans: loansPhysical,
+      loans: fbsLoans,
       stackedMaterialsDueDates: stackedMaterialsDueDatesFbs,
       isLoading: isLoadingFbs
     },
-    publizon: { loans: loansDigital, isLoading: isLoadingPublizon }
+    publizon: { loans: publizonLoans, isLoading: isLoadingPublizon }
   } = useLoans();
+  const loansPhysical = sortByDueDate(fbsLoans);
+  const loansDigital = sortByDueDate(publizonLoans);
   const openLoanDetailsModal = useCallback(
     (loan: LoanType) => {
       setModalLoan(loan);

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import dayjs from "dayjs";
 import {
   getAmountOfRenewableLoans,
+  getDueDatesLoan,
   getScrollClass,
   sortByDueDate
 } from "../../../core/utils/helpers/general";
@@ -55,15 +56,12 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
   const [dueDate, setDueDate] = useState<string | null>(null);
   const [modalLoan, setModalLoan] = useState<LoanType | null>(null);
   const {
-    fbs: {
-      loans: fbsLoans,
-      stackedMaterialsDueDates: stackedMaterialsDueDatesFbs,
-      isLoading: isLoadingFbs
-    },
+    fbs: { loans: fbsLoans, isLoading: isLoadingFbs },
     publizon: { loans: publizonLoans, isLoading: isLoadingPublizon }
   } = useLoans();
   const loansPhysical = sortByDueDate(fbsLoans);
   const loansDigital = sortByDueDate(publizonLoans);
+  const stackedMaterialsDueDatesFbs = getDueDatesLoan(loansPhysical);
   const openLoanDetailsModal = useCallback(
     (loan: LoanType) => {
       setModalLoan(loan);

--- a/src/components/GroupModal/GroupModalLoansList.tsx
+++ b/src/components/GroupModal/GroupModalLoansList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { FC, useState, useEffect, useMemo } from "react";
 import SelectableMaterial from "../../apps/loan-list/materials/selectable-material/selectable-material";
 import { useText } from "../../core/utils/text";
 import { isLoanType, LoanType } from "../../core/utils/types/loan-type";
@@ -8,6 +8,7 @@ import StatusBadge from "../../apps/loan-list/materials/utils/status-badge";
 import { formatDate } from "../../core/utils/helpers/date";
 import { ListType } from "../../core/utils/types/list-type";
 import { getLoanDeliveryDate } from "../../apps/loan-list/utils/helpers";
+import { sortLoansByIsRenewableThenDueDate } from "../../core/utils/helpers/general";
 
 export interface GroupModalLoansListProps {
   materials: LoanType[];
@@ -24,9 +25,11 @@ const GroupModalLoansList: FC<GroupModalLoansListProps> = ({
   selectMaterials,
   pageSize
 }) => {
-  // Show renewable materials first, then non-renewable
-  const groupedMaterials = materials.sort(
-    (a, b) => Number(!!b.isRenewable) - Number(!!a.isRenewable)
+  // Memoize groupedMaterials to prevent unnecessary re-computations
+  // Because groupedMaterials is a dependency of the useEffect hook
+  const groupedMaterials = useMemo(
+    () => sortLoansByIsRenewableThenDueDate(materials),
+    [materials]
   );
   const t = useText();
   const [displayedMaterials, setDisplayedMaterials] = useState<LoanType[]>([]);

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -227,19 +227,13 @@ export const sortByDueDate = (list: LoanType[]) => {
   );
 };
 
+export const sortByRenewable = (list: LoanType[]) => {
+  return orderBy(list, (item) => Number(!!item.isRenewable), "desc");
+};
+
 export const sortLoansByIsRenewableThenDueDate = (list: LoanType[]) => {
-  //  We use orderBy from lodash to avoid mutating the original list
-  return orderBy(
-    list,
-    [
-      // First criterion: isRenewable (Use "desc" to put renewable items first)
-      (item) => Number(!!item.isRenewable),
-      // Second criterion: dueDate (earlier dates first)
-      (item) =>
-        item.dueDate ? dayjs(item.dueDate).startOf("day").valueOf() : Infinity
-    ],
-    ["desc", "asc"]
-  );
+  const sortedByDueDate = sortByDueDate(list);
+  return sortByRenewable(sortedByDueDate);
 };
 
 export const getDueDatesLoan = (list: LoanType[]) => {

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -240,7 +240,7 @@ export const getDueDatesLoan = (list: LoanType[]) => {
   return Array.from(
     new Set(
       list
-        .filter(({ dueDate }) => dueDate !== (undefined || null))
+        .filter(({ dueDate }) => dueDate !== undefined && dueDate !== null)
         .map(({ dueDate }) => dueDate)
         .sort()
     )

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import dayjs from "dayjs";
-import { first, uniq } from "lodash";
+import { first, orderBy, uniq } from "lodash";
 import { vi } from "vitest";
 import { CoverProps } from "../../../components/cover/cover";
 import { UseTextFunction } from "../text";
@@ -214,6 +214,31 @@ export const sortByReservationDate = (list: ReservationType[]) => {
     (objA, objB) =>
       new Date(objA.dateOfReservation || new Date()).getTime() -
       new Date(objB.dateOfReservation || new Date()).getTime()
+  );
+};
+
+export const sortByDueDate = (list: LoanType[]) => {
+  //  We use orderBy from lodash to avoid mutating the original list
+  return orderBy(
+    list,
+    (item) =>
+      item.dueDate ? dayjs(item.dueDate).startOf("day").valueOf() : Infinity,
+    "asc"
+  );
+};
+
+export const sortLoansByIsRenewableThenDueDate = (list: LoanType[]) => {
+  //  We use orderBy from lodash to avoid mutating the original list
+  return orderBy(
+    list,
+    [
+      // First criterion: isRenewable (Use "desc" to put renewable items first)
+      (item) => Number(!!item.isRenewable),
+      // Second criterion: dueDate (earlier dates first)
+      (item) =>
+        item.dueDate ? dayjs(item.dueDate).startOf("day").valueOf() : Infinity
+    ],
+    ["desc", "asc"]
   );
 };
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -242,6 +242,17 @@ export const sortLoansByIsRenewableThenDueDate = (list: LoanType[]) => {
   );
 };
 
+export const getDueDatesLoan = (list: LoanType[]) => {
+  return Array.from(
+    new Set(
+      list
+        .filter(({ dueDate }) => dueDate !== (undefined || null))
+        .map(({ dueDate }) => dueDate)
+        .sort()
+    )
+  ) as string[];
+};
+
 export const getDueDatesForModal = (list: LoanType[], date: string) => {
   return list.filter(({ dueDate }) => dueDate === date);
 };

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -221,8 +221,7 @@ export const sortByDueDate = (list: LoanType[]) => {
   //  We use orderBy from lodash to avoid mutating the original list
   return orderBy(
     list,
-    (item) =>
-      item.dueDate ? dayjs(item.dueDate).startOf("day").valueOf() : Infinity,
+    (item) => (item.dueDate ? dayjs(item.dueDate).valueOf() : Infinity),
     "asc"
   );
 };

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { useGetLoansV2 } from "../fbs/fbs";
 import { useGetV1UserLoans } from "../publizon/publizon";
 import { daysBetweenTodayAndDate, materialIsOverdue } from "./helpers/general";
@@ -48,11 +49,11 @@ const getDueDatesLoan = (list: LoanType[]) => {
 const sortByDueDate = (list: LoanType[]) => {
   // Todo figure out what to do if loan does not have loan date
   // For now, its at the bottom of the list
-  return list.sort(
-    (a, b) =>
-      new Date(a.dueDate || new Date()).getTime() -
-      new Date(b.dueDate || new Date()).getTime()
-  );
+  return list.sort((a, b) => {
+    const dateA = a.dueDate ? dayjs(a.dueDate).valueOf() : Infinity;
+    const dateB = b.dueDate ? dayjs(b.dueDate).valueOf() : Infinity;
+    return dateA - dateB;
+  });
 };
 
 type Loans = {

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -33,17 +33,6 @@ const filterLoansSoonOverdue = (loans: LoanType[], warning: number) => {
     );
   });
 };
-//
-const getDueDatesLoan = (list: LoanType[]) => {
-  return Array.from(
-    new Set(
-      list
-        .filter(({ dueDate }) => dueDate !== (undefined || null))
-        .map(({ dueDate }) => dueDate)
-        .sort()
-    )
-  ) as string[];
-};
 
 type Loans = {
   loans: LoanType[];
@@ -52,7 +41,6 @@ type Loans = {
   farFromOverdue: LoanType[];
   isLoading: boolean;
   isError: boolean;
-  stackedMaterialsDueDates?: string[];
 };
 
 type UseLoansType = {
@@ -129,9 +117,6 @@ const useLoans: UseLoans = () => {
     ...loansFarFromOverduePublizon
   ];
 
-  // This logic should be moved to a separate function useloans shuld only return the data
-  // list of all due dates used for the stacked materials
-  const stackedMaterialsDueDatesFbs = getDueDatesLoan(mappedLoansFbs);
   return {
     all: {
       loans,
@@ -146,7 +131,6 @@ const useLoans: UseLoans = () => {
       overdue: loansOverdueFBS,
       soonOverdue: loansSoonOverdueFBS,
       farFromOverdue: loansFarFromOverdueFBS,
-      stackedMaterialsDueDates: stackedMaterialsDueDatesFbs,
       isLoading: isLoadingFbs,
       isError: isErrorFbs
     },


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-89

#### Description

<s>This pull request updates the `sortByDueDate` function to handle cases where the loan does not have a due date and now using `dayjs` for date manipulation instead of the native Date object. Previously, the code used the current date as a fallback, causing inconsistent sorting results. The new logic assigns 'Infinity' to loans without a due date, ensuring they always appear at the bottom of the list.</s>

The issue was that not all loans were being sorted correctly. As a solution, we decided to move the sorting logic out of `useLoans`, since different parts of the app have varying sorting requirements. 

Additionally, we identified an issue with JavaScript's `.sort()` mutating the original array. Therefore, we opted to use `groupBy` from Lodash, which creates a new array.