### PR TITLE
DDFSAL-36 - Track click to open reservation modal for specific manifestation

### DIFF
--- a/src/components/material/MaterialMainfestationItem.tsx
+++ b/src/components/material/MaterialMainfestationItem.tsx
@@ -176,6 +176,7 @@ const MaterialMainfestationItem: FC<MaterialMainfestationItemProps> = ({
           size="small"
           workId={workId}
           materialTitleId={mainfestationTitleId}
+          isSpecificManifestation
         />
       </div>
     </div>

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -43,6 +43,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   if (materialIsReservableFromAnotherLibrary) {
     return (
       <MaterialButtonReservableFromAnotherLibrary
+        workId={workId}
         size={size}
         manifestationMaterialType={getMaterialType(manifestations)}
         faustIds={faustIds}

--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -21,6 +21,7 @@ export interface MaterialButtonsProps {
   workId: WorkId;
   dataCy?: string;
   materialTitleId: string;
+  isSpecificManifestation?: boolean;
 }
 
 const MaterialButtons: FC<MaterialButtonsProps> = ({
@@ -28,7 +29,8 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   size,
   workId,
   dataCy = "material-buttons",
-  materialTitleId
+  materialTitleId,
+  isSpecificManifestation = false
 }) => {
   const faustIds = getAllFaustIds(manifestations);
   // We don't want to show physical buttons/find on shelf for articles because
@@ -57,6 +59,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
               manifestations={manifestations}
               size={size}
               dataCy={`${dataCy}-physical`}
+              isSpecificManifestation={isSpecificManifestation}
             />
             <MaterialButtonsFindOnShelf
               size={size}

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -37,8 +37,8 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   const onClick = () => {
     if (isSpecificManifestation && first(pids)) {
       track("click", {
-        id: statistics.specificManifestation.id,
-        name: statistics.specificManifestation.name,
+        id: statistics.reserveSpecificManifestation.id,
+        name: statistics.reserveSpecificManifestation.name,
         trackedData: `${first(pids)}`
       });
     }

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -3,23 +3,31 @@ import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { reservationModalId } from "../../../../apps/material/helper";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { FaustId } from "../../../../core/utils/types/ids";
+import { FaustId, Pid } from "../../../../core/utils/types/ids";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
+import { useStatistics } from "../../../../core/statistics/useStatistics";
+import { statistics } from "../../../../core/statistics/statistics";
+import { first } from "lodash";
 
 export interface MaterialButtonPhysicalProps {
   manifestationMaterialType: string;
   size?: ButtonSize;
   faustIds: FaustId[];
   dataCy?: string;
+  isSpecificManifestation?: boolean;
+  pids: Pid[];
 }
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   manifestationMaterialType,
   faustIds,
   size,
-  dataCy = "material-button-physical"
+  dataCy = "material-button-physical",
+  isSpecificManifestation,
+  pids
 }) => {
+  const { track } = useStatistics();
   const t = useText();
   const u = useUrls();
   const authUrl = u("authUrl");
@@ -27,6 +35,13 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   const { openGuarded } = useModalButtonHandler();
 
   const onClick = () => {
+    if (isSpecificManifestation && first(pids)) {
+      track("click", {
+        id: statistics.specificManifestation.id,
+        name: statistics.specificManifestation.name,
+        trackedData: `${first(pids)}`
+      });
+    }
     openGuarded({
       authUrl,
       modalId: reservationModalId(faustIds)

--- a/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonPhysical.tsx
@@ -3,17 +3,18 @@ import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { reservationModalId } from "../../../../apps/material/helper";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { FaustId, Pid } from "../../../../core/utils/types/ids";
+import { Pid } from "../../../../core/utils/types/ids";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
 import { useStatistics } from "../../../../core/statistics/useStatistics";
 import { statistics } from "../../../../core/statistics/statistics";
 import { first } from "lodash";
+import { convertPostIdsToFaustIds } from "../../../../core/utils/helpers/general";
 
 export interface MaterialButtonPhysicalProps {
   manifestationMaterialType: string;
   size?: ButtonSize;
-  faustIds: FaustId[];
+
   dataCy?: string;
   isSpecificManifestation?: boolean;
   pids: Pid[];
@@ -21,7 +22,6 @@ export interface MaterialButtonPhysicalProps {
 
 const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   manifestationMaterialType,
-  faustIds,
   size,
   dataCy = "material-button-physical",
   isSpecificManifestation,
@@ -31,7 +31,7 @@ const MaterialButtonPhysical: FC<MaterialButtonPhysicalProps> = ({
   const t = useText();
   const u = useUrls();
   const authUrl = u("authUrl");
-
+  const faustIds = convertPostIdsToFaustIds(pids);
   const { openGuarded } = useModalButtonHandler();
 
   const onClick = () => {

--- a/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
@@ -3,15 +3,18 @@ import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { reservationModalId } from "../../../../apps/material/helper";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { FaustId } from "../../../../core/utils/types/ids";
+import { FaustId, WorkId } from "../../../../core/utils/types/ids";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
+import { useStatistics } from "../../../../core/statistics/useStatistics";
+import { statistics } from "../../../../core/statistics/statistics";
 
 export interface MaterialButtonReservableFromAnotherLibraryProps {
   manifestationMaterialType: string;
   size?: ButtonSize;
   faustIds: FaustId[];
   dataCy?: string;
+  workId: WorkId;
 }
 
 const MaterialButtonReservableFromAnotherLibrary: FC<
@@ -20,15 +23,21 @@ const MaterialButtonReservableFromAnotherLibrary: FC<
   manifestationMaterialType,
   faustIds,
   size,
-  dataCy = "material-button-reservable-on-another-library"
+  dataCy = "material-button-reservable-on-another-library",
+  workId
 }) => {
   const t = useText();
   const u = useUrls();
   const authUrl = u("authUrl");
-
+  const { track } = useStatistics();
   const { openGuarded } = useModalButtonHandler();
 
   const onClick = () => {
+    track("click", {
+      id: statistics.orderFromAnotherLibrary.id,
+      name: statistics.orderFromAnotherLibrary.name,
+      trackedData: `${workId} ${manifestationMaterialType}`
+    });
     openGuarded({
       authUrl,
       modalId: reservationModalId(faustIds)

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -69,7 +69,6 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
       <MaterialButtonReservePhysical
         dataCy={dataCy}
         manifestationMaterialType={getMaterialType(manifestations)}
-        faustIds={faustIds}
         size={size}
         isSpecificManifestation={isSpecificManifestation}
         pids={pids}

--- a/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonsPhysical.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   getAllFaustIds,
+  getAllPids,
   getMaterialType
 } from "../../../../core/utils/helpers/general";
 import { isBlocked } from "../../../../core/utils/helpers/user";
@@ -20,16 +21,19 @@ export interface MaterialButtonsPhysicalProps {
   manifestations: Manifestation[];
   size?: ButtonSize;
   dataCy?: string;
+  isSpecificManifestation?: boolean;
 }
 
 const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
   manifestations,
   size,
-  dataCy = "material-buttons-physical"
+  dataCy = "material-buttons-physical",
+  isSpecificManifestation
 }) => {
   const t = useText();
   const config = useConfig();
   const faustIds = getAllFaustIds(manifestations);
+  const pids = getAllPids(manifestations);
   // We extract loading of Availability here, as it isn't possible within
   // UseReservableManifestations. React query uses cached version of the data
   // so we can determine if the request inside UseReservableManifestations is
@@ -67,6 +71,8 @@ const MaterialButtonsPhysical: React.FC<MaterialButtonsPhysicalProps> = ({
         manifestationMaterialType={getMaterialType(manifestations)}
         faustIds={faustIds}
         size={size}
+        isSpecificManifestation={isSpecificManifestation}
+        pids={pids}
       />
     );
   }

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -31,7 +31,10 @@ export const statistics: Statistics = {
 
   // Material
   findOnShelf: { id: 108, name: "Klik på ”Find på hylden”" },
-  specificManifestation: { id: 109, name: "Klik på specifik manifestation" }
+  reserveSpecificManifestation: {
+    id: 109,
+    name: "Klik på specifik manifestation"
+  }
 };
 
 export default {};

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -30,6 +30,7 @@ export const statistics: Statistics = {
   addToFavorites: { id: 61, name: "Tilføj til liste" },
 
   // Material
+  orderFromAnotherLibrary: { id: 70, name: "Bestil fra andet bibliotek" },
   findOnShelf: { id: 108, name: "Klik på ”Find på hylden”" },
   reserveSpecificManifestation: {
     id: 109,

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -30,7 +30,8 @@ export const statistics: Statistics = {
   addToFavorites: { id: 61, name: "Tilføj til liste" },
 
   // Material
-  findOnShelf: { id: 108, name: "Klik på ”Find på hylden”" }
+  findOnShelf: { id: 108, name: "Klik på ”Find på hylden”" },
+  specificManifestation: { id: 109, name: "Klik på specifik manifestation" }
 };
 
 export default {};


### PR DESCRIPTION
#### Links
https://reload.atlassian.net/browse/DDFSAL-36
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2186
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2186

#### Description
This tracks when the modal is opened for a specific manifestation, not the actual reservation itself, which we already track with `statistics.reservation`.


#### Test
https://varnish.pr-2186.dpl-cms.dplplat01.dpl.reload.dk/