### PR TITLE
Upgrade codecov action to version 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,6 @@ jobs:
     name: Integration test
     if: "!github.event.deleted"
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1
-      options: --user 1001
     env:
       TZ: Europe/Copenhagen
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate code coverage report
         run: yarn run nyc report --reporter=clover --reporter=text --report-dir=./coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate code coverage report
         run: yarn run nyc report --reporter=clover --reporter=text --report-dir=./coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/
           flags: integration
           fail_ci_if_error: false


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFBRA-323

#### Description

This PR upgrades the usage of codecov in our Github action to version 5.
While upgrading I discovered that it is now required to use an access token, which has been added to the repo.
I also discovered that the action was running inside a limited cypress container, which did not have the required packages available. As the cypress container was added to address a Chrome bug, that has since been fixed, it could be safely removed.
