### PR TITLE
Disable `react/display-name` eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -173,6 +173,7 @@ export default [
       "react/prop-types": "off",
       "react/require-default-props": "off",
       "react/no-unused-prop-types": "off",
+      "react/display-name": "off",
 
       "no-underscore-dangle": [
         "error",

--- a/src/apps/loan-list/materials/utils/digital-material-fetch-hoc.tsx
+++ b/src/apps/loan-list/materials/utils/digital-material-fetch-hoc.tsx
@@ -14,8 +14,6 @@ const fetchDigitalMaterial =
     Component: ComponentType<P & MaterialProps>,
     LoadingComponent?: ComponentType
   ): FC<P & InputProps> =>
-  // TODO: rewrite the code below and remove the eslint-disable-next-line react/display-name comment
-  // eslint-disable-next-line react/display-name
   ({ item, ...props }: InputProps) => {
     // If this is a physical book, another HOC fetches the data and this
     // HOC just returns the component

--- a/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
+++ b/src/apps/loan-list/materials/utils/material-fetch-hoc.tsx
@@ -23,8 +23,6 @@ const fetchMaterial =
     Component: ComponentType<P & MaterialProps>,
     FallbackComponent?: ComponentType
   ): FC<P & InputProps> =>
-  // TODO: rewrite the code below and remove the eslint-disable-next-line react/display-name comment
-  // eslint-disable-next-line react/display-name
   ({ item, ...props }: InputProps) => {
     // If this is a digital book, another HOC fetches the data and this
     // HOC just returns the component

--- a/src/core/utils/withIsPatronBlockedHoc.tsx
+++ b/src/core/utils/withIsPatronBlockedHoc.tsx
@@ -21,8 +21,6 @@ type InputProps = {
 // and explanation for the user.
 const withIsPatronBlockedHoc =
   <P extends object>(Component: ComponentType<P>): FC<P & InputProps> =>
-  // TODO: rewrite the code below and remove the eslint-disable-next-line react/display-name comment
-  // eslint-disable-next-line react/display-name
   ({ ...props }) => {
     // Used to check whether the modal has been opened by another component,
     // the modal should really only be showed once.


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-406

#### Description

We have decided on the Brahma team to disable the eslint rule, as it is very much an edge case to have a display name for higher order components when using React Developer Tools.
It would not be worth it to rewrite existing higher order components or having it required for any future ones.
