### PR TITLE
Use codegen in legacy mode

### DIFF
--- a/dbc-gateway.codegen.yml
+++ b/dbc-gateway.codegen.yml
@@ -11,6 +11,7 @@ generates:
         func: "../graphql-fetcher#fetcher"
       namingConvention: "./scripts/dbc-gateway.codegen.naming"
       defaultScalarType: unknown
+      legacyMode: true
     plugins:
       - "typescript"
       - "typescript-operations"


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-211

#### Description

Because we are using an older version react-query before it changed to TanStack, graphql-codegen references the new react-query package path, which does not exist in this project. By setting `legacyMode: true` we can instruct codegen to use the old react-query path as documented here:
https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-react-query#legacymode

#### Note
I verified that `yarn codegen:dbc:gateway` worked as expected, but could not introduce schema changes in this PR, as breaking type changes has been made to the API which should be resolved in a different task.
