### PR TITLE
Ddfbra 100 filtrering sker ikke

### DIFF
--- a/src/apps/search-header/search-header.tsx
+++ b/src/apps/search-header/search-header.tsx
@@ -28,6 +28,7 @@ import {
 import { useStatistics } from "../../core/statistics/useStatistics";
 import { statistics } from "../../core/statistics/statistics";
 import HeaderDropdown from "../../components/header-dropdown/HeaderDropdown";
+import useFilterHandler from "../search-result/useFilterHandler";
 
 const SearchHeader: React.FC = () => {
   const t = useText();
@@ -46,7 +47,7 @@ const SearchHeader: React.FC = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [currentlySelectedItem, setCurrentlySelectedItem] = useState<any>("");
   const [isAutosuggestOpen, setIsAutosuggestOpen] = useState<boolean>(false);
-
+  const { clearFilter } = useFilterHandler();
   const {
     data,
     isLoading,
@@ -221,6 +222,8 @@ const SearchHeader: React.FC = () => {
         name: statistics.autosuggestClick.name,
         trackedData: selectedItem.work.titles.main.join(", ")
       }).then(() => {
+        // Before redirecting we need to clean persisted filters from previous search.
+        clearFilter();
         redirectTo(
           constructMaterialUrl(materialUrl, selectedItem.work?.workId as WorkId)
         );
@@ -245,7 +248,8 @@ const SearchHeader: React.FC = () => {
       }).then(() => {
         const { term, facet } =
           getAutosuggestCategoryList(t)[highlightedCategoryIndex];
-
+        // Before redirecting we need to clean persisted filters from previous search.
+        clearFilter();
         redirectTo(
           constructSearchUrlWithFilter({
             searchUrl,
@@ -262,6 +266,8 @@ const SearchHeader: React.FC = () => {
       name: statistics.autosuggestClick.name,
       trackedData: determineSuggestionTerm(selectedItem)
     }).then(() => {
+      // Before redirecting we need to clean persisted filters from previous search.
+      clearFilter();
       redirectTo(
         constructSearchUrl(searchUrl, determineSuggestionTerm(selectedItem))
       );

--- a/src/apps/search-result/helper.ts
+++ b/src/apps/search-result/helper.ts
@@ -5,6 +5,17 @@ import { Manifestation } from "../../core/utils/types/entities";
 import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import { FacetFieldEnum } from "../../core/dbc-gateway/generated/graphql";
 
+export const mapFacetToFilter = (facet: FacetFieldEnum) => {
+  switch (facet) {
+    case FacetFieldEnum.Materialtypesspecific:
+      return "materialTypesSpecific";
+    case FacetFieldEnum.Worktypes:
+      return "workTypes";
+    default:
+      return "invalid";
+  }
+};
+
 export const getFirstMaterialTypeFromFilters = (
   filters: Filter,
   manifestations: Manifestation[]

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useDeepCompareEffect } from "react-use";
+import { useDeepCompareEffect, useEffectOnce } from "react-use";
 import SearchResultHeader from "../../components/search-bar/search-result-header/SearchResultHeader";
 import usePager from "../../components/result-pager/use-pager";
 import SearchResultList from "../../components/card-item-list/SearchResultList";
@@ -88,13 +88,13 @@ const SearchResult: React.FC<SearchResultProps> = ({ q, pageSize }) => {
     }
   }, [campaignFacets, mutate]);
 
-  // Check for material type filters in url on pageload
+  // Check for material type filters in url on page load
   // This is an initial, intentionally simple approach supporting what is required by the search header.
   // It could be reworked to support all filters and terms at a later point.
-  useEffect(() => {
+  useEffectOnce(() => {
     addFilterFromUrlParamListener(FacetFieldEnum.Materialtypesspecific);
     addFilterFromUrlParamListener(FacetFieldEnum.Worktypes);
-  }, [addFilterFromUrlParamListener]);
+  });
 
   const { data, isLoading } = useSearchWithPaginationQuery(
     {

--- a/src/apps/search-result/useFilterHandler.tsx
+++ b/src/apps/search-result/useFilterHandler.tsx
@@ -14,6 +14,7 @@ import {
   setQueryParametersInUrl
 } from "../../core/utils/helpers/url";
 import { FacetFieldEnum } from "../../core/dbc-gateway/generated/graphql";
+import { mapFacetToFilter } from "./helper";
 
 const useFilterHandler = () => {
   const dispatch = useDispatch();
@@ -43,11 +44,11 @@ const useFilterHandler = () => {
   );
 
   const addFilterFromUrlParamListener = (facet: FacetFieldEnum) => {
-    const urlFilter = getUrlQueryParam(facet);
+    const urlFilter = getUrlQueryParam(mapFacetToFilter(facet));
     if (urlFilter) {
       // We only use term from the url, therefore key is not important here.
       addToFilter({
-        facet,
+        facet: mapFacetToFilter(facet),
         term: { key: "key", term: urlFilter }
       });
     }

--- a/src/core/storybook/serviceUrlArgs.ts
+++ b/src/core/storybook/serviceUrlArgs.ts
@@ -91,7 +91,7 @@ export default {
   [serviceUrlKeys.dplCms]: process.env.CMS_BASEURL ?? "https://dpl-cms.docker",
   [serviceUrlKeys.cover]: "https://cover.dandigbib.org",
   [serviceUrlKeys.materialList]: "https://prod.materiallist.dandigbib.org",
-  [serviceUrlKeys.fbi]: "https://fbi-api.dbc.dk/next-present/graphql",
-  [serviceUrlKeys.fbiLocal]: "https://fbi-api.dbc.dk/next/graphql",
-  [serviceUrlKeys.fbiGlobal]: "https://fbi-api.dbc.dk/next-present/graphql"
+  [serviceUrlKeys.fbi]: "https://temp.fbi-api.dbc.dk/next-present/graphql",
+  [serviceUrlKeys.fbiLocal]: "https://temp.fbi-api.dbc.dk/next/graphql",
+  [serviceUrlKeys.fbiGlobal]: "https://temp.fbi-api.dbc.dk/next-present/graphql"
 };


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-100

#### Description
This PR fixes an issue for PR #790 - where category search didn't work. This was happening due to the FBI API spec change, where all the facets are now gathered inside the `FacetFieldEnum` which is CAPITALIZED, but the simple search query filters cannot be. So we now have a way to map between them. 

In the last commit ( f540ae59 ) I also took the liberty to fix an issue where persisted filters keep stacking up between searches. If you search for Harry `in books` and then follow up with Adam `in e-books` you would end up with a search for Adam `in books and ebooks`. So now whenever the user searches we reset persisted filters before redirecting to the search page.

#### Screenshot of the result
-

#### Additional comments or questions
-
