### PR TITLE
Ddfbra 47 flere samtidige reserveringer

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -65,6 +65,7 @@ import configuration, { getConf } from "../../core/configuration";
 import useReservableFromAnotherLibrary from "../../core/utils/useReservableFromAnotherLibrary";
 import { usePatronData } from "../../core/utils/helpers/usePatronData";
 import { Periods } from "./types";
+import { RequestStatus } from "../../core/utils/types/request";
 
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];
@@ -331,6 +332,7 @@ export const ReservationModalBody = ({
                       : selectedInterest
                   }
                   setSelectedInterest={setSelectedInterest}
+                  reservationStatus={reservationStatus}
                 />
               )}
 

--- a/src/components/reservation/UserListItems.tsx
+++ b/src/components/reservation/UserListItems.tsx
@@ -23,6 +23,7 @@ import {
 import PickupModal from "./forms/PickupModal";
 import NoInterestAfterModal from "./forms/NoInterestAfterModal";
 import { Periods } from "./types";
+import { RequestStatus } from "../../core/utils/types/request";
 
 export interface UserListItemsProps {
   patron: PatronV5;
@@ -32,6 +33,7 @@ export interface UserListItemsProps {
   selectedInterest: number | null;
   setSelectedInterest: (value: number) => void;
   whitelistBranches: AgencyBranch[];
+  reservationStatus: RequestStatus;
 }
 
 const UserListItems: FC<UserListItemsProps> = ({
@@ -42,7 +44,8 @@ const UserListItems: FC<UserListItemsProps> = ({
   selectBranchHandler,
   selectedInterest,
   setSelectedInterest,
-  whitelistBranches
+  whitelistBranches,
+  reservationStatus
 }) => {
   const t = useText();
   const config = useConfig();
@@ -83,6 +86,7 @@ const UserListItems: FC<UserListItemsProps> = ({
               selectedInterest ?? interestPeriods.defaultInterestPeriod.value
             }
             setSelectedInterest={setSelectedInterest}
+            reservationStatus={reservationStatus}
           />
         </>
       )}
@@ -99,6 +103,7 @@ const UserListItems: FC<UserListItemsProps> = ({
             branches={whitelistBranches}
             defaultBranch={selectedBranch ?? preferredPickupBranch}
             selectBranchHandler={selectBranchHandler}
+            reservationStatus={reservationStatus}
           />
         </>
       )}

--- a/src/components/reservation/forms/ModalReservationFormSelect.tsx
+++ b/src/components/reservation/forms/ModalReservationFormSelect.tsx
@@ -31,7 +31,7 @@ export interface ModalReservationFormSelectProps<
   saveCallback?: <TSaveValue extends FormSelectValue>(
     value: TSaveValue
   ) => void;
-  reservationStatus?: RequestStatus;
+  reservationStatus: RequestStatus;
   setReservationStatus?: (status: RequestStatus) => void;
 }
 
@@ -129,6 +129,7 @@ const ModalReservationFormSelect = <TValue extends FormSelectValue>({
           title={header.title}
           description={header.description}
           onSubmit={onSubmit}
+          disabledButton={reservationStatus === "pending"}
           buttonLabel={
             reservationStatus === "pending" ? t("loadingText") : undefined
           }

--- a/src/components/reservation/forms/NoInterestAfterModal.tsx
+++ b/src/components/reservation/forms/NoInterestAfterModal.tsx
@@ -10,7 +10,7 @@ interface NoInterestAfterModalProps {
   selectedInterest: number;
   setSelectedInterest: (value: number) => void;
   saveCallback?: <TValue extends FormSelectValue>(value: TValue) => void;
-  reservationStatus?: RequestStatus;
+  reservationStatus: RequestStatus;
   setReservationStatus?: (status: RequestStatus) => void;
 }
 

--- a/src/components/reservation/forms/PickupModal.tsx
+++ b/src/components/reservation/forms/PickupModal.tsx
@@ -10,7 +10,7 @@ export interface PickupModalProps {
   defaultBranch: string;
   selectBranchHandler: (value: string) => void;
   saveCallback?: <TValue extends FormSelectValue>(value: TValue) => void;
-  reservationStatus?: RequestStatus;
+  reservationStatus: RequestStatus;
   setReservationStatus?: (status: RequestStatus) => void;
 }
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-47

#### Description
This PR disables the "approve reservation" button if the user already clicked it. This prevents multiple requests from being fired before resolving. 
I also took the liberty to (for consistency's sake) unite the way we work with request state in regards to reservation - between the reservation modal and edit reservation modal in the user profile (reservations list page).

#### Screenshot of the result
-

#### Additional comments or questions
-