### PR TITLE
DDFSAL-37 - Track click to open "reserve from another library" modal

### DIFF
--- a/src/components/material/material-buttons/MaterialButtons.tsx
+++ b/src/components/material/material-buttons/MaterialButtons.tsx
@@ -43,6 +43,7 @@ const MaterialButtons: FC<MaterialButtonsProps> = ({
   if (materialIsReservableFromAnotherLibrary) {
     return (
       <MaterialButtonReservableFromAnotherLibrary
+        workId={workId}
         size={size}
         manifestationMaterialType={getMaterialType(manifestations)}
         faustIds={faustIds}

--- a/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
+++ b/src/components/material/material-buttons/physical/MaterialButtonReservableFromAnotherLibrary.tsx
@@ -3,15 +3,18 @@ import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { reservationModalId } from "../../../../apps/material/helper";
 import { useText } from "../../../../core/utils/text";
 import { ButtonSize } from "../../../../core/utils/types/button";
-import { FaustId } from "../../../../core/utils/types/ids";
+import { FaustId, WorkId } from "../../../../core/utils/types/ids";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
+import { useStatistics } from "../../../../core/statistics/useStatistics";
+import { statistics } from "../../../../core/statistics/statistics";
 
 export interface MaterialButtonReservableFromAnotherLibraryProps {
   manifestationMaterialType: string;
   size?: ButtonSize;
   faustIds: FaustId[];
   dataCy?: string;
+  workId: WorkId;
 }
 
 const MaterialButtonReservableFromAnotherLibrary: FC<
@@ -20,15 +23,21 @@ const MaterialButtonReservableFromAnotherLibrary: FC<
   manifestationMaterialType,
   faustIds,
   size,
-  dataCy = "material-button-reservable-on-another-library"
+  dataCy = "material-button-reservable-on-another-library",
+  workId
 }) => {
   const t = useText();
   const u = useUrls();
   const authUrl = u("authUrl");
-
+  const { track } = useStatistics();
   const { openGuarded } = useModalButtonHandler();
 
   const onClick = () => {
+    track("click", {
+      id: statistics.orderFromAnotherLibrary.id,
+      name: statistics.orderFromAnotherLibrary.name,
+      trackedData: `${workId} ${manifestationMaterialType}`
+    });
     openGuarded({
       authUrl,
       modalId: reservationModalId(faustIds)

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -30,6 +30,7 @@ export const statistics: Statistics = {
   addToFavorites: { id: 61, name: "Tilføj til liste" },
 
   // Material
+  orderFromAnotherLibrary: { id: 70, name: "Bestil fra andet bibliotek" },
   findOnShelf: { id: 108, name: "Klik på ”Find på hylden”" },
   specificManifestation: { id: 109, name: "Klik på specifik manifestation" }
 };


### PR DESCRIPTION
#### Links
https://reload.atlassian.net/browse/DDFSAL-37
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2193
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2193

#### Description

This tracks when the modal is opened for reserving from another library, not the actual reservation itself, which is already tracked with `statistics.reservation`.

#### Test

https://varnish.pr-2193.dpl-cms.dplplat01.dpl.reload.dk/