### PR TITLE
Bump eslint-plugin-cypress to version 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-loader": "^4.0.2",
-    "eslint-plugin-cypress": "^2.12.1",
+    "eslint-plugin-cypress": "^4.1.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-no-only-tests": "^3.3.0",

--- a/src/apps/advanced-search/advanced-search.test.ts
+++ b/src/apps/advanced-search/advanced-search.test.ts
@@ -12,16 +12,20 @@ describe("Search Result", () => {
   });
 
   it("Should translate typed in query-index into valid CQL", () => {
-    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
-    cy.getBySel("advanced-search-header-row").eq(1).click().type("Prince");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
+    cy.getBySel("advanced-search-header-row").eq(1).click();
+    cy.getBySel("advanced-search-header-row").eq(1).type("Prince");
     cy.getBySel("preview-section")
       .first()
       .should("contain", "'Harry' AND 'Prince'");
   });
 
   it("Should reflect operator changes in the translated CQL", () => {
-    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
-    cy.getBySel("advanced-search-header-row").eq(1).click().type("Prince");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
+    cy.getBySel("advanced-search-header-row").eq(1).click();
+    cy.getBySel("advanced-search-header-row").eq(1).type("Prince");
     cy.getBySel("advanced-search-header-row")
       .eq(1)
       .getBySel("clauses")
@@ -33,11 +37,13 @@ describe("Search Result", () => {
   });
 
   it("Should translate filters into CQL", () => {
-    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
-    cy.getBySel("advanced-search-header-row").eq(1).click().type("Prince");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
+    cy.getBySel("advanced-search-header-row").eq(1).click();
+    cy.getBySel("advanced-search-header-row").eq(1).type("Prince");
+    cy.getBySel("advanced-search-material-types").first().click();
     cy.getBySel("advanced-search-material-types")
       .first()
-      .click()
       .find("li")
       .eq(1)
       .should("contain", "Book")
@@ -47,9 +53,9 @@ describe("Search Result", () => {
       "contain",
       "'Harry' AND 'Prince' AND term.generalmaterialtype='bøger'"
     );
+    cy.getBySel("advanced-search-accessibility").first().click();
     cy.getBySel("advanced-search-accessibility")
       .first()
-      .click()
       .find("li")
       .eq(2)
       .should("contain", "Online")
@@ -63,38 +69,36 @@ describe("Search Result", () => {
 
   it("Should reset the form upon reset button click", () => {
     // Setup the search query.
-    cy.getBySel("advanced-search-header-row").eq(0).click().type("Harry");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
+    cy.getBySel("advanced-search-header-row").eq(1).click();
     cy.getBySel("advanced-search-header-row")
       .eq(1)
-      .click()
       .within(() => {
         cy.get("input").type("Rowling");
         cy.get("select").select(1);
       });
     cy.getBySel("advanced-search-add-row").click();
+    cy.getBySel("advanced-search-header-row").eq(2).click();
     cy.getBySel("advanced-search-header-row")
       .eq(2)
-      .click()
       .within(() => {
         cy.get("input").type("Magi");
         cy.get("select").select(2);
       });
-    cy.getBySel("advanced-search-material-types")
-      .click()
-      .within(() => {
-        cy.get("[role=option]").eq(1).click();
-        cy.get("[role=option]").eq(2).click();
-      });
-    cy.getBySel("advanced-search-fiction")
-      .click()
-      .within(() => {
-        cy.get("[role=option]").eq(1).click();
-      });
-    cy.getBySel("advanced-search-accessibility")
-      .click()
-      .within(() => {
-        cy.get("[role=option]").eq(1).click();
-      });
+    cy.getBySel("advanced-search-material-types").click();
+    cy.getBySel("advanced-search-material-types").within(() => {
+      cy.get("[role=option]").eq(1).click();
+      cy.get("[role=option]").eq(2).click();
+    });
+    cy.getBySel("advanced-search-fiction").click();
+    cy.getBySel("advanced-search-fiction").within(() => {
+      cy.get("[role=option]").eq(1).click();
+    });
+    cy.getBySel("advanced-search-accessibility").click();
+    cy.getBySel("advanced-search-accessibility").within(() => {
+      cy.get("[role=option]").eq(1).click();
+    });
 
     cy.getBySel("advanced-search-reset", true).click();
 
@@ -127,36 +131,35 @@ describe("Search Result", () => {
   });
 
   it("Should enable the search button if at least one input is filled out", () => {
-    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
     cy.getBySel("search-button").should("be.enabled");
   });
 
   it("Should persist advanced search query in url", () => {
     // Setup the search query.
-    cy.getBySel("advanced-search-header-row").eq(0).click().type("Harry");
+    cy.getBySel("advanced-search-header-row").eq(0).click();
+    cy.getBySel("advanced-search-header-row").eq(0).type("Harry");
+    cy.getBySel("advanced-search-header-row").eq(1).click();
     cy.getBySel("advanced-search-header-row")
       .eq(1)
-      .click()
       .within(() => {
         cy.get("input").type("Rowling");
         cy.get("select").select(1);
       });
-    cy.getBySel("advanced-search-material-types")
-      .click()
-      .within(() => {
-        cy.get("[role=option]").eq(1).click();
-        cy.get("[role=option]").eq(2).click();
-      });
-    cy.getBySel("advanced-search-fiction")
-      .click()
-      .within(() => {
-        cy.get("[role=option]").eq(1).click();
-      });
-    cy.getBySel("advanced-search-accessibility")
-      .click()
-      .within(() => {
-        cy.get("[role=option]").eq(1).click();
-      });
+    cy.getBySel("advanced-search-material-types").click();
+    cy.getBySel("advanced-search-material-types").within(() => {
+      cy.get("[role=option]").eq(1).click();
+      cy.get("[role=option]").eq(2).click();
+    });
+    cy.getBySel("advanced-search-fiction").click();
+    cy.getBySel("advanced-search-fiction").within(() => {
+      cy.get("[role=option]").eq(1).click();
+    });
+    cy.getBySel("advanced-search-accessibility").click();
+    cy.getBySel("advanced-search-accessibility").within(() => {
+      cy.get("[role=option]").eq(1).click();
+    });
 
     // Perform the search to persist it in the url.
     cy.getBySel("search-button").click();
@@ -217,7 +220,8 @@ describe("Search Result", () => {
   });
 
   it("Should show search results upon submitting the form", () => {
-    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
     cy.getBySel("search-button").click();
     cy.wait("@complexSearchWithPagination GraphQL operation");
     cy.getBySel("search-result-list").should("exist");
@@ -226,12 +230,14 @@ describe("Search Result", () => {
   });
 
   it("Updates search string after initial search is executed", () => {
-    cy.getBySel("advanced-search-header-row").first().click().type("Harry");
+    cy.getBySel("advanced-search-header-row").first().click();
+    cy.getBySel("advanced-search-header-row").first().type("Harry");
     cy.getBySel("preview-section").first().should("contain", "'Harry'");
     cy.getBySel("search-button").click();
     cy.wait("@complexSearchWithPagination GraphQL operation");
     cy.getBySel("search-result-list").should("exist");
-    cy.getBySel("advanced-search-header-row").eq(1).click().type("Potter");
+    cy.getBySel("advanced-search-header-row").eq(1).click();
+    cy.getBySel("advanced-search-header-row").eq(1).type("Potter");
     cy.getBySel("preview-section")
       .first()
       .should("contain", "'Harry' AND 'Potter'");

--- a/src/apps/loan-list/list/loan-list.test.ts
+++ b/src/apps/loan-list/list/loan-list.test.ts
@@ -374,9 +374,13 @@ describe("Loan list", () => {
     cy.get(".list-reservation-container")
       .find(".list-reservation")
       .eq(0)
-      .scrollIntoView()
-      .find(".list-reservation__information div a")
-      .should("exist");
+      .scrollIntoView();
+    cy.get(".list-reservation-container")
+      .find(".list-reservation")
+      .eq(0)
+      .within(() => {
+        cy.get(".list-reservation__information div a").should("exist");
+      });
 
     // 2.b.iv.3.c. Only shown if loan is overdue
     cy.get(".list-reservation-container")

--- a/src/apps/material/instant-loan.test.ts
+++ b/src/apps/material/instant-loan.test.ts
@@ -48,16 +48,16 @@ describe("Instant Loan", () => {
     cy.visit(
       "/iframe.html?&id=apps-material--instant-loan&viewMode=story&type=bog"
     ).scrollTo("bottom");
+    cy.getBySel("material-header-buttons-physical").scrollIntoView();
     cy.getBySel("material-header-buttons-physical")
-      .scrollIntoView()
       .should("be.visible")
       .and("contain", "Reserve bog")
       .click();
   });
 
   it("should render InstantLoan summary with title and cover", () => {
+    cy.getBySel("instant-loan").scrollIntoView();
     cy.getBySel("instant-loan")
-      .scrollIntoView()
       .should("have.attr", "aria-expanded", "false")
       .and("contain", "Hent bogen nu")
       .find("img")
@@ -66,25 +66,23 @@ describe("Instant Loan", () => {
   });
 
   it("should render InstantLoan branches", () => {
-    cy.getBySel("instant-loan").scrollIntoView().click();
+    cy.getBySel("instant-loan").scrollIntoView();
+    cy.getBySel("instant-loan").click();
 
-    cy.getBySel("instant-loan")
-      .scrollIntoView()
-      .should("have.attr", "aria-expanded", "true");
+    cy.getBySel("instant-loan").should("have.attr", "aria-expanded", "true");
 
-    cy.getBySel("instant-loan-branches")
-      .scrollIntoView()
-      .children()
-      .should("have.length", 1);
+    cy.getBySel("instant-loan-branches").scrollIntoView();
+    cy.getBySel("instant-loan-branches").children().should("have.length", 1);
   });
 
   it("should render InstantLoan branch", () => {
-    cy.getBySel("instant-loan").scrollIntoView().click();
+    cy.getBySel("instant-loan").scrollIntoView();
+    cy.getBySel("instant-loan").click();
 
+    cy.getBySel("instant-loan-branches").scrollIntoView();
     cy.getBySel("instant-loan-branches")
       .get("li")
       .contains("li", "Ørestad")
-      .scrollIntoView()
       .should("contain", "Ørestad")
       .and("contain", "2 stk");
   });

--- a/src/apps/material/login-redirect.test.ts
+++ b/src/apps/material/login-redirect.test.ts
@@ -12,8 +12,8 @@ describe("Material", () => {
     cy.scrollTo("bottom");
     cy.getBySel("material-description").scrollIntoView();
 
+    cy.getBySel("material-header-buttons-physical").scrollIntoView();
     cy.getBySel("material-header-buttons-physical")
-      .scrollIntoView()
       .should("be.visible")
       .and("contain", "Reserve bog")
       .click();
@@ -39,9 +39,9 @@ describe("Material", () => {
     cy.scrollTo("bottom");
     cy.getBySel("material-description").scrollIntoView();
 
+    cy.getBySel("material-header-buttons-physical").scrollIntoView();
     cy.getBySel("material-header-buttons-physical")
       .should("be.visible")
-      .scrollIntoView()
       .and("contain", "Reserve bog")
       .click();
 

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -405,9 +405,9 @@ describe("Material", () => {
 
     cy.scrollTo("bottom");
 
+    cy.getBySel("material-editions-disclosure").click();
     cy.getBySel("material-editions-disclosure")
       .should("contain", "Editions")
-      .click()
       .then((disclosure) => {
         cy.wrap(disclosure).should("contain", "Reserve");
       });

--- a/src/apps/material/order-digital-copy.test.ts
+++ b/src/apps/material/order-digital-copy.test.ts
@@ -86,9 +86,9 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .click();
 
+    cy.getBySel("email-order-digital-copy").clear();
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
-      .clear()
       .type("new-mail.test.com");
 
     cy.interceptGraphql({
@@ -112,9 +112,9 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .click();
 
+    cy.getBySel("email-order-digital-copy").clear();
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
-      .clear()
       .type("new-mail.test.com");
 
     cy.interceptGraphql({
@@ -139,9 +139,9 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .click();
 
+    cy.getBySel("email-order-digital-copy").clear();
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
-      .clear()
       .type("new-mail.test.com");
 
     cy.interceptGraphql({
@@ -166,9 +166,9 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .click();
 
+    cy.getBySel("email-order-digital-copy").clear();
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
-      .clear()
       .type("new-mail.test.com");
 
     cy.interceptGraphql({
@@ -193,9 +193,9 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .click();
 
+    cy.getBySel("email-order-digital-copy").clear();
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
-      .clear()
       .type("new-mail.test.com");
 
     cy.interceptGraphql({
@@ -220,9 +220,9 @@ describe("Material - Order digital copy", () => {
       .should("be.visible")
       .click();
 
+    cy.getBySel("email-order-digital-copy").clear();
     cy.getBySel("email-order-digital-copy")
       .should("be.visible")
-      .clear()
       .type("new-mail.test.com");
 
     cy.interceptGraphql({

--- a/src/apps/search-header/search-header.test.ts
+++ b/src/apps/search-header/search-header.test.ts
@@ -30,43 +30,54 @@ describe("Search header app", () => {
   });
 
   it("Allows user to write into the search field", () => {
-    cy.getBySel("search-header-input").should("be.visible").focus().type("ad");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").should("be.visible").type("ad");
   });
 
   it("Doesn't show suggestions before 3 characters are typed", () => {
-    cy.getBySel("search-header-input").focus().type("ha");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("ha");
     cy.getBySel("autosuggest").should("not.be.visible");
-    cy.getBySel("search-header-input").focus().type("r");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("r");
     cy.getBySel("autosuggest-text-item").should("be.visible");
   });
 
   it("Allows use of arrow keys to navigate autosuggest", () => {
-    cy.getBySel("search-header-input").focus().type("harry");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("harry");
     cy.getBySel("autosuggest").should("contain.text", "Harry");
-    cy.getBySel("search-header-input").focus().type("{downArrow}");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("{downArrow}");
     cy.getBySel("autosuggest-text-item")
       .first()
       .should("have.attr", "aria-selected", "true");
   });
 
   it("Matches text in the search field with highlighted item", () => {
-    cy.getBySel("search-header-input").focus().type("har");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("har");
     cy.getBySel("autosuggest").should("contain.text", "Harry");
-    cy.getBySel("search-header-input")
-      .focus()
-      .type("{downArrow}")
-      .should("have.attr", "value", "Harry Potter");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("{downArrow}");
+    cy.getBySel("search-header-input").should(
+      "have.attr",
+      "value",
+      "Harry Potter"
+    );
   });
 
   it("Shows both parts of the autosuggest", () => {
-    cy.getBySel("search-header-input").focus().type("har");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("har");
     cy.getBySel("autosuggest").should("contain.text", "Harry");
     cy.contains("Harry Potter (topic)");
     cy.contains("Harry Potter og de vises sten");
   });
 
   it("Shows cover pictures for the material suggestions", () => {
-    cy.getBySel("search-header-input").focus().type("har");
+    cy.getBySel("search-header-input").focus();
+    cy.getBySel("search-header-input").type("har");
     cy.getBySel("autosuggest-material-item")
       .first()
       .find("img")

--- a/src/apps/search-result/facet-browser.test.ts
+++ b/src/apps/search-result/facet-browser.test.ts
@@ -56,41 +56,35 @@ describe("The Facet Browser", () => {
   });
 
   it("Renders all facets", () => {
-    cy.getBySel("facet-browser-mainLanguages")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-mainLanguages").scrollIntoView();
+    cy.getBySel("facet-browser-mainLanguages").should("be.visible");
 
-    cy.getBySel("facet-browser-accessTypes")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-accessTypes").scrollIntoView();
+    cy.getBySel("facet-browser-accessTypes").should("be.visible");
 
-    cy.getBySel("facet-browser-childrenOrAdults")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-childrenOrAdults").scrollIntoView();
+    cy.getBySel("facet-browser-childrenOrAdults").should("be.visible");
 
-    cy.getBySel("facet-browser-creators").scrollIntoView().should("be.visible");
+    cy.getBySel("facet-browser-creators").scrollIntoView();
+    cy.getBySel("facet-browser-creators").should("be.visible");
 
-    cy.getBySel("facet-browser-fictionNonfiction")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-fictionNonfiction").scrollIntoView();
+    cy.getBySel("facet-browser-fictionNonfiction").should("be.visible");
 
-    cy.getBySel("facet-browser-fictionNonfiction")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-fictionNonfiction").scrollIntoView();
+    cy.getBySel("facet-browser-fictionNonfiction").should("be.visible");
 
-    cy.getBySel("facet-browser-genreAndForm")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-genreAndForm").scrollIntoView();
+    cy.getBySel("facet-browser-genreAndForm").should("be.visible");
 
-    cy.getBySel("facet-browser-materialTypes")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-materialTypes").scrollIntoView();
+    cy.getBySel("facet-browser-materialTypes").should("be.visible");
 
-    cy.getBySel("facet-browser-subjects").scrollIntoView().should("be.visible");
+    cy.getBySel("facet-browser-subjects").scrollIntoView();
+    cy.getBySel("facet-browser-subjects").should("be.visible");
 
-    cy.getBySel("facet-browser-workTypes")
-      .scrollIntoView()
-      .should("be.visible");
+    cy.getBySel("facet-browser-workTypes").scrollIntoView();
+    cy.getBySel("facet-browser-workTypes").should("be.visible");
   });
 
   it("Renders all terms in a facet when clicked", () => {
@@ -172,9 +166,13 @@ describe("The Facet Browser", () => {
 
     cy.getBySel("facet-browser-creators-Joanne K. Rowling")
       .should("be.visible")
-      .and("have.attr", "aria-pressed", "true")
-      .click()
-      .should("have.attr", "aria-pressed", "false");
+      .and("have.attr", "aria-pressed", "true");
+    cy.getBySel("facet-browser-creators-Joanne K. Rowling").click();
+    cy.getBySel("facet-browser-creators-Joanne K. Rowling").should(
+      "have.attr",
+      "aria-pressed",
+      "false"
+    );
 
     cy.getBySel("modal-facet-browser-modal-close-button").click();
 

--- a/src/components/multiselect/Multiselect.test.ts
+++ b/src/components/multiselect/Multiselect.test.ts
@@ -42,14 +42,14 @@ describe("Multiselect", () => {
 
   it("Allows selection of multiple values", () => {
     cy.get("button:visible").click();
+    cy.get("[role=option]").eq(1).click();
     cy.get("[role=option]")
       .eq(1)
-      .click()
       .should("contain", "An error occurred")
       .and("have.attr", "aria-selected", "true");
+    cy.get("[role=option]").eq(2).click();
     cy.get("[role=option]")
       .eq(2)
-      .click()
       .should("contain", "Available")
       .and("have.attr", "aria-selected", "true");
     cy.get("[role=option]")
@@ -126,9 +126,9 @@ describe("Multiselect", () => {
     cy.visit("/iframe.html?args=&id=components-multiselect--single-selected");
     cy.contains("An error occurred");
     cy.get("button:visible").click();
+    cy.get("[role=option]").eq(1).click();
     cy.get("[role=option]")
       .eq(1)
-      .click()
       .should("contain", "An error occurred")
       .and("have.attr", "aria-selected", "true");
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6673,12 +6673,12 @@ eslint-module-utils@^2.12.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-cypress@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz"
-  integrity sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==
+eslint-plugin-cypress@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-4.1.0.tgz#11178fd250d437e2ec57bf24b8a9058b356f8cac"
+  integrity sha512-JhqkMY02mw74USwK9OFhectx3YSj6Co1NgWBxlGdKvlqiAp9vdEuQqt33DKGQFvvGS/NWtduuhWXWNnU29xDSg==
   dependencies:
-    globals "^11.12.0"
+    globals "^15.11.0"
 
 eslint-plugin-import@^2.31.0:
   version "2.31.0"
@@ -7645,7 +7645,7 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
-globals@^11.1.0, globals@^11.12.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
@@ -7656,6 +7656,11 @@ globals@^13.19.0:
   integrity sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==
   dependencies:
     type-fest "^0.20.2"
+
+globals@^15.11.0:
+  version "15.14.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-15.14.0.tgz#b8fd3a8941ff3b4d38f3319d433b61bbb482e73f"
+  integrity sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==
 
 globalthis@^1.0.3, globalthis@^1.0.4:
   version "1.0.4"
@@ -12295,7 +12300,7 @@ string-env-interpolation@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12312,6 +12317,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -12407,7 +12421,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12420,6 +12434,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -13744,7 +13765,7 @@ wildcard@^2.0.0:
   resolved "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13766,6 +13787,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFNEXT-224

#### Description

- Bump eslint-plugin-cypress to version 4.1.0
- Fixed issues in the where the linter was throwing "cypress/unsafe-to-chain-command" errors