### PR TITLE
DDFSAL-56 - Track CQL on search click in Advanced Search

### DIFF
--- a/src/apps/advanced-search/AdvancedSearchHeader.tsx
+++ b/src/apps/advanced-search/AdvancedSearchHeader.tsx
@@ -23,6 +23,8 @@ import {
 import { Button } from "../../components/Buttons/Button";
 import CheckBox from "../../components/checkbox/Checkbox";
 import { LocationFilter } from "./LocationFilter";
+import { useStatistics } from "../../core/statistics/useStatistics";
+import { statistics } from "../../core/statistics/statistics";
 
 export type AdvancedSearchHeaderProps = {
   dataCy?: string;
@@ -50,6 +52,7 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
   locationFilter
 }) => {
   const t = useText();
+  const { track } = useStatistics();
   const [isFormMode, setIsFormMode] = useState<boolean>(true);
   // Keep an internal copy of the search object in a separate state. We only
   // want to update the outer state and perform a search when the user clicks
@@ -103,6 +106,11 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
   };
   const handleSearchButtonClick = () => {
     if (rawCql.trim() !== "" && !isFormMode) {
+      track("click", {
+        id: statistics.advancedSearchTerm.id,
+        name: statistics.advancedSearchTerm.name,
+        trackedData: rawCql
+      });
       setSearchQuery(rawCql);
       // Half a second makes sure search result is rendered before scrolling to it.
       setTimeout(() => {
@@ -110,6 +118,11 @@ const AdvancedSearchHeader: React.FC<AdvancedSearchHeaderProps> = ({
       }, 500);
       return;
     }
+    track("click", {
+      id: statistics.advancedSearchTerm.id,
+      name: statistics.advancedSearchTerm.name,
+      trackedData: previewCql
+    });
     setSearchObject(internalSearchObject);
     // Half a second makes sure search result is rendered before scrolling to it.
     setTimeout(() => {

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -5,6 +5,9 @@
 type Statistics = Record<string, { id: number; name: string }>;
 
 export const statistics: Statistics = {
+  // advanced search
+  advancedSearchTerm: { id: 9, name: "Avanceret søgning søgeterm" },
+
   // Search flow
   searchQuery: { id: 10, name: "OSS" },
   searchResultCount: { id: 11, name: "OSS Results" },


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-56

#### Test
https://varnish.pr-2202.dpl-cms.dplplat01.dpl.reload.dk/advanced-search

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2202

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2202

#### Description
Implement tracking of CQL queries on Advanced Search
The `handleSearchButtonClick` function tracks search term using two different CQL sources depending on the user's interaction mode