### PR TITLE
DDFSAL-34 - Add material type to reservation tracking

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -26,7 +26,7 @@ import {
 import { UseConfigFunction } from "../../core/utils/config";
 import {
   flattenCreators,
-  getManifestationType,
+  getMaterialType,
   orderManifestationsByYear
 } from "../../core/utils/helpers/general";
 import { constructModalId } from "../../core/utils/helpers/modal-helpers";
@@ -68,7 +68,7 @@ export const getManifestationsOrderByTypeAndYear = (
 export const filterManifestationsByType = (
   type: string,
   manifestations: Manifestation[]
-) => manifestations.filter((item) => getManifestationType([item]) === type);
+) => manifestations.filter((item) => getMaterialType([item]) === type);
 
 export const getManifestationsFromType = (
   type: string,

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
   getAllFaustIds,
-  getManifestationType,
+  getMaterialType,
   getMaterialTypes
 } from "../../core/utils/helpers/general";
 import {
@@ -70,7 +70,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             access={access}
             selected={
               selectedManifestations &&
-              materialType === getManifestationType(selectedManifestations)
+              materialType === getMaterialType(selectedManifestations)
             }
             handleSelectManifestation={
               setSelectedManifestations

--- a/src/components/availability-label/availability-labels.tsx
+++ b/src/components/availability-label/availability-labels.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   getAllFaustIds,
+  getManifestationType,
   getMaterialTypes
 } from "../../core/utils/helpers/general";
 import {
@@ -69,7 +70,7 @@ export const AvailabilityLabels: React.FC<AvailabilityLabelsProps> = ({
             access={access}
             selected={
               selectedManifestations &&
-              materialType === getMaterialTypes(selectedManifestations)[0]
+              materialType === getManifestationType(selectedManifestations)
             }
             handleSelectManifestation={
               setSelectedManifestations

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -3,7 +3,7 @@ import { getAllIdentifiers } from "../../../apps/material/helper";
 import { AccessTypeCodeEnum } from "../../../core/dbc-gateway/generated/graphql";
 import {
   getAllPids,
-  getManifestationType
+  getMaterialType
 } from "../../../core/utils/helpers/general";
 import { Manifestation } from "../../../core/utils/types/entities";
 import { hasCorrectAccessType } from "../material-buttons/helper";
@@ -19,7 +19,7 @@ interface Props {
 
 const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
   const t = useText();
-  const materialType = getManifestationType(manifestations);
+  const materialType = getMaterialType(manifestations);
   const isbns = getAllIdentifiers(manifestations);
   const { materialIsReservableFromAnotherLibrary } =
     useReservableFromAnotherLibrary(manifestations);

--- a/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
+++ b/src/components/material/MaterialAvailabilityText/MaterialAvailabilityText.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
-import { head } from "lodash";
 import { getAllIdentifiers } from "../../../apps/material/helper";
 import { AccessTypeCodeEnum } from "../../../core/dbc-gateway/generated/graphql";
 import {
   getAllPids,
-  getMaterialTypes
+  getManifestationType
 } from "../../../core/utils/helpers/general";
 import { Manifestation } from "../../../core/utils/types/entities";
 import { hasCorrectAccessType } from "../material-buttons/helper";
@@ -20,7 +19,7 @@ interface Props {
 
 const MaterialAvailabilityText: React.FC<Props> = ({ manifestations }) => {
   const t = useText();
-  const materialType = head(getMaterialTypes(manifestations));
+  const materialType = getManifestationType(manifestations);
   const isbns = getAllIdentifiers(manifestations);
   const { materialIsReservableFromAnotherLibrary } =
     useReservableFromAnotherLibrary(manifestations);

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import { AccessTypeCodeEnum } from "../../../core/dbc-gateway/generated/graphql";
 import {
   getAllFaustIds,
-  getManifestationType
+  getMaterialType
 } from "../../../core/utils/helpers/general";
 import { ButtonSize } from "../../../core/utils/types/button";
 import { Manifestation } from "../../../core/utils/types/entities";
@@ -42,7 +42,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
     return (
       <MaterialButtonReservableFromAnotherLibrary
         size={size}
-        manifestationMaterialType={getManifestationType(manifestations)}
+        manifestationMaterialType={getMaterialType(manifestations)}
         faustIds={faustIds}
       />
     );

--- a/src/components/material/material-buttons/online/MaterialButtonsOnlineInternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnlineInternal.tsx
@@ -9,7 +9,7 @@ import { ButtonSize } from "../../../../core/utils/types/button";
 import useReaderPlayer from "../../../../core/utils/useReaderPlayer";
 import LinkButton from "../../../Buttons/LinkButton";
 import { Button } from "../../../Buttons/Button";
-import { getManifestationType } from "../../../../core/utils/helpers/general";
+import { getMaterialType } from "../../../../core/utils/helpers/general";
 import { RequestStatus } from "../../../../core/utils/types/request";
 import DeleteReservationModal, {
   deleteReservationModalId
@@ -63,7 +63,7 @@ const MaterialButtonsOnlineInternal: FC<MaterialButtonsOnlineInternalType> = ({
   const [reservationToDelete, setReservationToDelete] =
     useState<ReservationType | null>(null);
 
-  const manifestationType = getManifestationType(manifestations);
+  const manifestationType = getMaterialType(manifestations);
   const reseveLabel = openModal
     ? t("reserveWithMaterialTypeText", {
         placeholders: { "@materialType": manifestationType }

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {
   getAllFaustIds,
-  getManifestationType
+  getMaterialType
 } from "../../../../core/utils/helpers/general";
 import { isBlocked } from "../../../../core/utils/helpers/user";
 import { ButtonSize } from "../../../../core/utils/types/button";
@@ -64,7 +64,7 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
     return (
       <MaterialButtonReservePhysical
         dataCy={dataCy}
-        manifestationMaterialType={getManifestationType(manifestations)}
+        manifestationMaterialType={getMaterialType(manifestations)}
         faustIds={faustIds}
         size={size}
       />

--- a/src/components/reservation/OnlineInternalModalBody.tsx
+++ b/src/components/reservation/OnlineInternalModalBody.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import {
   getAllFaustIds,
-  getManifestationType
+  getMaterialType
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
 import { Cover } from "../cover/cover";
@@ -39,7 +39,7 @@ const OnlineInternalModalBody = ({
   const [reservationOrLoanErrorResponse, setReservationOrLoanErrorResponse] =
     useState<ApiResult | null>(null);
 
-  const manifestationType = getManifestationType(selectedManifestations);
+  const manifestationType = getMaterialType(selectedManifestations);
   const faustIds = getAllFaustIds(selectedManifestations);
   const manifestation = selectedManifestations[0];
   const authorLine = getAuthorLine(manifestation, t);
@@ -138,7 +138,7 @@ const OnlineInternalModalBody = ({
           <Cover ids={[manifestation.pid]} size="medium" animate />
           <div className="reservation-modal-description">
             <div className="reservation-modal-tag">
-              {getManifestationType(selectedManifestations)}
+              {getMaterialType(selectedManifestations)}
             </div>
             <h2 className="text-header-h2 mt-22 mb-8">
               {manifestation.titles.main}

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "react-query";
 import {
   convertPostIdsToFaustIds,
   getAllPids,
-  getManifestationType,
+  getMaterialType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
 import { useText } from "../../core/utils/text";
@@ -112,7 +112,7 @@ export const ReservationModalBody = ({
     blacklistBranchesInstantLoan.concat(blacklistPickupBranches)
   );
 
-  const mainManifestationType = getManifestationType(selectedManifestations);
+  const mainManifestationType = getMaterialType(selectedManifestations);
   const { reservableManifestations } = UseReservableManifestations({
     manifestations: selectedManifestations,
     type: mainManifestationType
@@ -168,7 +168,7 @@ export const ReservationModalBody = ({
   const interestPeriod =
     selectedInterest || interestPeriods.defaultInterestPeriod.value;
   const expiryDate = getFutureDateString(interestPeriod);
-  const materialType = getManifestationType(selectedManifestations);
+  const materialType = getMaterialType(selectedManifestations);
 
   const saveReservation = () => {
     if (manifestationsToReserve?.length) {

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { first } from "lodash";
 import Various from "@danskernesdigitalebibliotek/dpl-design-system/build/icons/collection/Various.svg";
 import { useQueryClient } from "react-query";
 import {
@@ -40,8 +41,7 @@ import {
   getInstantLoanBranchHoldings,
   getInstantLoanBranchHoldingsAboveThreshold,
   removePrefixFromBranchId,
-  translateOpenOrderStatus,
-  getFirstAuthorLine
+  translateOpenOrderStatus
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
 import { PeriodicalEdition } from "../material/periodical/helper";
@@ -161,7 +161,7 @@ export const ReservationModalBody = ({
   const holdings = getTotalHoldings(holdingsData);
   const reservations = getTotalReservations(holdingsData);
   const { patron } = userData;
-  const authorLine = getFirstAuthorLine(selectedManifestations, t);
+  const authorLine = getAuthorLine(first(selectedManifestations), t);
   const interestPeriods = config<Periods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -168,6 +168,7 @@ export const ReservationModalBody = ({
   const interestPeriod =
     selectedInterest || interestPeriods.defaultInterestPeriod.value;
   const expiryDate = getFutureDateString(interestPeriod);
+  const materialType = getMaterialTypes(selectedManifestations)[0];
 
   const saveReservation = () => {
     if (manifestationsToReserve?.length) {
@@ -189,7 +190,7 @@ export const ReservationModalBody = ({
             track("click", {
               id: statistics.reservation.id,
               name: statistics.reservation.name,
-              trackedData: work.workId
+              trackedData: `${work.workId} ${materialType}`
             });
             // This state is used to show the success or error modal.
             setReservationResponse(res);
@@ -269,9 +270,7 @@ export const ReservationModalBody = ({
           <header className="reservation-modal-header">
             <Cover ids={[manifestation.pid]} size="medium" animate />
             <div className="reservation-modal-description">
-              <div className="reservation-modal-tag">
-                {getMaterialTypes(selectedManifestations)[0]}
-              </div>
+              <div className="reservation-modal-tag">{materialType}</div>
               <h2 className="text-header-h2 mt-22 mb-8">
                 {getManifestationTitle(manifestation)}
                 {selectedPeriodical && ` ${selectedPeriodical.displayText}`}

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from "react-query";
 import {
   convertPostIdsToFaustIds,
   getAllPids,
-  getMaterialTypes,
   getManifestationType,
   materialIsFiction
 } from "../../core/utils/helpers/general";
@@ -169,7 +168,7 @@ export const ReservationModalBody = ({
   const interestPeriod =
     selectedInterest || interestPeriods.defaultInterestPeriod.value;
   const expiryDate = getFutureDateString(interestPeriod);
-  const materialType = getMaterialTypes(selectedManifestations)[0];
+  const materialType = getManifestationType(selectedManifestations);
 
   const saveReservation = () => {
     if (manifestationsToReserve?.length) {

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -41,7 +41,8 @@ import {
   getInstantLoanBranchHoldings,
   getInstantLoanBranchHoldingsAboveThreshold,
   removePrefixFromBranchId,
-  translateOpenOrderStatus
+  translateOpenOrderStatus,
+  getFirstAuthorLine
 } from "./helper";
 import UseReservableManifestations from "../../core/utils/UseReservableManifestations";
 import { PeriodicalEdition } from "../material/periodical/helper";
@@ -161,7 +162,7 @@ export const ReservationModalBody = ({
   const holdings = getTotalHoldings(holdingsData);
   const reservations = getTotalReservations(holdingsData);
   const { patron } = userData;
-  const authorLine = getAuthorLine(selectedManifestations[0], t);
+  const authorLine = getFirstAuthorLine(selectedManifestations, t);
   const interestPeriods = config<Periods>("interestPeriodsConfig", {
     transformer: "jsonParse"
   });

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -1,4 +1,5 @@
 import { UseTextFunction } from "../../core/utils/text";
+import { first } from "lodash";
 import {
   AgencyBranch,
   CreateReservation,
@@ -137,6 +138,18 @@ export const getAuthorLine = (
   return !author
     ? null
     : [t("materialHeaderAuthorByText"), author, year].join(" ");
+};
+
+export const getFirstAuthorLine = (
+  selectedManifestations: Manifestation[],
+  t: UseTextFunction
+) => {
+  const firstSelectedManifestation = first(selectedManifestations);
+  if (firstSelectedManifestation) {
+    return getAuthorLine(firstSelectedManifestation, t);
+  }
+  // This should never happen. Therefore, it’s not translated.
+  return "Unknown";
 };
 
 export const getManifestationsToReserve = (

--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -1,5 +1,4 @@
 import { UseTextFunction } from "../../core/utils/text";
-import { first } from "lodash";
 import {
   AgencyBranch,
   CreateReservation,
@@ -121,9 +120,16 @@ export const constructReservationData = ({
 };
 
 export const getAuthorLine = (
-  manifestation: Manifestation,
+  manifestation: Manifestation | undefined,
   t: UseTextFunction
 ) => {
+  // Manifestation may be undefined if it is retrieved from an array which might
+  // be empty.
+  if (manifestation === undefined) {
+    // This should never happen. Therefore, it’s not translated.
+    return [t("materialHeaderAuthorByText"), "Unknown"].join(" ");
+  }
+
   const { creators } = manifestation;
   const publicationYear = getManifestationPublicationYear(manifestation);
   const author = creatorsToString(flattenCreators(creators), t) || null;
@@ -138,18 +144,6 @@ export const getAuthorLine = (
   return !author
     ? null
     : [t("materialHeaderAuthorByText"), author, year].join(" ");
-};
-
-export const getFirstAuthorLine = (
-  selectedManifestations: Manifestation[],
-  t: UseTextFunction
-) => {
-  const firstSelectedManifestation = first(selectedManifestations);
-  if (firstSelectedManifestation) {
-    return getAuthorLine(firstSelectedManifestation, t);
-  }
-  // This should never happen. Therefore, it’s not translated.
-  return "Unknown";
 };
 
 export const getManifestationsToReserve = (

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -381,7 +381,12 @@ export const getMaterialTypes = (
 
 export const getManifestationType = (manifestations: Manifestation[]) => {
   const uniqueTypes = getMaterialTypes(manifestations);
-  return uniqueTypes[0];
+  const firstUniqueType = first(uniqueTypes);
+  if (firstUniqueType) {
+    return firstUniqueType;
+  }
+  // This should never happen.
+  return "Unknown" as ManifestationMaterialType;
 };
 
 export const getAllPids = (manifestations: Manifestation[]) => {

--- a/src/core/utils/helpers/general.ts
+++ b/src/core/utils/helpers/general.ts
@@ -379,7 +379,7 @@ export const getMaterialTypes = (
   ) as ManifestationMaterialType[];
 };
 
-export const getManifestationType = (manifestations: Manifestation[]) => {
+export const getMaterialType = (manifestations: Manifestation[]) => {
   const uniqueTypes = getMaterialTypes(manifestations);
   const firstUniqueType = first(uniqueTypes);
   if (firstUniqueType) {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-34
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2168

#### Description
Updated reservation tracking to include material type. 

This change ensures that libraries have the necessary data for proper tracking, as workId alone was not sufficient.


I went down a bit of a rabbit hole by not using [0] on arrays, as Copilot first commented, since it may be undefined. This led to some changes that are not ticket-relevant but improve the current code. My Git commit should be descriptive of why I made the changes.

I have chosen to ignore the last Copilot suggestions, as I don’t think they are relevant.

#### Test
https://varnish.pr-2168.dpl-cms.dplplat01.dpl.reload.dk/
