### PR TITLE
DDFNEXT-752 - Fix `2025.10.0`

### DIFF
--- a/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
+++ b/src/apps/material-grid/automatic/MaterialGridAutomatic.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { useComplexSearchWithPaginationQuery } from "../../../core/dbc-gateway/generated/graphql";
 import useGetCleanBranches from "../../../core/utils/branches";
-import { Work } from "../../../core/utils/types/entities";
 import MaterialGrid from "../MaterialGrid";
 import MaterialGridSkeleton from "../MaterialGridSkeleton";
 import { ValidSelectedIncrements } from "../materiel-grid-util";
+import { WorkId } from "../../../core/utils/types/ids";
 
 export type MaterialGridAutomaticProps = {
   cql: string;
@@ -34,10 +34,10 @@ const MaterialGridAutomatic: React.FC<MaterialGridAutomaticProps> = ({
     return <MaterialGridSkeleton title={title} />;
   }
 
-  const resultWorks: Work[] = data.complexSearch.works as Work[];
+  const resultWorks = data.complexSearch.works;
   const materials = resultWorks.map((work) => {
     return {
-      wid: work.workId
+      wid: work.workId as WorkId
     };
   });
 

--- a/src/apps/material-grid/link-automatic/MaterialGridLinkAutomatic.tsx
+++ b/src/apps/material-grid/link-automatic/MaterialGridLinkAutomatic.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { useComplexSearchWithPaginationQuery } from "../../../core/dbc-gateway/generated/graphql";
 import useGetCleanBranches from "../../../core/utils/branches";
-import { Work } from "../../../core/utils/types/entities";
 import MaterialGrid from "../MaterialGrid";
 import MaterialGridSkeleton from "../MaterialGridSkeleton";
 import { ValidSelectedIncrements } from "../materiel-grid-util";
 import { getQueryParams } from "../../../core/utils/helpers/url";
 import { commaSeparatedStringToArray } from "../../advanced-search/helpers";
+import { WorkId } from "../../../core/utils/types/ids";
 
 export type MaterialGridLinkAutomaticProps = {
   link: URL;
@@ -49,10 +49,10 @@ const MaterialGridLinkAutomatic: React.FC<MaterialGridLinkAutomaticProps> = ({
     return <MaterialGridSkeleton title={title} />;
   }
 
-  const resultWorks: Work[] = data.complexSearch.works as Work[];
+  const resultWorks = data.complexSearch.works;
   const materials = resultWorks.map((work) => {
     return {
-      wid: work.workId
+      wid: work.workId as WorkId
     };
   });
 

--- a/src/apps/material-search/MaterialSearchList.tsx
+++ b/src/apps/material-search/MaterialSearchList.tsx
@@ -7,7 +7,6 @@ import { useText } from "../../core/utils/text";
 import useInfiniteScrollLoading from "./useInfiteScrollLoading";
 import { SearchWithPaginationQuery } from "../../core/dbc-gateway/generated/graphql";
 import { Work } from "../../core/utils/types/entities";
-import { getWorkTitle } from "../material/helper";
 
 type MaterialSearchListResultsProps = {
   data: SearchWithPaginationQuery["search"]["works"];
@@ -84,7 +83,7 @@ const MaterialSearchListResults: FC<MaterialSearchListResultsProps> = ({
                 }}
                 onFocus={(e) => handleFocus(index, e.currentTarget)}
                 aria-label={t("materialSearchAriaButtonSelectWorkWithText", {
-                  placeholders: { "@title": `${getWorkTitle(work)}` }
+                  placeholders: { "@title": `${work.titles.full}` }
                 })}
               >
                 <Cover
@@ -99,7 +98,7 @@ const MaterialSearchListResults: FC<MaterialSearchListResultsProps> = ({
                       {t("materialSearchPreviewTitleText")}:
                     </span>
                     <span className="material-search-list__detail">
-                      {getWorkTitle(work)}
+                      {work.titles.full}
                     </span>
                   </div>
                   <div className="material-search-list__detail-item">

--- a/src/apps/material-search/MaterialSearchList.tsx
+++ b/src/apps/material-search/MaterialSearchList.tsx
@@ -6,7 +6,6 @@ import { flattenCreators } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import useInfiniteScrollLoading from "./useInfiteScrollLoading";
 import { SearchWithPaginationQuery } from "../../core/dbc-gateway/generated/graphql";
-import { Work } from "../../core/utils/types/entities";
 
 type MaterialSearchListResultsProps = {
   data: SearchWithPaginationQuery["search"]["works"];
@@ -51,7 +50,7 @@ const MaterialSearchListResults: FC<MaterialSearchListResultsProps> = ({
   }
 
   if (!data || data.length === 0) return null;
-  const works = data as Work[];
+  const works = data;
 
   return (
     <div className="material-search-list" ref={containerRef}>

--- a/src/components/simple-material/SimpleMaterial.tsx
+++ b/src/components/simple-material/SimpleMaterial.tsx
@@ -5,7 +5,6 @@ import ButtonFavourite, {
   ButtonFavouriteId
 } from "../button-favourite/button-favourite";
 import { Cover } from "../cover/cover";
-import { Work } from "../../core/utils/types/entities";
 import { getContributors, getWorkPid } from "../../core/utils/helpers/general";
 import { TypedDispatch } from "../../core/store";
 import { guardedRequest } from "../../core/guardedRequests.slice";
@@ -13,9 +12,10 @@ import { constructMaterialUrl } from "../../core/utils/helpers/url";
 import Link from "../atoms/links/Link";
 import { useUrls } from "../../core/utils/url";
 import { GuardedAppId } from "../../core/utils/types/ids";
+import { WorkSmall } from "../../core/utils/types/entities";
 
 export interface SimpleMaterialProps {
-  work: Work;
+  work: WorkSmall;
   bright?: boolean;
   app: GuardedAppId;
 }

--- a/src/components/simple-material/SimpleMaterialAdapter.tsx
+++ b/src/components/simple-material/SimpleMaterialAdapter.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { useGetSmallWorkQuery } from "../../core/dbc-gateway/generated/graphql";
-import { Work } from "../../core/utils/types/entities";
+import { WorkSmall } from "../../core/utils/types/entities";
 import { Pid, GuardedAppId } from "../../core/utils/types/ids";
 import SimpleMaterial from "./SimpleMaterial";
 
@@ -23,7 +23,7 @@ const SimpleMaterialAdapter: FC<SimpleMaterialAdapterProps> = ({
       {data && data.work && (
         <SimpleMaterial
           key={data.work?.workId}
-          work={data.work as Work}
+          work={data.work as WorkSmall}
           app={app}
           bright={bright}
         />

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -14,7 +14,10 @@ import { FaustId, Pid } from "../types/ids";
 import { getUrlQueryParam } from "./url";
 import { LoanType } from "../types/loan-type";
 import { ListType } from "../types/list-type";
-import { ManifestationReviewFieldsFragment } from "../../dbc-gateway/generated/graphql";
+import {
+  ManifestationReviewFieldsFragment,
+  WorkSmallFragment
+} from "../../dbc-gateway/generated/graphql";
 import { FeeV2 } from "../../fbs/model/feeV2";
 import { ReservationType } from "../types/reservation-type";
 import { ManifestationMaterialType } from "../types/material-type";
@@ -49,8 +52,8 @@ export const orderManifestationsByYear = (
   });
 };
 
-export const flattenCreators = (creators: Work["creators"]) =>
-  creators.map((creator: Work["creators"][0]) => {
+export const flattenCreators = (creators: WorkSmallFragment["creators"]) =>
+  creators.map((creator) => {
     return creator.display;
   });
 

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -9,15 +9,12 @@ import configuration, {
   getConf,
   getDeviceConf
 } from "../../configuration";
-import { Manifestation, Work } from "../types/entities";
+import { Manifestation, Work, WorkSmall } from "../types/entities";
 import { FaustId, Pid } from "../types/ids";
 import { getUrlQueryParam } from "./url";
 import { LoanType } from "../types/loan-type";
 import { ListType } from "../types/list-type";
-import {
-  ManifestationReviewFieldsFragment,
-  WorkSmallFragment
-} from "../../dbc-gateway/generated/graphql";
+import { ManifestationReviewFieldsFragment } from "../../dbc-gateway/generated/graphql";
 import { FeeV2 } from "../../fbs/model/feeV2";
 import { ReservationType } from "../types/reservation-type";
 import { ManifestationMaterialType } from "../types/material-type";
@@ -52,7 +49,7 @@ export const orderManifestationsByYear = (
   });
 };
 
-export const flattenCreators = (creators: WorkSmallFragment["creators"]) =>
+export const flattenCreators = (creators: WorkSmall["creators"]) =>
   creators.map((creator) => {
     return creator.display;
   });

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -120,7 +120,7 @@ export const getFirstPublishedYear = (manifestations: Manifestation[]) => {
 };
 
 // This function is used to find the most representative pid of a work.
-export const getWorkPid = (work: Work) => {
+export const getWorkPid = (work: WorkSmall) => {
   return work.manifestations.bestRepresentation.pid || null;
 };
 

--- a/src/core/utils/types/entities.ts
+++ b/src/core/utils/types/entities.ts
@@ -8,7 +8,8 @@ import {
   ManifestationReviewFieldsFragment,
   ManifestationsSimpleFieldsFragment,
   Relations,
-  WorkMediumFragment
+  WorkMediumFragment,
+  WorkSmallFragment
 } from "../../dbc-gateway/generated/graphql";
 import { PatronV5 } from "../../fbs/model";
 import { Pid, WorkId } from "./ids";
@@ -22,6 +23,16 @@ export type ReviewManifestation = Omit<
   "pid"
 > & {
   pid: Pid;
+};
+
+export type WorkSmall = Omit<WorkSmallFragment, "workId" | "manifestations"> & {
+  workId: WorkId;
+  manifestations: {
+    all: Manifestation[];
+    first: Manifestation;
+    latest: Manifestation;
+    bestRepresentation: Manifestation;
+  };
 };
 
 export type Work = Omit<


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFNEXT-752


#### Description

Refactor `MaterialSearchList` to use work titles directly instead of a helper function.

The work data comes from `useComplexSearchWithPaginationQuery` and uses `WorkSmall`, which does not contain `mainLanguages` and `materialTypes`, both of which are required for `getWorkTitle`.
