### PR TITLE
Make codecov patch status informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,8 @@ coverage:
         # Use informational status checks as we do not have a hard policy
         # regarding code coverage at the moment.
         informational: true
+    patch:
+      default:
+        # Use informational status checks as we do not have a hard policy
+        # regarding code coverage at the moment.
+        informational: true


### PR DESCRIPTION
#### Description

Code coverage patch status has been missing for a while. Now that is it back we see it failing a lot.

Make it informational just as the project status is. This avoids the noice while stille keeping track of code coverage for future work.

See more documentation here: https://docs.codecov.com/docs/commit-status#patch-status

#1773 shows that this works while the original version of the change #1766 fails.

#### Screenshot of the result

Before:

![Monosnap WIP: DDFSAL-41 DDFSAL-42 DDFSAL-43 DDFSAL-44 - Track E-Materials (Publizon) by kasperbirch1 · Pull Request #1764 · danskernesdi… 2025-03-31 15-24-12](https://github.com/user-attachments/assets/d05a42d4-8e5a-47ae-8069-397c733faa7a)

After:

![dpl-react 2025-03-31 15-33-51](https://github.com/user-attachments/assets/b31325ce-3f09-4c18-8514-4f5dca3ac7ed)



#### Additional comments or questions

This was made relevant again after #1759 was merged. 