### PR TITLE
Never render an inactive access url

### DIFF
--- a/cypress/fixtures/material-buttons/material-buttons-movie-fbi-api.json
+++ b/cypress/fixtures/material-buttons/material-buttons-movie-fbi-api.json
@@ -521,7 +521,8 @@
                 "__typename": "AccessUrl",
                 "origin": "www.filmstriben.dk",
                 "url": "http://www.filmstriben.dk/fjernleje/film/details.aspx?id=9000004315",
-                "loginRequired": false
+                "loginRequired": false,
+                "status": "OK"
               }
             ],
             "shelfmark": {
@@ -697,7 +698,8 @@
               "__typename": "AccessUrl",
               "origin": "www.filmstriben.dk",
               "url": "http://www.filmstriben.dk/fjernleje/film/details.aspx?id=9000004315",
-              "loginRequired": false
+              "loginRequired": false,
+              "status": "OK"
             }
           ],
           "shelfmark": {
@@ -872,7 +874,8 @@
               "__typename": "AccessUrl",
               "origin": "www.filmstriben.dk",
               "url": "http://www.filmstriben.dk/fjernleje/film/details.aspx?id=9000004315",
-              "loginRequired": false
+              "loginRequired": false,
+              "status": "OK"
             }
           ],
           "shelfmark": {

--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -58,7 +58,11 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
 
   // Check if the access type is external (e.g., Filmstriben or eReolen Global).
   if (hasCorrectAccess("AccessUrl", manifestations)) {
-    const accessElement = first(first(manifestations)?.access);
+    // Get the first manifestation and return the first active access element.
+    const manifestation = first(manifestations);
+    const accessElement = manifestation?.access?.find(
+      (access) => access.__typename === "AccessUrl" && access.status === "OK"
+    );
 
     if (!accessElement) {
       throw new Error("No access element found.");

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -121,6 +121,7 @@ fragment ManifestationsSimpleFields on Manifestation {
       origin
       url
       loginRequired
+      status
     }
     ... on InfomediaService {
       id

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -1332,6 +1332,82 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ComplexSearchIndex",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "facet",
+            "description": "Can be used for faceting",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "index",
+            "description": "The name of a Complex Search index",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "search",
+            "description": "Can be used for searching",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sort",
+            "description": "Can be used for sorting",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ComplexSearchResponse",
         "description": "The search response",
         "isOneOf": null,
@@ -2279,6 +2355,30 @@
             "deprecationReason": null
           },
           {
+            "name": "large",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CoverDetails",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "medium",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CoverDetails",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "origin",
             "description": null,
             "args": [],
@@ -2291,12 +2391,84 @@
             "deprecationReason": null
           },
           {
+            "name": "small",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CoverDetails",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "thumbnail",
             "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "xSmall",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CoverDetails",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CoverDetails",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "height",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "width",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5998,6 +6170,30 @@
             "deprecationReason": null
           },
           {
+            "name": "bestRepresentations",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Manifestation",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "first",
             "description": null,
             "args": [],
@@ -6052,44 +6248,23 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Marc",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
+          },
           {
-            "name": "getMarcByRecordId",
-            "description": "Gets the MARC record collection for the given record identifier, containing either standalone or head and/or section and volume records.",
-            "args": [
-              {
-                "name": "recordId",
-                "description": "The marc record identifier",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
+            "name": "searchHits",
+            "description": "A list of manifestations that matched the search query.\n\nThis field is populated only when a work is retrieved within a search context.\nEach entry is a SearchHit object representing a manifestation that matched the search criteria.\nOnly one manifestation per unit is returned.",
+            "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "MarcRecord",
-              "ofType": null
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SearchHit",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7702,6 +7877,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CONTAINS_AI_GENERATED_CONTENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "DESCRIPTION_OF_MATERIAL",
             "description": null,
             "isDeprecated": false,
@@ -7787,6 +7968,12 @@
           },
           {
             "name": "TYPE_OF_SCORE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "WITHDRAWN_PUBLICATION",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -8404,6 +8591,26 @@
             "deprecationReason": null
           },
           {
+            "name": "complexSearchIndexes",
+            "description": "All indexes in complex search",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ComplexSearchIndex",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "complexSuggest",
             "description": null,
             "args": [
@@ -8683,22 +8890,6 @@
                   "name": "Manifestation",
                   "ofType": null
                 }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "marc",
-            "description": "Field for presenting bibliographic records in MARC format",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Marc",
-                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -11028,6 +11219,30 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SearchHit",
+        "description": "A search hit that encapsulates a matched manifestation from a search query.",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "match",
+            "description": "The manifestation that was matched during the search.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Manifestation",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/src/core/dbc-gateway/generated/graphql.ts
+++ b/src/core/dbc-gateway/generated/graphql.ts
@@ -236,6 +236,18 @@ export type ComplexSearchFiltersInput = {
   sublocation?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
 
+export type ComplexSearchIndex = {
+  __typename?: "ComplexSearchIndex";
+  /** Can be used for faceting */
+  facet: Scalars["Boolean"]["output"];
+  /** The name of a Complex Search index */
+  index: Scalars["String"]["output"];
+  /** Can be used for searching */
+  search: Scalars["Boolean"]["output"];
+  /** Can be used for sorting */
+  sort: Scalars["Boolean"]["output"];
+};
+
 /** The search response */
 export type ComplexSearchResponse = {
   __typename?: "ComplexSearchResponse";
@@ -371,8 +383,19 @@ export type Cover = {
   detail117?: Maybe<Scalars["String"]["output"]>;
   detail207?: Maybe<Scalars["String"]["output"]>;
   detail500?: Maybe<Scalars["String"]["output"]>;
+  large?: Maybe<CoverDetails>;
+  medium?: Maybe<CoverDetails>;
   origin?: Maybe<Scalars["String"]["output"]>;
+  small?: Maybe<CoverDetails>;
   thumbnail?: Maybe<Scalars["String"]["output"]>;
+  xSmall?: Maybe<CoverDetails>;
+};
+
+export type CoverDetails = {
+  __typename?: "CoverDetails";
+  height?: Maybe<Scalars["Int"]["output"]>;
+  url?: Maybe<Scalars["String"]["output"]>;
+  width?: Maybe<Scalars["Int"]["output"]>;
 };
 
 export type CreatorInterface = {
@@ -929,19 +952,18 @@ export type Manifestations = {
   __typename?: "Manifestations";
   all: Array<Manifestation>;
   bestRepresentation: Manifestation;
+  bestRepresentations: Array<Manifestation>;
   first: Manifestation;
   latest: Manifestation;
   mostRelevant: Array<Manifestation>;
-};
-
-export type Marc = {
-  __typename?: "Marc";
-  /** Gets the MARC record collection for the given record identifier, containing either standalone or head and/or section and volume records. */
-  getMarcByRecordId?: Maybe<MarcRecord>;
-};
-
-export type MarcGetMarcByRecordIdArgs = {
-  recordId: Scalars["String"]["input"];
+  /**
+   * A list of manifestations that matched the search query.
+   *
+   * This field is populated only when a work is retrieved within a search context.
+   * Each entry is a SearchHit object representing a manifestation that matched the search criteria.
+   * Only one manifestation per unit is returned.
+   */
+  searchHits?: Maybe<Array<SearchHit>>;
 };
 
 export type MarcRecord = {
@@ -1171,6 +1193,7 @@ export type Note = {
 
 export enum NoteTypeEnum {
   ConnectionToOtherWorks = "CONNECTION_TO_OTHER_WORKS",
+  ContainsAiGeneratedContent = "CONTAINS_AI_GENERATED_CONTENT",
   DescriptionOfMaterial = "DESCRIPTION_OF_MATERIAL",
   Dissertation = "DISSERTATION",
   Edition = "EDITION",
@@ -1185,7 +1208,8 @@ export enum NoteTypeEnum {
   References = "REFERENCES",
   RestrictionsOnUse = "RESTRICTIONS_ON_USE",
   TechnicalRequirements = "TECHNICAL_REQUIREMENTS",
-  TypeOfScore = "TYPE_OF_SCORE"
+  TypeOfScore = "TYPE_OF_SCORE",
+  WithdrawnPublication = "WITHDRAWN_PUBLICATION"
 }
 
 export enum OrderTypeEnum {
@@ -1276,6 +1300,8 @@ export type PublicationYear = {
 export type Query = {
   __typename?: "Query";
   complexSearch: ComplexSearchResponse;
+  /** All indexes in complex search */
+  complexSearchIndexes?: Maybe<Array<ComplexSearchIndex>>;
   complexSuggest: ComplexSuggestResponse;
   debug?: Maybe<Debug>;
   infomedia: InfomediaResponse;
@@ -1283,8 +1309,6 @@ export type Query = {
   localSuggest: LocalSuggestResponse;
   manifestation?: Maybe<Manifestation>;
   manifestations: Array<Maybe<Manifestation>>;
-  /** Field for presenting bibliographic records in MARC format */
-  marc: Marc;
   mood: MoodQueries;
   /** Get recommendations */
   recommend: RecommendationResponse;
@@ -1573,6 +1597,13 @@ export type SearchFiltersInput = {
   sublocation?: InputMaybe<Array<Scalars["String"]["input"]>>;
   workTypes?: InputMaybe<Array<Scalars["String"]["input"]>>;
   year?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
+/** A search hit that encapsulates a matched manifestation from a search query. */
+export type SearchHit = {
+  __typename?: "SearchHit";
+  /** The manifestation that was matched during the search. */
+  match?: Maybe<Manifestation>;
 };
 
 /** The supported fields to query */
@@ -2268,6 +2299,7 @@ export type GetSmallWorkQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -2391,6 +2423,7 @@ export type GetSmallWorkQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -2514,6 +2547,7 @@ export type GetSmallWorkQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -2888,6 +2922,7 @@ export type GetMaterialQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -3011,6 +3046,7 @@ export type GetMaterialQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -3134,6 +3170,7 @@ export type GetMaterialQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -3362,6 +3399,7 @@ export type GetMaterialGloballyQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -3485,6 +3523,7 @@ export type GetMaterialGloballyQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -3608,6 +3647,7 @@ export type GetMaterialGloballyQuery = {
               origin: string;
               url: string;
               loginRequired: boolean;
+              status: LinkStatusEnum;
             }
           | { __typename: "DigitalArticleService"; issn: string }
           | {
@@ -3880,6 +3920,7 @@ export type RecommendFromFaustQuery = {
                   origin: string;
                   url: string;
                   loginRequired: boolean;
+                  status: LinkStatusEnum;
                 }
               | { __typename: "DigitalArticleService"; issn: string }
               | {
@@ -4003,6 +4044,7 @@ export type RecommendFromFaustQuery = {
                   origin: string;
                   url: string;
                   loginRequired: boolean;
+                  status: LinkStatusEnum;
                 }
               | { __typename: "DigitalArticleService"; issn: string }
               | {
@@ -4126,6 +4168,7 @@ export type RecommendFromFaustQuery = {
                   origin: string;
                   url: string;
                   loginRequired: boolean;
+                  status: LinkStatusEnum;
                 }
               | { __typename: "DigitalArticleService"; issn: string }
               | {
@@ -4311,6 +4354,7 @@ export type SearchWithPaginationQuery = {
                 origin: string;
                 url: string;
                 loginRequired: boolean;
+                status: LinkStatusEnum;
               }
             | { __typename: "DigitalArticleService"; issn: string }
             | {
@@ -4434,6 +4478,7 @@ export type SearchWithPaginationQuery = {
                 origin: string;
                 url: string;
                 loginRequired: boolean;
+                status: LinkStatusEnum;
               }
             | { __typename: "DigitalArticleService"; issn: string }
             | {
@@ -4557,6 +4602,7 @@ export type SearchWithPaginationQuery = {
                 origin: string;
                 url: string;
                 loginRequired: boolean;
+                status: LinkStatusEnum;
               }
             | { __typename: "DigitalArticleService"; issn: string }
             | {
@@ -4789,6 +4835,7 @@ export type ComplexSearchWithPaginationQuery = {
                 origin: string;
                 url: string;
                 loginRequired: boolean;
+                status: LinkStatusEnum;
               }
             | { __typename: "DigitalArticleService"; issn: string }
             | {
@@ -4912,6 +4959,7 @@ export type ComplexSearchWithPaginationQuery = {
                 origin: string;
                 url: string;
                 loginRequired: boolean;
+                status: LinkStatusEnum;
               }
             | { __typename: "DigitalArticleService"; issn: string }
             | {
@@ -5035,6 +5083,7 @@ export type ComplexSearchWithPaginationQuery = {
                 origin: string;
                 url: string;
                 loginRequired: boolean;
+                status: LinkStatusEnum;
               }
             | { __typename: "DigitalArticleService"; issn: string }
             | {
@@ -5270,6 +5319,7 @@ export type ManifestationsSimpleFragment = {
           origin: string;
           url: string;
           loginRequired: boolean;
+          status: LinkStatusEnum;
         }
       | { __typename: "DigitalArticleService"; issn: string }
       | {
@@ -5387,6 +5437,7 @@ export type ManifestationsSimpleFragment = {
           origin: string;
           url: string;
           loginRequired: boolean;
+          status: LinkStatusEnum;
         }
       | { __typename: "DigitalArticleService"; issn: string }
       | {
@@ -5504,6 +5555,7 @@ export type ManifestationsSimpleFragment = {
           origin: string;
           url: string;
           loginRequired: boolean;
+          status: LinkStatusEnum;
         }
       | { __typename: "DigitalArticleService"; issn: string }
       | {
@@ -5650,6 +5702,7 @@ export type ManifestationsSimpleFieldsFragment = {
         origin: string;
         url: string;
         loginRequired: boolean;
+        status: LinkStatusEnum;
       }
     | { __typename: "DigitalArticleService"; issn: string }
     | {
@@ -5912,6 +5965,7 @@ export type WorkSmallFragment = {
             origin: string;
             url: string;
             loginRequired: boolean;
+            status: LinkStatusEnum;
           }
         | { __typename: "DigitalArticleService"; issn: string }
         | {
@@ -6035,6 +6089,7 @@ export type WorkSmallFragment = {
             origin: string;
             url: string;
             loginRequired: boolean;
+            status: LinkStatusEnum;
           }
         | { __typename: "DigitalArticleService"; issn: string }
         | {
@@ -6158,6 +6213,7 @@ export type WorkSmallFragment = {
             origin: string;
             url: string;
             loginRequired: boolean;
+            status: LinkStatusEnum;
           }
         | { __typename: "DigitalArticleService"; issn: string }
         | {
@@ -6379,6 +6435,7 @@ export type WorkMediumFragment = {
             origin: string;
             url: string;
             loginRequired: boolean;
+            status: LinkStatusEnum;
           }
         | { __typename: "DigitalArticleService"; issn: string }
         | {
@@ -6502,6 +6559,7 @@ export type WorkMediumFragment = {
             origin: string;
             url: string;
             loginRequired: boolean;
+            status: LinkStatusEnum;
           }
         | { __typename: "DigitalArticleService"; issn: string }
         | {
@@ -6625,6 +6683,7 @@ export type WorkMediumFragment = {
             origin: string;
             url: string;
             loginRequired: boolean;
+            status: LinkStatusEnum;
           }
         | { __typename: "DigitalArticleService"; issn: string }
         | {
@@ -6898,6 +6957,7 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
       origin
       url
       loginRequired
+      status
     }
     ... on InfomediaService {
       id


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-502

#### Description

This PR refactors how we get the correct access element before rendering the external manifestation link button. By making sure that we find the access element, which has the status as "OK", an inactive link will not get rendered.