### PR TITLE
DDFNEXT-661 - Fix "shelfmark" in `FindOnShelfManifestationListItem`

### DIFF
--- a/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
+++ b/src/components/find-on-shelf/FindOnShelfManifestationListItem.tsx
@@ -42,7 +42,7 @@ const FindOnShelfManifestationListItem: FC<
       </span>
       <span role="cell">
         {locationArrayWithShelfmark.length
-          ? getFindOnShelfLocationText(locationArray, author)
+          ? getFindOnShelfLocationText(locationArrayWithShelfmark, author)
           : t("findOnShelfModalNoLocationSpecifiedText")}
       </span>
       <span className="find-on-shelf__item-count-text" role="cell">


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFNEXT-661

#### Description

This resolves a minor oversight in [DDFHER-83](https://reload.atlassian.net/browse/DDFHER-83), where I mistakenly forgot to include `locationArrayWithShelfmark`.

### Test
https://varnish.pr-1833.dpl-cms.dplplat01.dpl.reload.dk/work/work-of:870970-basis:46867394?type=bog&modal=find-on-shelf-modal-46867394 



[DDFHER-83]: https://reload.atlassian.net/browse/DDFHER-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ