### PR TITLE
Increase the limit of Facets being displayed to users to 50.

### DIFF
--- a/src/components/facet-line/FacetLine.tsx
+++ b/src/components/facet-line/FacetLine.tsx
@@ -17,7 +17,7 @@ const FacetLine: React.FunctionComponent<FacetLineProps> = ({ q }) => {
   const { data, isLoading } = useIntelligentFacetsQuery({
     q: { all: q },
     facetsLimit: 6,
-    valuesLimit: 5,
+    valuesLimit: 50,
     filters: createFilters(filters, cleanBranches)
   });
 


### PR DESCRIPTION

#### Link to issue

[Jira](https://reload.atlassian.net/jira/software/c/projects/DDFSAL/boards/539?selectedIssue=DDFSAL-12)

#### Description

The intend of this change is to allow users to see more facets, which was limited to 5.

I've decided to start with changing this limit to 50 to begin with.

Option lists in a <select/> element, and are not easily styled. Because of this, i've also decided to see if the native renders of these will suffice before changing more markup.



