### PR TITLE
DDFSAL-45 - Track click on recommended material

### DIFF
--- a/src/components/atoms/links/LinkNoStyle.tsx
+++ b/src/components/atoms/links/LinkNoStyle.tsx
@@ -9,6 +9,7 @@ export interface LinkNoStyleProps {
   dataCy?: string;
   ariaLabelledBy?: string;
   isHiddenFromScreenReaders?: boolean;
+  trackClick?: () => Promise<unknown>;
 }
 
 const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
@@ -18,7 +19,8 @@ const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
   className,
   dataCy = "link-no-style",
   ariaLabelledBy,
-  isHiddenFromScreenReaders
+  isHiddenFromScreenReaders,
+  trackClick
 }) => {
   return (
     <Link
@@ -28,6 +30,7 @@ const LinkNoStyle: React.FC<LinkNoStyleProps> = ({
       dataCy={dataCy}
       ariaLabelledBy={ariaLabelledBy}
       isHiddenFromScreenReaders={isHiddenFromScreenReaders}
+      trackClick={trackClick}
     >
       {children}
     </Link>

--- a/src/components/cover/cover.tsx
+++ b/src/components/cover/cover.tsx
@@ -23,6 +23,7 @@ export type CoverProps = {
   idType?: GetCoverCollectionType;
   shadow?: "small" | "medium";
   linkAriaLabelledBy?: string;
+  trackClick?: () => Promise<unknown>;
 };
 
 export const Cover = ({
@@ -36,7 +37,8 @@ export const Cover = ({
   bestRepresentation,
   idType = "pid",
   shadow,
-  linkAriaLabelledBy
+  linkAriaLabelledBy,
+  trackClick
 }: CoverProps) => {
   const [imageLoaded, setImageLoaded] = useState<boolean | null>(null);
   const handleSetImageLoaded = useCallback(() => {
@@ -92,6 +94,7 @@ export const Cover = ({
         url={url}
         ariaLabelledBy={linkAriaLabelledBy}
         isHiddenFromScreenReaders={!alt}
+        trackClick={trackClick}
       >
         {coverSrc && (
           <CoverImage

--- a/src/components/recommended-material/recommended-material.tsx
+++ b/src/components/recommended-material/recommended-material.tsx
@@ -22,6 +22,8 @@ import { Work } from "../../core/utils/types/entities";
 import { WorkId } from "../../core/utils/types/ids";
 import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 import { useUrls } from "../../core/utils/url";
+import { useEventStatistics } from "../../core/statistics/useStatistics";
+import { statistics } from "../../core/statistics/statistics";
 
 export type RecommendedMaterialProps = {
   wid: WorkId;
@@ -36,6 +38,7 @@ const RecommendedMaterialComp: React.FC<RecommendedMaterialProps> = ({
 }) => {
   const t = useText();
   const u = useUrls();
+  const { track } = useEventStatistics();
   const materialUrl = u("materialUrl");
   const dispatch = useDispatch<TypedDispatch>();
   const queryClient = useQueryClient();
@@ -76,6 +79,13 @@ const RecommendedMaterialComp: React.FC<RecommendedMaterialProps> = ({
     );
   };
 
+  const trackData = () =>
+    track("click", {
+      id: statistics.recommendedMaterial.id,
+      name: statistics.recommendedMaterial.name,
+      trackedData: wid
+    });
+
   return (
     <div
       className={clsx(
@@ -97,12 +107,14 @@ const RecommendedMaterialComp: React.FC<RecommendedMaterialProps> = ({
         animate
         alt=""
         shadow="medium"
+        trackClick={trackData}
       />
       <div className="recommended-material__texts">
         <Link
           href={materialFullUrl}
           className="recommended-material__description"
           dataCy="recommended-description"
+          trackClick={trackData}
         >
           {fullTitle}
         </Link>
@@ -110,6 +122,7 @@ const RecommendedMaterialComp: React.FC<RecommendedMaterialProps> = ({
           href={materialFullUrl}
           className="recommended-material__author"
           dataCy="recommended-author"
+          trackClick={trackData}
         >
           {author}
         </Link>

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -164,7 +164,13 @@ export const statistics: Statistics = {
     name: "Klik på LÆS/LYT (Publizon)",
     parameterName: ""
   },
-  publizonTry: { id: 84, name: "Klik på Prøv (Publizon)", parameterName: "" }
+  publizonTry: { id: 84, name: "Klik på Prøv (Publizon)", parameterName: "" },
+  // Paragraphs
+  recommendedMaterial: {
+    id: 74,
+    name: "Klik på recommended material",
+    parameterName: ""
+  }
 };
 
 export default {};

--- a/src/core/statistics/useStatistics.ts
+++ b/src/core/statistics/useStatistics.ts
@@ -69,6 +69,13 @@ export function usePageStatistics() {
     // Wait time based on intuition — not strictly calculated.
     // I've used 1000, 2500, and even 5000ms on the work page
     setTimeout(() => {
+      if (window.location.href.includes("dapple-cms")) {
+        // eslint-disable-next-line no-console
+        console.warn("⚠️ Mapp tracking is not enabled for dapple-cms");
+        // eslint-disable-next-line no-console, no-underscore-dangle
+        console.log("Tracking: send, page", JSON.stringify(window._ti));
+        return;
+      }
       if (!domain || !id) {
         // eslint-disable-next-line no-console
         console.warn("⚠️ Mapp Domain or ID is not defined");


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-45

#### Test
https://varnish.pr-2389.dpl-cms.dplplat01.dpl.reload.dk/paragraph-side

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2389
https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2389

#### Description
Implements click tracking for recommended materials.  
Since only one tracking ID is available at the moment, it's applied to all three links: cover, title, and author.
