### PR TITLE
Don't render button if no active AccessUrl is found

### DIFF
--- a/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnline.tsx
@@ -65,7 +65,8 @@ const MaterialButtonsOnline: FC<MaterialButtonsOnlineProps> = ({
     );
 
     if (!accessElement) {
-      throw new Error("No access element found.");
+      // If there is no active access element, don't render anything.
+      return null;
     }
     const { origin, url: externalUrl } = accessElement as AccessUrl;
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFNEXT-777
https://reload.atlassian.net/browse/DDFNEXT-778

#### Description

It seems DBC sometimes returns manifestations where all access URLs have `status: BROKEN`. As we throw an error when no accessElement is found, this breaks the whole material page.
