### PR TITLE
DDFHER-77 - Allow age to be equal to the configured minimum age in `patronAgeValid`

### DIFF
--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -409,7 +409,7 @@ export const patronAgeValid = (cpr: string, minAge: number) => {
   if (cprDate === null) return false;
 
   const age = dayjs().diff(dayjs(cprDate), "year");
-  return age > minAge;
+  return age >= minAge;
 };
 
 // Create a string of authors with commas and a conjunction


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFHER-77

#### Description
The issue was that users whose age exactly matched the configured minimum age were being rejected during validation. The logic previously checked if the user's age was strictly greater than the minimum age, which caused this issue.

This pull request updates the age validation to ensure that the calculated age is greater than or equal to the configured minimum age. This resolves the problem by allowing users who are exactly the minimum age to pass validation.

#### Test
https://varnish.pr-1639.dpl-cms.dplplat01.dpl.reload.dk/