### PR TITLE
DDFBRA-187 - Remove `eReolen` references from the application

### DIFF
--- a/src/apps/menu/menu.stories.tsx
+++ b/src/apps/menu/menu.stories.tsx
@@ -148,9 +148,6 @@ const meta: Meta<typeof WrappedMenu> = {
     menuSignUpUrl: {
       control: { type: "text" }
     },
-    ereolenHomepageUrl: {
-      control: { type: "text" }
-    },
     expirationWarningDaysBeforeConfig: {
       control: { type: "text" }
     },
@@ -212,7 +209,6 @@ export const UserMenu: Story = {
     menuLoginUrl: "/Login",
     menuSignUpText: "Sign up",
     menuSignUpUrl: "/Signup",
-    ereolenHomepageUrl: "https://ereolen.dk/",
     expirationWarningDaysBeforeConfig: "6",
     searchHeaderLoginText: "Login",
     searchHeaderFavoritesText: "Liked"

--- a/src/apps/patron-page/PatronPage.entry.tsx
+++ b/src/apps/patron-page/PatronPage.entry.tsx
@@ -21,7 +21,6 @@ interface PatronPageConfigProps {
 export interface PatronPageUrlProps {
   deletePatronUrl: string;
   pauseReservationInfoUrl: string;
-  alwaysLoanableEreolenUrl: string;
 }
 
 interface PatronPageTextProps {
@@ -54,7 +53,6 @@ interface PatronPageTextProps {
   patronPageSaveButtonText: string;
   patronPageStatusSectionBodyText: string;
   patronPageStatusSectionHeaderText: string;
-  patronPageStatusSectionLinkText: string;
   patronPageStatusSectionLoanHeaderText: string;
   patronPageStatusSectionLoansAudioBooksText: string;
   patronPageStatusSectionLoansEbooksText: string;
@@ -73,7 +71,6 @@ interface PatronPageTextProps {
   pauseReservationModalSaveButtonLabelText: string;
   pickupBranchesDropdownLabelText: string;
   pickupBranchesDropdownNothingSelectedText: string;
-  alwaysAvailableEreolenUrl: string;
 }
 
 export interface PatronPageProps

--- a/src/apps/patron-page/PatronPage.stories.tsx
+++ b/src/apps/patron-page/PatronPage.stories.tsx
@@ -46,12 +46,6 @@ const meta: Meta<typeof PatronPage> = {
     textNotificationsEnabledConfig: {
       control: { type: "text" }
     },
-    alwaysAvailableEreolenUrl: {
-      control: { type: "text" }
-    },
-    ereolenHomepageUrl: {
-      control: { type: "text" }
-    },
     // Texts
     patronPageHeaderText: {
       control: { type: "text" }
@@ -108,9 +102,6 @@ const meta: Meta<typeof PatronPage> = {
       control: { type: "text" }
     },
     patronPageStatusSectionBodyText: {
-      control: { type: "text" }
-    },
-    patronPageStatusSectionLinkText: {
       control: { type: "text" }
     },
     patronPageStatusSectionLoanHeaderText: {
@@ -217,9 +208,6 @@ const meta: Meta<typeof PatronPage> = {
     pauseReservationInfoUrl:
       "https://images.unsplash.com/photo-1560888126-5c13ad3f9345?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2371&q=80", // A goat.
     textNotificationsEnabledConfig: "1",
-    alwaysAvailableEreolenUrl:
-      "https://images.unsplash.com/photo-1560888126-5c13ad3f9345?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2371&q=80", // A goat.
-    ereolenHomepageUrl: "https://ereolen.dk/",
     // Texts
     patronPageHeaderText: "Patron profile page",
     pauseReservationModalHeaderText: "Pause reservations on physical items",
@@ -242,11 +230,9 @@ const meta: Meta<typeof PatronPage> = {
     patronContactEmailLabelText: "E-mail",
     patronContactEmailCheckboxText:
       "Receive emails about your loans, reservations, and so forth",
-    patronPageStatusSectionHeaderText: "Digital loans (eReolen)",
+    patronPageStatusSectionHeaderText: "Digital loans",
     patronPageStatusSectionBodyText:
       "There is a number of materials without limitation to amounts of loans per month.",
-    patronPageStatusSectionLinkText:
-      "Click here, to see titles always eligible to be loaned",
     patronPageStatusSectionLoanHeaderText: "Loans per month",
     patronPageStatusSectionLoansEbooksText: "E-books",
     patronPageStatusSectionLoansAudioBooksText: "Audiobooks",

--- a/src/apps/patron-page/PatronPage.test.tsx
+++ b/src/apps/patron-page/PatronPage.test.tsx
@@ -115,7 +115,7 @@ describe("Patron page", () => {
     // ID 36 2.b. Digital loans - quota
     cy.get(".dpl-patron-page .dpl-status-loans")
       .find("h2")
-      .should("have.text", "Digital loans (eReolen)");
+      .should("have.text", "Digital loans");
 
     // ID 36 2.b.i. Number of digital loans (ebook - audiobooks) the patron has left in "this" month
     cy.get(".dpl-patron-page .dpl-status-loans")

--- a/src/apps/patron-page/sections/StatusSection.tsx
+++ b/src/apps/patron-page/sections/StatusSection.tsx
@@ -5,13 +5,9 @@ import {
 } from "../../../core/publizon/publizon";
 import { LibraryProfile, UserData } from "../../../core/publizon/model";
 import { useText } from "../../../core/utils/text";
-import { useUrls } from "../../../core/utils/url";
-import Link from "../../../components/atoms/links/Link";
 
 const StatusSection: FC = () => {
   const t = useText();
-  const u = useUrls();
-  const alwaysAvailableEreolenUrl = u("alwaysAvailableEreolenUrl");
 
   const { data: libraryProfileFetched } = useGetV1LibraryProfile();
   const { isSuccess, data } = useGetV1UserLoans();
@@ -67,10 +63,7 @@ const StatusSection: FC = () => {
             {t("patronPageStatusSectionHeaderText")}
           </h2>
           <div className="text-body-small-regular mb-8">
-            {t("patronPageStatusSectionBodyText")}{" "}
-            <Link href={alwaysAvailableEreolenUrl}>
-              {t("patronPageStatusSectionLinkText")}
-            </Link>
+            {t("patronPageStatusSectionBodyText")}
           </div>
           <div className="text-body-small-regular mt-8 mb-8">
             {t("patronPageStatusSectionReservationsText", {

--- a/src/apps/reservation-list/list/reservation-list.entry.tsx
+++ b/src/apps/reservation-list/list/reservation-list.entry.tsx
@@ -12,7 +12,6 @@ import { DeleteReservationModalArgs } from "../../../core/storybook/deleteReserv
 import { GlobalEntryTextProps } from "../../../core/storybook/globalTextArgs";
 
 export interface ReservationListUrlProps {
-  ereolenMyPageUrl: string;
   expirationWarningDaysBeforeConfig: string;
   pauseReservationInfoUrl: string;
 }

--- a/src/apps/reservation-list/list/reservation-list.stories.tsx
+++ b/src/apps/reservation-list/list/reservation-list.stories.tsx
@@ -59,13 +59,7 @@ const meta: Meta<typeof ReservationList> = {
       control: { type: "number" }
     },
     // Urls
-    ereolenMyPageUrl: {
-      control: { type: "text" }
-    },
     pauseReservationInfoUrl: {
-      control: { type: "text" }
-    },
-    ereolenHomepageUrl: {
       control: { type: "text" }
     },
     // Texts
@@ -225,10 +219,8 @@ export const Default: Story = {
     pageSizeDesktop: 20,
     pageSizeMobile: 10,
     // Urls
-    ereolenMyPageUrl: "https://ereolen.dk/user/me/",
     pauseReservationInfoUrl:
       "https://images.unsplash.com/photo-1571043733612-d5444ff7d4ae?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1335&q=80",
-    ereolenHomepageUrl: "https://ereolen.dk/",
     // Texts
     reservationListHeaderText: "Your reservations",
     reservationListPhysicalReservationsHeaderText: "Physical reservations",

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -191,7 +191,7 @@ describe("Reservation details modal", () => {
     // ID 43 2.b. Material types including accessibility of material
     // ID 17 2.b.ii "Ready for loan" if the reservation is ready for loan, or else it will not be shown
 
-    // ID 17 2.d. button: go to ereolen
+    // ID 17 2.d. button: View material
     cy.get(".modal")
       .find("[data-cy='view-material-button']")
       .eq(0)

--- a/src/components/availability-label/useOnlineAvailabilityData.ts
+++ b/src/components/availability-label/useOnlineAvailabilityData.ts
@@ -32,11 +32,11 @@ const useOnlineAvailabilityData = ({
       }
     });
 
-  // Ereol request.
-  const { isLoading: isLoadingEreolData, data: dataEreol } =
+  // Publizon request.
+  const { isLoading: isLoadingPublizonData, data: dataPublizon } =
     useGetV1LoanstatusIdentifier(isbn || "", {
       // Publizon / useGetV1LoanstatusIdentifier shows loan status per material.
-      // This status is only available for products found on Ereol. Other online
+      // This status is only available for products found on Publizon. Other online
       // materials are always supposed to be shown as "available"
       enabled:
         enabled &&
@@ -44,7 +44,7 @@ const useOnlineAvailabilityData = ({
         !!isbn &&
         // If the material is free (I think it is called blue material btw.)
         // we should not load the loan status because then we know that it is available.
-        // So If the material is not free and we know it is an "Ereol" material we should load the loan status.
+        // So If the material is not free and we know it is an "Publizon" material we should load the loan status.
         dataIdentifier?.product?.costFree === false &&
         access.some((acc) => acc === "Ereol")
     });
@@ -54,22 +54,24 @@ const useOnlineAvailabilityData = ({
       !enabled ||
       isAvailable !== null ||
       isLoadingIdentifier !== false ||
-      isLoadingEreolData !== false
+      isLoadingPublizonData !== false
     ) {
       return;
     }
 
-    // If we have ereol data, we can use that to determine the availability.
-    if (dataEreol && dataEreol.loanStatus) {
-      setIsAvailable(publizonProductStatuses[dataEreol.loanStatus].isAvailable);
+    // If we have Publizon data, we can use that to determine the availability.
+    if (dataPublizon && dataPublizon.loanStatus) {
+      setIsAvailable(
+        publizonProductStatuses[dataPublizon.loanStatus].isAvailable
+      );
     }
   }, [
     isLoadingIdentifier,
     isAvailable,
     faustIds,
     enabled,
-    dataEreol,
-    isLoadingEreolData
+    dataPublizon,
+    isLoadingPublizonData
   ]);
 
   // If hook is not enabled make it clear that the loading and availability status is unknown.
@@ -90,7 +92,7 @@ const useOnlineAvailabilityData = ({
 
   // Return the availability status.
   return {
-    isLoading: isLoadingIdentifier && isLoadingEreolData,
+    isLoading: isLoadingIdentifier && isLoadingPublizonData,
     isAvailable
   };
 };

--- a/src/components/material/reserve-button.md
+++ b/src/components/material/reserve-button.md
@@ -27,7 +27,7 @@ ButtonWithType[The button says 'Reserve /material type/' + is enabled]
 CannotbeReserved[The button says 'Cannot be reserved' + Is disabled]
 
 5{Does the manifestation have origin and url?}
---Yes--> Ereol[The button says: 'Go to + origin' e.g. 'Gå til ereolen]
+--Yes--> Ereol[The button says: 'Go to + origin' e.g. 'Gå til materialet]
 5{Does the manifestation have origin and url?}
 --No--> 6{Does the manifestation have an issn digital article id?}
 

--- a/src/core/storybook/publizonErrorArgs.ts
+++ b/src/core/storybook/publizonErrorArgs.ts
@@ -118,7 +118,7 @@ export default {
   publizonErrorStatusLibraryServerNotRespondingText:
     "The library's server is not responding – try logging in again later.",
   publizonErrorStatusNoAccessBecauseNotResidentText:
-    "You do not have access to eReolen from this library as you are not registered as a resident in the municipality. Contact the library.",
+    "You do not have access to publizon from this library as you are not registered as a resident in the municipality. Contact the library.",
   publizonErrorStatusNoCountryFoundWithGivenCountryCodeText:
     "No country could be found with the given country code",
   publizonErrorStatusUnknownErrorText: "Unknown error."

--- a/src/core/storybook/reservationListArgs.ts
+++ b/src/core/storybook/reservationListArgs.ts
@@ -25,9 +25,6 @@ export const argTypes = {
     control: { type: "number" }
   },
   // Urls
-  ereolenMyPageUrl: {
-    control: { type: "text" }
-  },
   pauseReservationInfoUrl: {
     control: { type: "text" }
   },
@@ -202,7 +199,6 @@ export default {
     '[\n   {\n      "branchId":"DK-775120",\n      "title":"Højbjerg"\n   },\n   {\n      "branchId":"DK-775122",\n      "title":"Beder-Malling"\n   },\n   {\n      "branchId":"DK-775144",\n      "title":"Gellerup"\n   },\n   {\n      "branchId":"DK-775167",\n      "title":"Lystrup"\n   },\n   {\n      "branchId":"DK-775146",\n      "title":"Harlev"\n   },\n   {\n      "branchId":"DK-775168",\n      "title":"Skødstrup"\n   },\n   {\n      "branchId":"FBS-751010",\n      "title":"Arresten"\n   },\n   {\n      "branchId":"DK-775147",\n      "title":"Hasle"\n   },\n   {\n      "branchId":"FBS-751032",\n      "title":"Må ikke benyttes"\n   },\n   {\n      "branchId":"FBS-751031",\n      "title":"Fjernlager 1"\n   },\n   {\n      "branchId":"DK-775126",\n      "title":"Solbjerg"\n   },\n   {\n      "branchId":"FBS-751030",\n      "title":"ITK"\n   },\n   {\n      "branchId":"DK-775149",\n      "title":"Sabro"\n   },\n   {\n      "branchId":"DK-775127",\n      "title":"Tranbjerg"\n   },\n   {\n      "branchId":"DK-775160",\n      "title":"Risskov"\n   },\n   {\n      "branchId":"DK-775162",\n      "title":"Hjortshøj"\n   },\n   {\n      "branchId":"DK-775140",\n      "title":"Åby"\n   },\n   {\n      "branchId":"FBS-751009",\n      "title":"Fjernlager 2"\n   },\n   {\n      "branchId":"FBS-751029",\n      "title":"Stadsarkivet"\n   },\n   {\n      "branchId":"FBS-751027",\n      "title":"Intern"\n   },\n   {\n      "branchId":"FBS-751026",\n      "title":"Fælles undervejs"\n   },\n   {\n      "branchId":"FBS-751025",\n      "title":"Fællessekretariatet"\n   },\n   {\n      "branchId":"DK-775133",\n      "title":"Bavnehøj"\n   },\n   {\n      "branchId":"FBS-751024",\n      "title":"Fjernlånte materialer"\n   },\n   {\n      "branchId":"DK-775100",\n      "title":"Hovedbiblioteket"\n   },\n   {\n      "branchId":"DK-775170",\n      "title":"Trige"\n   },\n   {\n      "branchId":"DK-775150",\n      "title":"Tilst"\n   },\n   {\n      "branchId":"DK-775130",\n      "title":"Viby"\n   },\n   {\n      "branchId":"DK-775164",\n      "title":"Egå"\n   }\n]',
   pageSizeDesktop: 20,
   pageSizeMobile: 10,
-  ereolenMyPageUrl: "https://ereolen.dk/user/me/",
   pauseReservationInfoUrl:
     "https://images.unsplash.com/photo-1571043733612-d5444ff7d4ae?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1335&q=80",
   reservationListHeaderText: "Your reservations",

--- a/src/core/storybook/reservationMaterialDetailsArgs.ts
+++ b/src/core/storybook/reservationMaterialDetailsArgs.ts
@@ -109,15 +109,6 @@ export const argTypes = {
     },
     control: { type: "text" }
   },
-  reservationDetailsDigitalReservationGoToEreolenText: {
-    table: {
-      type: { summary: "text" },
-      defaultValue: {
-        summary: "Go to eReolen"
-      }
-    },
-    control: { type: "text" }
-  },
   reservationDetailsReadyForLoanText: {
     table: {
       type: { summary: "text" },
@@ -289,7 +280,6 @@ export default {
   reservationDetailsButtonRemoveText: "Remove your reservation",
   reservationDetailsStatusTitleText: "Status",
   reservationDetailsBorrowBeforeText: "Borrow before @date",
-  reservationDetailsDigitalReservationGoToEreolenText: "Go to eReolen",
   reservationDetailsReadyForLoanText: "Ready for pickup",
   reservationDetailsPickupDeadlineTitleText: "Pickup deadline",
   interestPeriodsConfig:
@@ -327,7 +317,6 @@ export interface ReservationMaterialDetailsProps {
   reservationDetailsButtonRemoveText: string;
   reservationDetailsStatusTitleText: string;
   reservationDetailsBorrowBeforeText: string;
-  reservationDetailsDigitalReservationGoToEreolenText: string;
   reservationDetailsReadyForLoanText: string;
   reservationDetailsPickupDeadlineTitleText: string;
   interestPeriodsConfig: string;

--- a/src/core/utils/types/global-url-props.ts
+++ b/src/core/utils/types/global-url-props.ts
@@ -3,7 +3,6 @@ interface GlobalUrlEntryPropsInterface {
   searchUrl: string;
   advancedSearchUrl: string;
   fbsBaseUrl: string;
-  loanListEreolenUrl: string;
   feesPageUrl: string;
   publizonBaseUrl: string;
   dplCmsBaseUrl: string;
@@ -13,7 +12,6 @@ interface GlobalUrlEntryPropsInterface {
   fbiLocalBaseUrl: string;
   fbiGlobalBaseUrl: string;
   authUrl: string;
-  ereolenHomepageUrl: string;
   materialListBaseUrl: string;
 }
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-187

#### Description
This PR removes obsolete references to `eReolen` in the application.
- Cleaned up unused text and outdated URLs that referenced `eReolen`.
- Removed `patronPageStatusSectionLinkText` and `alwaysAvailableEreolenUrl` as these concepts are no longer relevant since we can not filter exclusively for blue titles.

DPL-CMS PR:
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2144


#### Test
https://varnish.pr-2144.dpl-cms.dplplat01.dpl.reload.dk/

