### PR TITLE
Handle TS error differently

### DIFF
--- a/src/apps/material-search/useInfiteScrollLoading.ts
+++ b/src/apps/material-search/useInfiteScrollLoading.ts
@@ -47,9 +47,7 @@ const useInfiniteScrollLoading = ({
     };
   }, [handleScroll]);
 
-  // TODO: Fix the typescript error for useIntersection
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error: react-use does not yet support React 19, and TS will throw an error until it has been fixed
   // Handle intersection to load more items when the last item becomes visible using useIntersection
   const intersection = useIntersection(lastItemRef, {
     root: containerRef.current,

--- a/src/components/GroupModal/GroupModalContent.tsx
+++ b/src/components/GroupModal/GroupModalContent.tsx
@@ -24,10 +24,8 @@ const GroupModalContent: FC<GroupModalContentProps> = ({
 }) => {
   const t = useText();
 
-  const intersectionRef = useRef(null);
-  // TODO: Fix the typescript error for useIntersection
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  const intersectionRef = useRef<HTMLDivElement | null>(null);
+  // @ts-expect-error: react-use does not yet support React 19, and TS will throw an error until it has been fixed
   const intersection = useIntersection(intersectionRef, {
     threshold: 0
   });

--- a/src/core/utils/helpers/lazy-load.ts
+++ b/src/core/utils/helpers/lazy-load.ts
@@ -3,9 +3,7 @@ import { useIntersection } from "react-use";
 
 export const useItemHasBeenVisible = () => {
   const itemRef = useRef(null);
-  // TODO: Fix the typescript error for useIntersection
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error: react-use does not yet support React 19, and TS will throw an error until it has been fixed
   const intersection = useIntersection(itemRef, {
     root: null,
     rootMargin: "0%",


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-407

#### Description

Replace `@ts-ignore` with `@ts-expect-error`

This way TypeScript will let us know when a fix is made in the `react-use` package, and that we can safely remove the Directive Comments, which saves the need for a TODO in the code.
