### PR TITLE
Add a Dependabot group for React dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,12 @@ updates:
           - "@graphql-typed-document-node/core"
           - "replace-in-file"
           - "typescript-graphql-typed-files-modules"
+      react:
+        patterns:
+          - "react"
+          - "@types/react"
+          - "react-dom"
+          - "@types/react-dom"
       redux:
         patterns:
           - "@reduxjs/toolkit"


### PR DESCRIPTION
#### Description

We want to ensure that React and React DOM is updated in parallel.

This is especially relevant for React 19.
