### PR TITLE
DDFBRA-414 - Standardize the use of `dayjs` and format dates to "locale/da"

### DIFF
--- a/src/apps/dashboard/util/helpers.ts
+++ b/src/apps/dashboard/util/helpers.ts
@@ -1,13 +1,16 @@
-import dayjs from "dayjs";
-import { dateFormatDayjs } from "../../../core/configuration/date-format";
 import {
   faustIdentifierLength,
   digitalMaterialIdentifierLength
 } from "../../../core/configuration/identifier-lengths";
+import {
+  getNextWeekDate,
+  getNextYearDate,
+  getYesterdayDate
+} from "../../../core/utils/helpers/date";
 
-export const yesterday = dayjs().subtract(1, "day").format(dateFormatDayjs);
-export const soon = dayjs().add(7, "days").format(dateFormatDayjs);
-export const longer = dayjs().add(1, "year").format(dateFormatDayjs);
+export const yesterday = getYesterdayDate();
+export const soon = getNextWeekDate();
+export const longer = getNextYearDate();
 
 export const getReservationType = (reservationId: string) => {
   if (reservationId.length === faustIdentifierLength) {

--- a/src/apps/fee-list/fee-list.test.ts
+++ b/src/apps/fee-list/fee-list.test.ts
@@ -125,7 +125,7 @@ describe("Fee list", () => {
       .find(".list-reservation__deadline")
       .find(".text-small-caption")
       .should("exist")
-      .should("have.text", "Fees charged 06. 04. 2022");
+      .should("have.text", "Fees charged 6. april 2022");
 
     // 3. e Label: reason
     cy.getBySel("fee-list-page")
@@ -171,7 +171,7 @@ describe("Fee list", () => {
       .find("div")
       .find(".modal-loan__title")
       .should("exist")
-      .should("have.text", "Turned in 18. October 2019");
+      .should("have.text", "Turned in 18. oktober 2019");
 
     // book list
     cy.get(".modal-loan__list-materials")

--- a/src/apps/fee-list/stackable-fees/fee-details-content.tsx
+++ b/src/apps/fee-list/stackable-fees/fee-details-content.tsx
@@ -1,12 +1,11 @@
-import dayjs from "dayjs";
 import * as React from "react";
 import { FC } from "react";
 import { FeeV2 } from "../../../core/fbs/model";
 import { useText } from "../../../core/utils/text";
-import { dateFormatCustom } from "../../../core/configuration/date-format";
 import StackableFeesList from "./stackable-fees-list";
 import GroupModalContent from "../../../components/GroupModal/GroupModalContent";
 import { formatCurrency } from "../../../core/utils/helpers/currency";
+import { formatCustomDateString } from "../../../core/utils/helpers/date";
 
 export interface FeeDetailsContentProps {
   feeDetailsData: FeeV2;
@@ -20,7 +19,7 @@ const FeeDetailsContent: FC<FeeDetailsContentProps> = ({ feeDetailsData }) => {
     materials = [],
     reasonMessage
   } = feeDetailsData;
-  const creationDateFormatted = dayjs(creationDate).format(dateFormatCustom);
+  const creationDateFormatted = formatCustomDateString(creationDate);
 
   return (
     <div className="modal-loan__container">

--- a/src/apps/fee-list/stackable-fees/fee-status.tsx
+++ b/src/apps/fee-list/stackable-fees/fee-status.tsx
@@ -1,6 +1,5 @@
-import dayjs from "dayjs";
 import React, { FC } from "react";
-import { dateFormatDefault } from "../../../core/configuration/date-format";
+import { formatCustomDateString } from "../../../core/utils/helpers/date";
 import { useText } from "../../../core/utils/text";
 
 interface FeeStatusProps {
@@ -10,7 +9,7 @@ interface FeeStatusProps {
 
 const FeeStatus: FC<FeeStatusProps> = ({ dueDate, reasonMessage }) => {
   const t = useText();
-  const dueDateFormatted = dayjs(dueDate).format(dateFormatDefault);
+  const dueDateFormatted = formatCustomDateString(dueDate);
   return (
     <div>
       <div className="list-reservation__deadline">

--- a/src/apps/fee-list/utils/fee-status-circle.tsx
+++ b/src/apps/fee-list/utils/fee-status-circle.tsx
@@ -1,8 +1,8 @@
-import dayjs from "dayjs";
 import React, { FC } from "react";
 import { getColors } from "../../../core/utils/helpers/general";
 import { useText } from "../../../core/utils/text";
 import StatusCircleIcon from "../../loan-list/materials/utils/status-circle-icon";
+import { calculateDateDayDifference } from "../../../core/utils/helpers/date";
 
 interface FeeStatusCircleProps {
   dueDate: string;
@@ -15,9 +15,9 @@ const FeeStatusCircle: FC<FeeStatusCircleProps> = ({
 }) => {
   const t = useText();
   const colors = getColors();
-  const daysBetweenDueAndDelivered = dayjs(dueDate).diff(
-    feeCreationDate,
-    "day"
+  const daysBetweenDueAndDelivered = calculateDateDayDifference(
+    dueDate,
+    feeCreationDate
   );
 
   return (

--- a/src/apps/loan-list/list/loan-list.tsx
+++ b/src/apps/loan-list/list/loan-list.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, FC, useCallback } from "react";
 import { useSelector } from "react-redux";
-import dayjs from "dayjs";
 import {
   getAmountOfRenewableLoans,
   getDueDatesLoan,
@@ -39,7 +38,7 @@ import LoansGroupModal from "../../../components/GroupModal/LoansGroupModal";
 import SimpleModalHeader from "../../../components/GroupModal/SimpleModalHeader";
 import StatusCircleModalHeader from "../../../components/GroupModal/StatusCircleModalHeader";
 import StatusCircle from "../materials/utils/status-circle";
-import { formatDate } from "../../../core/utils/helpers/date";
+import { formatDate, getMonthAgoDate } from "../../../core/utils/helpers/date";
 import useLoans from "../../../core/utils/useLoans";
 import LoanListSkeleton from "./loan-list-skeleton";
 
@@ -214,10 +213,7 @@ const LoanList: FC<LoanListProps> = ({ pageSize }) => {
               })}
               dueDate={dueDate}
               statusCircleComponent={
-                <StatusCircle
-                  loanDate={dayjs().subtract(1, "month").format("YYYY-MM-DD")}
-                  dueDate={dueDate}
-                />
+                <StatusCircle loanDate={getMonthAgoDate()} dueDate={dueDate} />
               }
             />
           )}

--- a/src/apps/loan-list/materials/utils/status-badge.tsx
+++ b/src/apps/loan-list/materials/utils/status-badge.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { daysBetweenTodayAndDate } from "../../../../core/utils/helpers/general";
+import { calculateRoundedUpDaysUntil } from "../../../../core/utils/helpers/date";
 import useLoanThresholds from "../../../../core/utils/useLoanThresholds";
 import StatusBadgeContent from "./status-badge-content";
 
@@ -24,7 +24,7 @@ const StatusBadge: FC<StatusBadgeProps> = ({
 }) => {
   const threshold = useLoanThresholds();
   const daysBetweenTodayAndDue = badgeDate
-    ? daysBetweenTodayAndDate(badgeDate)
+    ? calculateRoundedUpDaysUntil(badgeDate)
     : 0;
 
   if (daysBetweenTodayAndDue < threshold.danger && dangerText) {

--- a/src/apps/loan-list/materials/utils/status-circle.tsx
+++ b/src/apps/loan-list/materials/utils/status-circle.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from "react";
 import check from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/basic/icon-check.svg";
 import StatusCircleIcon from "./status-circle-icon";
+import { getColors } from "../../../../core/utils/helpers/general";
 import {
-  getColors,
-  daysBetweenTodayAndDate,
-  daysBetweenDates
-} from "../../../../core/utils/helpers/general";
+  calculateRoundedUpDaysDifference,
+  calculateRoundedUpDaysUntil
+} from "../../../../core/utils/helpers/date";
 import { useText } from "../../../../core/utils/text";
 import useLoanThresholds from "../../../../core/utils/useLoanThresholds";
 
@@ -24,8 +24,8 @@ const StatusCircle: FC<StatusCircleProps> = ({ loanDate, dueDate }) => {
   let daysBetweenTodayAndDue = null;
   let daysBetweenLoanAndDue = null;
   if (dueDate) {
-    daysBetweenTodayAndDue = daysBetweenTodayAndDate(dueDate);
-    daysBetweenLoanAndDue = daysBetweenDates(dueDate, loanDate);
+    daysBetweenTodayAndDue = calculateRoundedUpDaysUntil(dueDate);
+    daysBetweenLoanAndDue = calculateRoundedUpDaysDifference(dueDate, loanDate);
 
     percent = 100 - (daysBetweenTodayAndDue / daysBetweenLoanAndDue) * 100;
     if (percent < 0) {

--- a/src/apps/opening-hours-editor/ConfirmAddRepeatedOpeningHour.tsx
+++ b/src/apps/opening-hours-editor/ConfirmAddRepeatedOpeningHour.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useText } from "../../core/utils/text";
 import { OpeningHoursCategoriesType } from "./types";
-import { getDateString, getWeekDayName } from "./helper";
+import { formatDate, formatWeekday } from "../../core/utils/helpers/date";
 
 type ConfirmAddRepeatedOpeningHourType = {
   startDate: Date;
@@ -50,15 +50,15 @@ const ConfirmAddRepeatedOpeningHour = ({
           </tr>
           <tr>
             <td>{t("openingHoursEventFormStartDateText")}:</td>
-            <td>{getDateString(startDate)}</td>
+            <td>{formatDate(startDate)}</td>
           </tr>
           <tr>
             <td>{t("openingHoursEventFormEndDateText")}:</td>
-            <td>{getDateString(repeatedEndDate)}</td>
+            <td>{formatDate(repeatedEndDate)}</td>
           </tr>
           <tr>
             <td>{t("openingHoursEventFormEveryWeekdayText")}:</td>
-            <td>{getWeekDayName(startDate)}</td>
+            <td>{formatWeekday(startDate)}</td>
           </tr>
         </tbody>
       </table>

--- a/src/apps/opening-hours-editor/DialogFormAdd.tsx
+++ b/src/apps/opening-hours-editor/DialogFormAdd.tsx
@@ -3,9 +3,7 @@ import { DateSelectArg } from "@fullcalendar/core";
 import {
   adjustEndDateToStartDayGridMonth,
   adjustEndDateToStartDayTimeGridWeek,
-  formatDateStr,
-  formatFullCalendarEventToCmsEventAdd,
-  updateDateTime
+  formatFullCalendarEventToCmsEventAdd
 } from "./helper";
 import EventForm, { EventFormOnSubmitType } from "./EventForm";
 import {
@@ -16,6 +14,10 @@ import { OpeningHoursCategoriesType } from "./types";
 import useDialog from "../../components/dialog/useDialog";
 import ConfirmAddRepeatedOpeningHour from "./ConfirmAddRepeatedOpeningHour";
 import Dialog from "../../components/dialog/Dialog";
+import {
+  formatDateStringISO,
+  updateDateTime
+} from "../../core/utils/helpers/date";
 
 type DialogFormAddProps = {
   selectedEventInfo: DateSelectArg;
@@ -46,7 +48,7 @@ const DialogFormAdd: React.FC<DialogFormAddProps> = ({
     repeatedEndDate
   }: EventFormOnSubmitType) => {
     const start = updateDateTime(selectedEventInfo.start, startTime);
-    const startStr = formatDateStr(start);
+    const startStr = formatDateStringISO(start);
     let end = updateDateTime(selectedEventInfo.end, endTime);
     let { endStr } = selectedEventInfo;
 

--- a/src/apps/opening-hours-editor/DialogFormEdit.tsx
+++ b/src/apps/opening-hours-editor/DialogFormEdit.tsx
@@ -3,8 +3,7 @@ import { EventImpl } from "@fullcalendar/core/internal";
 import {
   adjustEndDateBasedOnStartDate,
   formatFullCalendarEventToCmsEventEdit,
-  isOpeningHourWeeklyRepetition,
-  updateDateTime
+  isOpeningHourWeeklyRepetition
 } from "./helper";
 import EventForm, { EventFormOnSubmitType } from "./EventForm";
 import { useText } from "../../core/utils/text";
@@ -16,6 +15,7 @@ import {
 import useDialog from "../../components/dialog/useDialog";
 import Dialog from "../../components/dialog/Dialog";
 import ConfirmEditRepeatedOpeningHour from "./ConfirmEditRepeatedOpeningHour";
+import { updateDateTime } from "../../core/utils/helpers/date";
 
 type DialogFormEditProps = {
   eventInfo: EventImpl;

--- a/src/apps/opening-hours-editor/EventForm.tsx
+++ b/src/apps/opening-hours-editor/EventForm.tsx
@@ -3,10 +3,10 @@ import { OpeningHoursCategoriesType } from "./types";
 import { useText } from "../../core/utils/text";
 import {
   extractTime,
-  getDateString,
-  getStringForDateInput,
-  getWeekDayName
-} from "./helper";
+  formatDate,
+  formatDateForAPI,
+  formatWeekday
+} from "../../core/utils/helpers/date";
 
 export type EventFormOnSubmitType = {
   category: OpeningHoursCategoriesType;
@@ -43,8 +43,8 @@ const EventForm: React.FC<EventFormProps> = ({
 
   const initialStartTime = extractTime(startDate);
   const initialEndTime = extractTime(endDate);
-  const weekDayName = getWeekDayName(startDate);
-  const startDateString = getDateString(startDate);
+  const weekDayName = formatWeekday(startDate);
+  const startDateString = formatDate(startDate);
 
   const [startTime, setStartTime] = useState(initialStartTime);
   const [endTime, setEndTime] = useState(initialEndTime);
@@ -171,7 +171,7 @@ const EventForm: React.FC<EventFormProps> = ({
             type="date"
             className="opening-hours-editor-form__time-input"
             id="event-form-end-date"
-            min={getStringForDateInput(startDate)}
+            min={formatDateForAPI(startDate)}
             disabled={!isRepeated}
             required={isRepeated}
             value={repeatedEndDate || ""}

--- a/src/apps/opening-hours-editor/OpeningHoursEditorEventContent.tsx
+++ b/src/apps/opening-hours-editor/OpeningHoursEditorEventContent.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import logo from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/logo/reload_logo_black.svg";
 import { EventInput } from "@fullcalendar/core";
-import { extractTime, isOpeningHourWeeklyRepetition } from "./helper";
+import { isOpeningHourWeeklyRepetition } from "./helper";
+import { extractTime } from "../../core/utils/helpers/date";
 
 type OpeningHoursEditorEventContentProps = {
   eventInput: EventInput;

--- a/src/apps/opening-hours-editor/helper.ts
+++ b/src/apps/opening-hours-editor/helper.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { EventInput } from "@fullcalendar/core";
 import { EventImpl } from "@fullcalendar/core/internal";
 import {
@@ -7,6 +6,12 @@ import {
   DplOpeningHoursUpdatePATCH200Item,
   DplOpeningHoursListGET200ItemRepetitionType
 } from "../../core/dpl-cms/model";
+import {
+  convertToDayJs,
+  extractTime,
+  formatDateStringISO,
+  formatDateForAPI
+} from "../../core/utils/helpers/date";
 
 const formatDateTimeString = (date: string, time: string): string => {
   return `${date}T${time}:00`;
@@ -37,8 +42,8 @@ export const formatFullCalendarEventToCmsEventAdd = (
     throw new Error("Invalid event format");
   }
 
-  const startDate = dayjs(event.startStr);
-  const endDate = dayjs(event.endStr);
+  const startDate = event.startStr;
+  const endDate = event.endStr;
 
   return {
     id: Number(event.id),
@@ -46,9 +51,9 @@ export const formatFullCalendarEventToCmsEventAdd = (
       title: event.title,
       color: event.color
     },
-    date: startDate.format("YYYY-MM-DD"),
-    start_time: startDate.format("HH:mm"),
-    end_time: endDate.format("HH:mm"),
+    date: formatDateForAPI(startDate),
+    start_time: extractTime(startDate),
+    end_time: extractTime(endDate),
     repetition: event.repetition,
     // set to id 0 to because the API requires a branch_id.
     // This will be overwritten when the event is added or edited in the useOpeningHoursEditor hook
@@ -63,8 +68,8 @@ export const formatFullCalendarEventToCmsEventEdit = (
     throw new Error("Invalid event format");
   }
 
-  const startDate = dayjs(event.startStr);
-  const endDate = dayjs(event.endStr);
+  const startDate = event.startStr;
+  const endDate = event.endStr;
 
   return {
     id: Number(event.id),
@@ -72,9 +77,9 @@ export const formatFullCalendarEventToCmsEventEdit = (
       title: event.title,
       color: event.backgroundColor
     },
-    date: startDate.format("YYYY-MM-DD"),
-    start_time: startDate.format("HH:mm"),
-    end_time: endDate.format("HH:mm"),
+    date: formatDateForAPI(startDate),
+    start_time: extractTime(startDate),
+    end_time: extractTime(endDate),
     repetition: event.repetition,
     // set to id 0 to because the API requires a branch_id.
     // This will be overwritten when the event is added or edited in the useOpeningHoursEditor hook
@@ -82,13 +87,9 @@ export const formatFullCalendarEventToCmsEventEdit = (
   };
 };
 
-export const formatDateStr = (date: Date) => {
-  return dayjs(date).format("YYYY-MM-DDTHH:mm:ssZ");
-};
-
 export const adjustEndDateBasedOnStartDate = (startDay: Date, endDay: Date) => {
-  const start = dayjs(startDay);
-  const end = dayjs(endDay);
+  const start = convertToDayJs(startDay);
+  const end = convertToDayJs(endDay);
 
   // Check if the start and end dates are on the same day no adjustment is needed
   if (start.isSame(end, "day")) {
@@ -108,8 +109,8 @@ export const adjustEndDateToStartDayTimeGridWeek = (
   endDay: Date
 ) => {
   let adjustedEndDay;
-  const start = dayjs(startDay);
-  const end = dayjs(endDay);
+  const start = convertToDayJs(startDay);
+  const end = convertToDayJs(endDay);
 
   // If startDay and endDay are the same, no adjustment is needed
   if (start.isSame(end, "day")) {
@@ -121,7 +122,7 @@ export const adjustEndDateToStartDayTimeGridWeek = (
 
   return {
     end: adjustedEndDay.toDate(),
-    endStr: formatDateStr(adjustedEndDay.toDate())
+    endStr: formatDateStringISO(adjustedEndDay.toDate())
   };
 };
 
@@ -133,29 +134,8 @@ export const adjustEndDateToStartDayGridMonth = (
 
   return {
     end: adjustedEndDay,
-    endStr: formatDateStr(adjustedEndDay)
+    endStr: formatDateStringISO(adjustedEndDay)
   };
-};
-
-export const extractTime = (date: Date) => {
-  return dayjs(date).format("HH:mm");
-};
-
-export const updateDateTime = (date: Date, timeStr: string): Date => {
-  const [hours, minutes] = timeStr.split(":").map(Number);
-  return dayjs(date).hour(hours).minute(minutes).toDate();
-};
-
-export const getWeekDayName = (date: Date) => {
-  return dayjs(date).format("dddd");
-};
-
-export const getDateString = (date: Date) => {
-  return dayjs(date).format("DD-MM-YYYY");
-};
-
-export const getStringForDateInput = (date: Date) => {
-  return dayjs(date).format("YYYY-MM-DD");
 };
 
 export const isOpeningHourWeeklyRepetition = (

--- a/src/apps/opening-hours-editor/useOpeningHoursEditor.tsx
+++ b/src/apps/opening-hours-editor/useOpeningHoursEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { DatesSetArg, EventInput } from "@fullcalendar/core";
 import { useQueryClient } from "react-query";
-import { formatCmsEventsToFullCalendar, getStringForDateInput } from "./helper";
+import { formatCmsEventsToFullCalendar } from "./helper";
 import {
   getDplOpeningHoursListGETQueryKey,
   useDplOpeningHoursCreatePOST,
@@ -15,6 +15,7 @@ import {
 } from "../../core/dpl-cms/model";
 import { useConfig } from "../../core/utils/config";
 import { HandleEventRemoveType } from "./types";
+import { formatDateForAPI } from "../../core/utils/helpers/date";
 
 const useOpeningHoursEditor = () => {
   const config = useConfig();
@@ -27,8 +28,8 @@ const useOpeningHoursEditor = () => {
     {
       branch_id: openingHoursBranchId,
       ...(datesSet && {
-        from_date: getStringForDateInput(datesSet.start),
-        to_date: getStringForDateInput(datesSet.end)
+        from_date: formatDateForAPI(datesSet.start),
+        to_date: formatDateForAPI(datesSet.end)
       })
     },
     { enabled: !!datesSet }

--- a/src/apps/opening-hours-sidebar/OpeningHoursSidebarContent.tsx
+++ b/src/apps/opening-hours-sidebar/OpeningHoursSidebarContent.tsx
@@ -3,8 +3,9 @@ import iconWatch from "@danskernesdigitalebibliotek/dpl-design-system/build/icon
 import DisclosureControllable from "../../components/Disclosures/DisclosureControllable";
 import OpeningHoursSidebarSummary from "./OpeningHoursSidebarSummary";
 import OpeningHoursSidebarDetails from "./OpeningHoursSidebarDetails";
-import { LibraryType, toDayString } from "./helper";
+import { LibraryType } from "./helper";
 import { useText } from "../../core/utils/text";
+import { toDayString } from "../../core/utils/helpers/date";
 
 const OpeningHoursSidebarContent: FC<{ libraries: LibraryType[] }> = ({
   libraries

--- a/src/apps/opening-hours-sidebar/helper.ts
+++ b/src/apps/opening-hours-sidebar/helper.ts
@@ -1,8 +1,4 @@
-import dayjs from "dayjs";
-import "dayjs/locale/da";
 import { DplOpeningHoursListGET200Item } from "../../core/dpl-cms/model";
-
-dayjs.locale("da");
 
 type OpeningHoursDataType = {
   term: string;
@@ -74,8 +70,3 @@ export const convertBranchesToLibraries = (
     };
   });
 };
-
-export const formatDateForAPI = (date: Date): string =>
-  dayjs(date).format("YYYY-MM-DD");
-
-export const toDayString = (): string => dayjs().format("dddd D. MMMM");

--- a/src/apps/opening-hours-sidebar/useOpeningHoursSidebar.ts
+++ b/src/apps/opening-hours-sidebar/useOpeningHoursSidebar.ts
@@ -1,10 +1,7 @@
 import { useDplOpeningHoursListGET } from "../../core/dpl-cms/dpl-cms";
 import { useConfig } from "../../core/utils/config";
-import {
-  formatDateForAPI,
-  convertBranchesToLibraries,
-  BranchConfigType
-} from "./helper";
+import { formatDateForAPI } from "../../core/utils/helpers/date";
+import { convertBranchesToLibraries, BranchConfigType } from "./helper";
 
 const useOpeningHoursSidebar = () => {
   const config = useConfig();

--- a/src/apps/opening-hours/OpeningHourWeekList.tsx
+++ b/src/apps/opening-hours/OpeningHourWeekList.tsx
@@ -1,13 +1,12 @@
-import dayjs from "dayjs";
-import "dayjs/locale/da";
 import React from "react";
 import { useText } from "../../core/utils/text";
 import OpeningHourWeekListSkeleton from "./OpeningHourWeekListSkeleton";
 import OpeningHoursDayEntry from "./OpeningHoursDayEntry";
+import { GroupedOpeningHours } from "./OpeningHoursHelpers";
 import {
-  GroupedOpeningHours,
-  formatDateToWeekday
-} from "./OpeningHoursHelpers";
+  formatDateToWeekday,
+  formatDayMonth
+} from "../../core/utils/helpers/date";
 
 interface OpeningHoursWeekListProps {
   data: GroupedOpeningHours;
@@ -26,7 +25,7 @@ const OpeningHoursWeekList: React.FC<OpeningHoursWeekListProps> = ({
     <ul className="opening-hours__content" data-cy="opening-hours-week-list">
       {data.map(({ dateTime, openingHourEntries }) => {
         const dateAsWeekday = formatDateToWeekday(dateTime);
-        const formattedDateForDisplay = dayjs(dateTime).format("DD/MM");
+        const formattedDateForDisplay = formatDayMonth(dateTime);
 
         return (
           <li key={formattedDateForDisplay} className="opening-hours__row">

--- a/src/apps/opening-hours/OpeningHours.tsx
+++ b/src/apps/opening-hours/OpeningHours.tsx
@@ -7,7 +7,7 @@ import {
   formatWeekString,
   getNextWeek,
   getPreviousWeek
-} from "./OpeningHoursHelpers";
+} from "../../core/utils/helpers/date";
 import useOpeningHours from "./useOpeningHours";
 
 export type OpeningHoursProps = {

--- a/src/apps/opening-hours/OpeningHoursHelpers.ts
+++ b/src/apps/opening-hours/OpeningHoursHelpers.ts
@@ -1,59 +1,5 @@
-import dayjs from "dayjs";
-import "dayjs/locale/da";
-import weekOfYear from "dayjs/plugin/weekOfYear";
-import { upperFirst } from "lodash";
 import { DplOpeningHoursListGET200Item as OpeningHoursItem } from "../../core/dpl-cms/model";
-
-dayjs.locale("da");
-dayjs.extend(weekOfYear);
-
-export const getNextWeek = (date: Date): Date => {
-  return dayjs(date).add(1, "week").toDate();
-};
-
-export const getPreviousWeek = (date: Date): Date => {
-  return dayjs(date).subtract(1, "week").toDate();
-};
-
-export const getWeek = (date: Date): string => {
-  return dayjs(date).week().toString();
-};
-
-export const getYear = (date: Date): string => {
-  return dayjs(date).year().toString();
-};
-
-export const formatWeekString = (
-  translationKey: string,
-  date: Date
-): string => {
-  const week = getWeek(date);
-  const year = getYear(date);
-
-  return `${translationKey} ${week}, ${year}`;
-};
-
-const capitalizeString = (string: string): string => {
-  return upperFirst(string);
-};
-
-export const formatDateToWeekday = (date: Date): string => {
-  const formattedAsWeekday = dayjs(date).format("dddd");
-  const capitalizedWeekday = capitalizeString(formattedAsWeekday);
-
-  return capitalizedWeekday;
-};
-
-export const formatDateForAPI = (date: Date): string => {
-  return dayjs(date).format("YYYY-MM-DD");
-};
-
-export const getWeekStartAndEndDate = (date = new Date()) => {
-  const start = dayjs(date).startOf("week").toDate();
-  const end = dayjs(date).endOf("week").toDate();
-
-  return { start, end };
-};
+import { convertToDayJs, isSameDay } from "../../core/utils/helpers/date";
 
 export type GroupedOpeningHours = Array<{
   dateTime: Date;
@@ -65,8 +11,8 @@ export const groupOpeningHoursByWeekday = (
   endDate: Date,
   openingHours: OpeningHoursItem[]
 ): GroupedOpeningHours => {
-  const startDay = dayjs(startDate);
-  const endDay = dayjs(endDate);
+  const startDay = convertToDayJs(startDate);
+  const endDay = convertToDayJs(endDate);
   let currentDay = startDay;
 
   // Generate array of days between start and end dates
@@ -82,7 +28,7 @@ export const groupOpeningHoursByWeekday = (
       dateTime: day,
       openingHourEntries: openingHours
         .filter((individualOpeningHour) =>
-          dayjs(individualOpeningHour.date).isSame(day, "day")
+          isSameDay(individualOpeningHour.date, day)
         )
         .sort((a, b) => {
           // The array is primarily sorted by the start_time property of each object.

--- a/src/apps/opening-hours/useOpeningHours.ts
+++ b/src/apps/opening-hours/useOpeningHours.ts
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import { useDplOpeningHoursListGET } from "../../core/dpl-cms/dpl-cms";
 import {
   GroupedOpeningHours,
+  groupOpeningHoursByWeekday
+} from "./OpeningHoursHelpers";
+import {
   formatDateForAPI,
   getNextWeek,
   getPreviousWeek,
-  getWeekStartAndEndDate,
-  groupOpeningHoursByWeekday
-} from "./OpeningHoursHelpers";
+  getWeekStartAndEndDate
+} from "../../core/utils/helpers/date";
 
 interface UseOpeningHoursReturn {
   groupedOpeningHours: GroupedOpeningHours;

--- a/src/apps/reservation-list/modal/pause-reservation/pause-reservation.tsx
+++ b/src/apps/reservation-list/modal/pause-reservation/pause-reservation.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback, useState, useEffect, useId } from "react";
-import dayjs from "dayjs";
 import Link from "../../../../components/atoms/links/Link";
 import Modal, { useModalButtonHandler } from "../../../../core/utils/modal";
 import { useText } from "../../../../core/utils/text";
@@ -8,6 +7,7 @@ import { getModalIds } from "../../../../core/utils/helpers/modal-helpers";
 import DateRangeInput from "../../../../components/date-inputs/DateRangeInput";
 import useSavePatron from "../../../../core/utils/useSavePatron";
 import { Patron } from "../../../../core/utils/types/entities";
+import { getTodayDate } from "../../../../core/utils/helpers/date";
 
 interface PauseReservationProps {
   id: string;
@@ -36,7 +36,7 @@ const PauseReservation: FC<PauseReservationProps> = ({ id, user }) => {
     }
   });
   const saveFormId = useId();
-  const currentDate = dayjs().format("YYYY-MM-DD");
+  const currentDate = getTodayDate();
   const [startDate, setStartDate] = useState<string>(currentDate);
   const [endDate, setEndDate] = useState<string>("");
   const pauseActive = user?.onHold?.from && user?.onHold?.to;

--- a/src/apps/reservation-list/modal/reservation-details/helper.ts
+++ b/src/apps/reservation-list/modal/reservation-details/helper.ts
@@ -1,6 +1,6 @@
 import { FormSelectValue } from "../../../../components/reservation/forms/types";
-import { getFutureDateString } from "../../../../components/reservation/helper";
 import { ComplexSearchWithPaginationWorkAccessQuery } from "../../../../core/dbc-gateway/generated/graphql";
+import { getFutureDateString } from "../../../../core/utils/helpers/date";
 
 type AccessManifestations =
   ComplexSearchWithPaginationWorkAccessQuery["complexSearch"]["works"][0]["manifestations"]["all"];

--- a/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/physical-list-details.tsx
@@ -12,10 +12,7 @@ import {
   useUpdateReservations,
   getGetReservationsV2QueryKey
 } from "../../../../core/fbs/fbs";
-import {
-  getFutureDateString,
-  getPreferredBranch
-} from "../../../../components/reservation/helper";
+import { getPreferredBranch } from "../../../../components/reservation/helper";
 import { AgencyBranch } from "../../../../core/fbs/model";
 import ListDetails from "../../../../components/list-details/list-details";
 import { useConfig } from "../../../../core/utils/config";
@@ -29,7 +26,10 @@ import { excludeBlacklistedBranches } from "../../../../core/utils/branches";
 import ReservationFormListItem from "../../../../components/reservation/ReservationFormListItem";
 import NoInterestAfterModal from "../../../../components/reservation/forms/NoInterestAfterModal";
 import { RequestStatus } from "../../../../core/utils/types/request";
-import { formatDate } from "../../../../core/utils/helpers/date";
+import {
+  formatDate,
+  getFutureDateString
+} from "../../../../core/utils/helpers/date";
 import { getReadyForPickup } from "../../utils/helpers";
 import { Periods } from "../../../../components/reservation/types";
 import { FormSelectValue } from "../../../../components/reservation/forms/types";

--- a/src/apps/reservation-list/reservation-material/reservation-info.tsx
+++ b/src/apps/reservation-list/reservation-material/reservation-info.tsx
@@ -3,10 +3,8 @@ import check from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/ba
 import { useDeepCompareEffect } from "react-use";
 import { useText } from "../../../core/utils/text";
 import { ReservationType } from "../../../core/utils/types/reservation-type";
-import {
-  getColors,
-  daysBetweenTodayAndDate
-} from "../../../core/utils/helpers/general";
+import { getColors } from "../../../core/utils/helpers/general";
+import { calculateRoundedUpDaysUntil } from "../../../core/utils/helpers/date";
 import { getPreferredBranch } from "../../../components/reservation/helper";
 import ReservationStatus from "./reservation-status";
 import { useGetBranches } from "../../../core/utils/branches";
@@ -138,16 +136,19 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
   }
 
   if (state === "reserved" && !pickupBranch && pickupDeadline) {
-    const daysBetweenTodayAndPickup = daysBetweenTodayAndDate(pickupDeadline);
+    const daysBetweenTodayAndPickup =
+      calculateRoundedUpDaysUntil(pickupDeadline);
     const reservationAvailableLabel = showStatusCircleIcon
       ? t("reservationListAvailableInText", {
-          placeholders: { "@count": daysBetweenTodayAndDate(pickupDeadline) }
+          placeholders: {
+            "@count": calculateRoundedUpDaysUntil(pickupDeadline)
+          }
         })
       : "";
 
     return (
       <ReservationStatus
-        percent={daysBetweenTodayAndDate(pickupDeadline) / 100}
+        percent={calculateRoundedUpDaysUntil(pickupDeadline) / 100}
         label={reservationAvailableLabel}
         reservationInfo={reservationInfo}
         openReservationDetailsModal={openReservationDetailsModal}
@@ -160,7 +161,7 @@ const ReservationInfo: FC<ReservationInfoProps> = ({
           {/* if somehow it is possible to break text in one div into two lines */}
           {/* where the first line has another font size AND is only the first "word" */}
           {/* then this should be changed to do that */}
-          {daysBetweenTodayAndDate(pickupDeadline) > 0
+          {calculateRoundedUpDaysUntil(pickupDeadline) > 0
             ? daysBetweenTodayAndPickup
             : 0}{" "}
         </span>

--- a/src/apps/reservation-list/utils/helpers.ts
+++ b/src/apps/reservation-list/utils/helpers.ts
@@ -1,6 +1,8 @@
 import { ReservationDetailsV2 } from "../../../core/fbs/model";
-import { formatDateDependingOnDigitalMaterial } from "../../../core/utils/helpers/date";
-import { daysBetweenTodayAndDate } from "../../../core/utils/helpers/general";
+import {
+  calculateRoundedUpDaysUntil,
+  formatDateDependingOnDigitalMaterial
+} from "../../../core/utils/helpers/date";
 import { UseTextFunction } from "../../../core/utils/text";
 import { ReservationType } from "../../../core/utils/types/reservation-type";
 
@@ -72,7 +74,7 @@ export const getStatusText = (
 
     return t("reservationListAvailableInText", {
       placeholders: {
-        "@count": daysBetweenTodayAndDate(pickupDeadline)
+        "@count": calculateRoundedUpDaysUntil(pickupDeadline)
       }
     });
   }

--- a/src/components/date-inputs/DateRangeInput.tsx
+++ b/src/components/date-inputs/DateRangeInput.tsx
@@ -8,6 +8,7 @@ import "flatpickr/dist/flatpickr.css";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Danish } from "flatpickr/dist/l10n/da";
 import dayjs from "dayjs";
+import { dateFormatDayjs } from "../../core/configuration/date-format";
 
 export interface DateRangeInputProps {
   setStartDate: (date: string) => void;
@@ -94,8 +95,8 @@ const DateRangeInput: FC<DateRangeInputProps> = ({
           }}
           onChange={([start, end]) => {
             if (start && end) {
-              setStartDate(dayjs(start).format("YYYY-MM-DD"));
-              setEndDate(dayjs(end).format("YYYY-MM-DD"));
+              setStartDate(dayjs(start).format(dateFormatDayjs));
+              setEndDate(dayjs(end).format(dateFormatDayjs));
             }
           }}
         />

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -33,7 +33,6 @@ import {
 } from "../../core/fbs/fbs";
 import { Manifestation, Work } from "../../core/utils/types/entities";
 import {
-  getFutureDateString,
   getPreferredBranch,
   constructReservationData,
   getAuthorLine,
@@ -41,8 +40,7 @@ import {
   getInstantLoanBranchHoldings,
   getInstantLoanBranchHoldingsAboveThreshold,
   removePrefixFromBranchId,
-  translateOpenOrderStatus,
-  getFutureDateStringISO
+  translateOpenOrderStatus
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
 import { PeriodicalEdition } from "../material/periodical/helper";
@@ -66,6 +64,10 @@ import useReservableFromAnotherLibrary from "../../core/utils/useReservableFromA
 import { usePatronData } from "../../core/utils/helpers/usePatronData";
 import { Periods } from "./types";
 import { RequestStatus } from "../../core/utils/types/request";
+import {
+  getFutureDateString,
+  getFutureDateStringISO
+} from "../../core/utils/helpers/date";
 
 type ReservationModalProps = {
   selectedManifestations: Manifestation[];

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { UseTextFunction } from "../../core/utils/text";
 import {
   AgencyBranch,
@@ -42,16 +41,6 @@ export const getNoInterestAfter = (
     return interestPeriodFound.label;
   }
   return `${days} ${t("daysText")}`;
-};
-
-export const getFutureDateString = (num: number) => {
-  const futureDate = dayjs().add(num, "day").format("YYYY-MM-DD");
-  return futureDate;
-};
-
-export const getFutureDateStringISO = (num: number) => {
-  const futureDate = dayjs().add(num, "day").format("YYYY-MM-DDTHH:mm:ssZ");
-  return futureDate;
 };
 
 type Periodical = Pick<

--- a/src/core/configuration/date-format.ts
+++ b/src/core/configuration/date-format.ts
@@ -2,12 +2,24 @@ const dateFormats = {
   dateFormatDefault: "DD. MM. YYYY",
   dateFormatCustom: "D. MMMM YYYY",
   dateFormatDayjs: "YYYY-MM-DD",
-  dateFormatIso: "YYYY-MM-DDTHH:mm:ssZ"
+  dateFormatIso: "YYYY-MM-DDTHH:mm:ssZ",
+  dateFormatWeekdayMonth: "dddd D. MMMM",
+  dateFormatDash: "DD-MM-YYYY",
+  dateFormatDashWithTime: "DD-MM-YYYY HH:mm",
+  dateFormatSlashDayMonth: "DD/MM",
+  dateFormatWeekday: "dddd",
+  timeFormat: "HH:mm"
 };
 
 export const {
   dateFormatCustom,
   dateFormatDayjs,
   dateFormatDefault,
-  dateFormatIso
+  dateFormatIso,
+  dateFormatWeekdayMonth,
+  dateFormatDash,
+  dateFormatDashWithTime,
+  dateFormatSlashDayMonth,
+  dateFormatWeekday,
+  timeFormat
 } = dateFormats;

--- a/src/core/configuration/date-format.ts
+++ b/src/core/configuration/date-format.ts
@@ -1,8 +1,13 @@
 const dateFormats = {
   dateFormatDefault: "DD. MM. YYYY",
   dateFormatCustom: "D. MMMM YYYY",
-  dateFormatDayjs: "YYYY-MM-DD"
+  dateFormatDayjs: "YYYY-MM-DD",
+  dateFormatIso: "YYYY-MM-DDTHH:mm:ssZ"
 };
 
-export const { dateFormatCustom, dateFormatDayjs, dateFormatDefault } =
-  dateFormats;
+export const {
+  dateFormatCustom,
+  dateFormatDayjs,
+  dateFormatDefault,
+  dateFormatIso
+} = dateFormats;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -1,17 +1,31 @@
+import { upperFirst } from "lodash";
 import dayjs from "dayjs";
 import "dayjs/locale/da";
+import weekOfYear from "dayjs/plugin/weekOfYear";
 import {
   dateFormatCustom,
-  dateFormatDayjs
+  dateFormatDayjs,
+  dateFormatIso
 } from "../../configuration/date-format";
 
+dayjs.locale("da");
+dayjs.extend(weekOfYear);
+
 const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
+
+export const convertToDayJs = (date: string | Date) => {
+  return dayjs(date);
+};
 
 export const getDateValueOf = (date: string) => {
   return dayjs(date).valueOf();
 };
 
 // Date comparison functions
+export const isSameDay = (date1: string | Date, date2: string | Date) => {
+  return dayjs(date1).isSame(date2, "day");
+};
+
 export const dateHasPassed = (date: string) => {
   return dayjs().isAfter(date, "day");
 };
@@ -51,12 +65,32 @@ export const calculateRoundedUpDaysDifference = (
 };
 
 // Date formatting functions
-export const formatDate = (date: string) => {
+export const toDayString = (): string => {
+  return dayjs().format("dddd D. MMMM");
+};
+
+export const formatDate = (date: string | Date) => {
   return dayjs(date).format("DD-MM-YYYY");
 };
 
 export const formatDateTime = (date: string) => {
   return dayjs(date).format("DD-MM-YYYY HH:mm");
+};
+
+export const formatDayMonth = (date: string | Date) => {
+  return dayjs(date).format("DD/MM");
+};
+
+export const formatWeekday = (date: string | Date) => {
+  return dayjs(date).format("dddd");
+};
+
+export const formatDateForAPI = (date: Date): string => {
+  return dayjs(date).format("YYYY-MM-DD");
+};
+
+export const formatDateStringISO = (date: Date) => {
+  return dayjs(date).format(dateFormatIso);
 };
 
 export const formatCustomDateString = (dateString: string) =>
@@ -87,6 +121,46 @@ export const getNextWeekDate = () =>
 export const getNextYearDate = () =>
   dayjs().add(1, "year").format(dateFormatDayjs);
 
+export const getPreviousWeek = (date: Date): Date => {
+  return dayjs(date).subtract(1, "week").toDate();
+};
+
+export const getWeek = (date: Date): string => {
+  return dayjs(date).week().toString();
+};
+
+export const getNextWeek = (date: Date): Date => {
+  return dayjs(date).add(1, "week").toDate();
+};
+
+export const getYear = (date: Date): string => {
+  return dayjs(date).year().toString();
+};
+
+export const getWeekStartAndEndDate = (date = new Date()) => {
+  const start = dayjs(date).startOf("week").toDate();
+  const end = dayjs(date).endOf("week").toDate();
+
+  return { start, end };
+};
+
+export const formatWeekString = (
+  translationKey: string,
+  date: Date
+): string => {
+  const week = getWeek(date);
+  const year = getYear(date);
+
+  return `${translationKey} ${week}, ${year}`;
+};
+
+export const formatDateToWeekday = (date: Date): string => {
+  const formattedAsWeekday = formatWeekday(date);
+  const capitalizedWeekday = upperFirst(formattedAsWeekday);
+
+  return capitalizedWeekday;
+};
+
 // Date calculation functions: Get future dates
 export const getFutureDateString = (num: number) => {
   const futureDate = dayjs().add(num, "day").format(dateFormatDayjs);
@@ -94,8 +168,17 @@ export const getFutureDateString = (num: number) => {
 };
 
 export const getFutureDateStringISO = (num: number) => {
-  const futureDate = dayjs().add(num, "day").format("YYYY-MM-DDTHH:mm:ssZ");
+  const futureDate = dayjs().add(num, "day").format(dateFormatIso);
   return futureDate;
+};
+
+export const extractTime = (date: Date) => {
+  return dayjs(date).format("HH:mm");
+};
+
+export const updateDateTime = (date: Date, timeStr: string): Date => {
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  return dayjs(date).hour(hours).minute(minutes).toDate();
 };
 
 export default getCurrentUnixTime;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -7,6 +7,10 @@ import {
 
 const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
 
+export const getDateValueOf = (date: string) => {
+  return dayjs(date).valueOf();
+};
+
 // Date comparison functions
 export const dateHasPassed = (date: string) => {
   return dayjs().isAfter(date, "day");
@@ -17,6 +21,10 @@ export const calculateDateDayDifference = (
   endDate: string
 ) => {
   return dayjs(startDate).diff(dayjs(endDate), "day");
+};
+
+export const calculateDateYearsDifference = (date: string | Date) => {
+  return dayjs().diff(dayjs(date), "year");
 };
 
 export const calculateRoundedUpDaysUntil = (date: string) => {

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -56,4 +56,15 @@ export const getNextWeekDate = () =>
 export const getNextYearDate = () =>
   dayjs().add(1, "year").format(dateFormatDayjs);
 
+// Date calculation functions: Get future dates
+export const getFutureDateString = (num: number) => {
+  const futureDate = dayjs().add(num, "day").format(dateFormatDayjs);
+  return futureDate;
+};
+
+export const getFutureDateStringISO = (num: number) => {
+  const futureDate = dayjs().add(num, "day").format("YYYY-MM-DDTHH:mm:ssZ");
+  return futureDate;
+};
+
 export default getCurrentUnixTime;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -19,6 +19,29 @@ export const calculateDateDayDifference = (
   return dayjs(startDate).diff(dayjs(endDate), "day");
 };
 
+export const calculateRoundedUpDaysUntil = (date: string) => {
+  const inputDate = dayjs(new Date(date));
+  const today = dayjs(new Date());
+
+  // Math.ceil 0 diff last param true is because "diff()" rounds the number down
+  // and we need it to be rounded up
+  // todo figure out if ceil is correct (talk to ddb)
+  return Math.ceil(inputDate.diff(today, "day", true));
+};
+
+export const calculateRoundedUpDaysDifference = (
+  startDate: string,
+  endDate: string
+) => {
+  const inputFirstDate = dayjs(new Date(startDate));
+  const inputSecondDate = dayjs(new Date(endDate));
+
+  // Math.ceil 0 diff last param true is because "diff()" rounds the number down
+  // and we need it to be rounded up
+  // todo figure out if ceil is correct (talk to ddb)
+  return Math.ceil(inputFirstDate.diff(inputSecondDate, "day", true));
+};
+
 // Date formatting functions
 export const formatDate = (date: string) => {
   return dayjs(date).format("DD-MM-YYYY");

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -7,16 +7,22 @@ import {
 
 const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
 
+// Date comparison functions
 export const dateHasPassed = (date: string) => {
   return dayjs().isAfter(date, "day");
 };
 
+// Date formatting functions
 export const formatDate = (date: string) => {
   return dayjs(date).format("DD-MM-YYYY");
 };
+
 export const formatDateTime = (date: string) => {
   return dayjs(date).format("DD-MM-YYYY HH:mm");
 };
+
+export const formatCustomDateString = (dateString: string) =>
+  dayjs(dateString).format(dateFormatCustom);
 
 export const formatDateDependingOnDigitalMaterial = ({
   date,
@@ -28,6 +34,10 @@ export const formatDateDependingOnDigitalMaterial = ({
   return isDigital ? formatDateTime(date) : formatDate(date);
 };
 
+// Date calculation functions: Get dates relative to today
+export const getMonthAgoDate = () =>
+  dayjs().subtract(1, "month").format(dateFormatDayjs);
+
 export const getYesterdayDate = () =>
   dayjs().subtract(1, "day").format(dateFormatDayjs);
 
@@ -36,8 +46,5 @@ export const getNextWeekDate = () =>
 
 export const getNextYearDate = () =>
   dayjs().add(1, "year").format(dateFormatDayjs);
-
-export const formatCustomDateString = (dateString: string) =>
-  dayjs(dateString).format(dateFormatCustom);
 
 export default getCurrentUnixTime;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -1,4 +1,6 @@
 import dayjs from "dayjs";
+import "dayjs/locale/da";
+import { dateFormatDayjs } from "../../configuration/date-format";
 
 const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
 
@@ -22,5 +24,14 @@ export const formatDateDependingOnDigitalMaterial = ({
 }) => {
   return isDigital ? formatDateTime(date) : formatDate(date);
 };
+
+export const getYesterdayDate = () =>
+  dayjs().subtract(1, "day").format(dateFormatDayjs);
+
+export const getNextWeekDate = () =>
+  dayjs().add(7, "days").format(dateFormatDayjs);
+
+export const getNextYearDate = () =>
+  dayjs().add(1, "year").format(dateFormatDayjs);
 
 export default getCurrentUnixTime;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -17,7 +17,7 @@ export const convertToDayJs = (date: string | Date) => {
   return dayjs(date);
 };
 
-export const getDateValueOf = (date: string) => {
+export const getUnixTimestamp = (date: string) => {
   return dayjs(date).valueOf();
 };
 

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -1,6 +1,9 @@
 import dayjs from "dayjs";
 import "dayjs/locale/da";
-import { dateFormatDayjs } from "../../configuration/date-format";
+import {
+  dateFormatCustom,
+  dateFormatDayjs
+} from "../../configuration/date-format";
 
 const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
 
@@ -33,5 +36,8 @@ export const getNextWeekDate = () =>
 
 export const getNextYearDate = () =>
   dayjs().add(1, "year").format(dateFormatDayjs);
+
+export const formatCustomDateString = (dateString: string) =>
+  dayjs(dateString).format(dateFormatCustom);
 
 export default getCurrentUnixTime;

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -48,6 +48,8 @@ export const getMonthAgoDate = () =>
 export const getYesterdayDate = () =>
   dayjs().subtract(1, "day").format(dateFormatDayjs);
 
+export const getTodayDate = () => dayjs().format(dateFormatDayjs);
+
 export const getNextWeekDate = () =>
   dayjs().add(7, "days").format(dateFormatDayjs);
 

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -12,6 +12,13 @@ export const dateHasPassed = (date: string) => {
   return dayjs().isAfter(date, "day");
 };
 
+export const calculateDateDayDifference = (
+  startDate: string,
+  endDate: string
+) => {
+  return dayjs(startDate).diff(dayjs(endDate), "day");
+};
+
 // Date formatting functions
 export const formatDate = (date: string) => {
   return dayjs(date).format("DD-MM-YYYY");

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -4,8 +4,14 @@ import "dayjs/locale/da";
 import weekOfYear from "dayjs/plugin/weekOfYear";
 import {
   dateFormatCustom,
+  dateFormatDash,
+  dateFormatDashWithTime,
   dateFormatDayjs,
-  dateFormatIso
+  dateFormatIso,
+  dateFormatSlashDayMonth,
+  dateFormatWeekday,
+  dateFormatWeekdayMonth,
+  timeFormat
 } from "../../configuration/date-format";
 
 dayjs.locale("da");
@@ -66,27 +72,27 @@ export const calculateRoundedUpDaysDifference = (
 
 // Date formatting functions
 export const toDayString = (): string => {
-  return dayjs().format("dddd D. MMMM");
+  return dayjs().format(dateFormatWeekdayMonth);
 };
 
 export const formatDate = (date: string | Date) => {
-  return dayjs(date).format("DD-MM-YYYY");
+  return dayjs(date).format(dateFormatDash);
 };
 
 export const formatDateTime = (date: string) => {
-  return dayjs(date).format("DD-MM-YYYY HH:mm");
+  return dayjs(date).format(dateFormatDashWithTime);
 };
 
 export const formatDayMonth = (date: string | Date) => {
-  return dayjs(date).format("DD/MM");
+  return dayjs(date).format(dateFormatSlashDayMonth);
 };
 
 export const formatWeekday = (date: string | Date) => {
-  return dayjs(date).format("dddd");
+  return dayjs(date).format(dateFormatWeekday);
 };
 
 export const formatDateForAPI = (date: Date): string => {
-  return dayjs(date).format("YYYY-MM-DD");
+  return dayjs(date).format(dateFormatDayjs);
 };
 
 export const formatDateStringISO = (date: Date) => {
@@ -173,7 +179,7 @@ export const getFutureDateStringISO = (num: number) => {
 };
 
 export const extractTime = (date: Date) => {
-  return dayjs(date).format("HH:mm");
+  return dayjs(date).format(timeFormat);
 };
 
 export const updateDateTime = (date: Date, timeStr: string): Date => {

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -23,7 +23,7 @@ import { formatCurrency } from "./currency";
 import {
   dateHasPassed,
   calculateDateYearsDifference,
-  getDateValueOf
+  getUnixTimestamp
 } from "./date";
 
 export const capitalizeFirstLetters = (str: string) => {
@@ -206,7 +206,7 @@ export const sortByDueDate = (list: LoanType[]) => {
   //  We use orderBy from lodash to avoid mutating the original list
   return orderBy(
     list,
-    (item) => (item.dueDate ? getDateValueOf(item.dueDate) : Infinity),
+    (item) => (item.dueDate ? getUnixTimestamp(item.dueDate) : Infinity),
     "asc"
   );
 };

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import dayjs from "dayjs";
 import { first, orderBy, uniq } from "lodash";
 import { vi } from "vitest";
 import { CoverProps } from "../../../components/cover/cover";
@@ -21,6 +20,11 @@ import { ManifestationMaterialType } from "../types/material-type";
 import { store } from "../../store";
 import { constructModalId } from "./modal-helpers";
 import { formatCurrency } from "./currency";
+import {
+  dateHasPassed,
+  calculateDateYearsDifference,
+  getDateValueOf
+} from "./date";
 
 export const capitalizeFirstLetters = (str: string) => {
   return str
@@ -202,7 +206,7 @@ export const sortByDueDate = (list: LoanType[]) => {
   //  We use orderBy from lodash to avoid mutating the original list
   return orderBy(
     list,
-    (item) => (item.dueDate ? dayjs(item.dueDate).valueOf() : Infinity),
+    (item) => (item.dueDate ? getDateValueOf(item.dueDate) : Infinity),
     "asc"
   );
 };
@@ -331,7 +335,7 @@ export const pageSizeGlobal = (
 };
 
 export const materialIsOverdue = (date: string | undefined | null) =>
-  dayjs().isAfter(dayjs(date), "day");
+  date ? dateHasPassed(date) : false;
 
 export const loansOverdue = (loans: LoanType[]): boolean => {
   return loans.every((loan) => materialIsOverdue(loan.dueDate));
@@ -418,7 +422,7 @@ export const patronAgeValid = (cpr: string, minAge: number) => {
   const cprDate = getDateFromCpr(cpr);
   if (cprDate === null) return false;
 
-  const age = dayjs().diff(dayjs(cprDate), "year");
+  const age = calculateDateYearsDifference(cprDate);
   return age >= minAge;
 };
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -142,25 +142,6 @@ export const getRecommenderMaterialLimits = () => {
   return getConf("recommenderMaterialLimits", configuration);
 };
 
-export const daysBetweenTodayAndDate = (date: string) => {
-  const inputDate = dayjs(new Date(date));
-  const today = dayjs(new Date());
-
-  // Math.ceil 0 diff last param true is because "diff()" rounds the number down
-  // and we need it to be rounded up
-  // todo figure out if ceil is correct (talk to ddb)
-  return Math.ceil(inputDate.diff(today, "day", true));
-};
-export const daysBetweenDates = (firstDate: string, secondDate: string) => {
-  const inputFirstDate = dayjs(new Date(firstDate));
-  const inputSecondDate = dayjs(new Date(secondDate));
-
-  // Math.ceil 0 diff last param true is because "diff()" rounds the number down
-  // and we need it to be rounded up
-  // todo figure out if ceil is correct (talk to ddb)
-  return Math.ceil(inputFirstDate.diff(inputSecondDate, "day", true));
-};
-
 export const usePrevious = <Type>(value: Type) => {
   const ref = useRef<Type>(null);
   useEffect(() => {

--- a/src/core/utils/useLoans.tsx
+++ b/src/core/utils/useLoans.tsx
@@ -1,6 +1,7 @@
 import { useGetLoansV2 } from "../fbs/fbs";
 import { useGetV1UserLoans } from "../publizon/publizon";
-import { daysBetweenTodayAndDate, materialIsOverdue } from "./helpers/general";
+import { calculateRoundedUpDaysUntil } from "./helpers/date";
+import { materialIsOverdue } from "./helpers/general";
 import {
   mapFBSLoanToLoanType,
   mapPublizonLoanToLoanType
@@ -12,7 +13,7 @@ import useLoanThresholds from "./useLoanThresholds";
 const filterLoansNotOverdue = (loans: LoanType[], warning: number) => {
   return loans.filter(({ dueDate }) => {
     const due: string = dueDate || "";
-    const daysUntilExpiration = daysBetweenTodayAndDate(due);
+    const daysUntilExpiration = calculateRoundedUpDaysUntil(due);
     return daysUntilExpiration - warning > 0;
   });
 };
@@ -26,7 +27,7 @@ const filterLoansOverdue = (loans: LoanType[]) => {
 const filterLoansSoonOverdue = (loans: LoanType[], warning: number) => {
   return loans.filter(({ dueDate }) => {
     const due: string = dueDate || "";
-    const daysUntilExpiration = daysBetweenTodayAndDate(due);
+    const daysUntilExpiration = calculateRoundedUpDaysUntil(due);
     return (
       daysUntilExpiration - warning <= 0 &&
       daysUntilExpiration - warning >= -warning

--- a/src/tests/unit/date.test.ts
+++ b/src/tests/unit/date.test.ts
@@ -5,6 +5,10 @@ import {
   formatDateDependingOnDigitalMaterial,
   formatDateTime
 } from "../../core/utils/helpers/date";
+import {
+  dateFormatDash,
+  dateFormatDashWithTime
+} from "../../core/configuration/date-format";
 
 // We're describing a test suite for the `dateHasPassed` function
 describe("formatDate helper function", () => {
@@ -17,7 +21,7 @@ describe("formatDate helper function", () => {
 
     // We use dayjs to format the test date in the same way as our function
     // This will be the expected result
-    const expectedResult = dayjs(testDate).format("DD-MM-YYYY");
+    const expectedResult = dayjs(testDate).format(dateFormatDash);
 
     // We compare the result of our function to the expected result
     // If they match, our function is working correctly
@@ -33,7 +37,7 @@ describe("formatDateTime", () => {
     const date = "2022-04-22T14:30:00Z";
 
     // Expected result from the function
-    const expectedResult = dayjs(date).format("DD-MM-YYYY HH:mm");
+    const expectedResult = dayjs(date).format(dateFormatDashWithTime);
 
     // Call the function with the test data
     const result = formatDateTime(date);
@@ -49,13 +53,13 @@ describe("Date helper tests", () => {
   it("should correctly format date and time", () => {
     const date = dayjs().format(); // Get current date
     const formattedDate = formatDateTime(date);
-    expect(formattedDate).toBe(dayjs(date).format("DD-MM-YYYY HH:mm"));
+    expect(formattedDate).toBe(dayjs(date).format(dateFormatDashWithTime));
   });
   // Test for formatDate function
   it("should correctly format date", () => {
     const date = dayjs().format(); // Get current date
     const formattedDate = formatDate(date);
-    expect(formattedDate).toBe(dayjs(date).format("DD-MM-YYYY"));
+    expect(formattedDate).toBe(dayjs(date).format(dateFormatDash));
   });
   // Test for formatDateDependingOnDigitalMaterial function
   it("should format date depending on digital material", () => {
@@ -70,10 +74,10 @@ describe("Date helper tests", () => {
 
     // Check if date is formatted correctly depending on whether material is digital or not
     expect(formattedDigitalMaterialDate).toBe(
-      dayjs(date).format("DD-MM-YYYY HH:mm")
+      dayjs(date).format(dateFormatDashWithTime)
     );
     expect(formattedNonDigitalMaterialDate).toBe(
-      dayjs(date).format("DD-MM-YYYY")
+      dayjs(date).format(dateFormatDash)
     );
   });
 });


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-414
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2059

#### Description
This pull request standardizes how we work with Day.js.

Previously, we had a lot of duplicate functionality spread across multiple files. To improve maintainability, all Day.js-related functions have now been consolidated into the date helper module.

In the date helper, Day.js is now properly configured with the Danish locale, ensuring that date-related text (e.g., "October" → "oktober") is displayed consistently throughout the application.

Additionally, some functions have been renamed or removed where redundant implementations already existed.

These changes will make working with dates and times easier and more predictable in future development.

#### Test 
https://varnish.pr-2059.dpl-cms.dplplat01.dpl.reload.dk/
