### PR TITLE
Update `useSavePatron` to comply with new FBS API requirements

### DIFF
--- a/src/apps/patron-page/PatronPage.entry.tsx
+++ b/src/apps/patron-page/PatronPage.entry.tsx
@@ -71,6 +71,7 @@ interface PatronPageTextProps {
   pauseReservationModalSaveButtonLabelText: string;
   pickupBranchesDropdownLabelText: string;
   pickupBranchesDropdownNothingSelectedText: string;
+  userinfoUrl: string;
 }
 
 export interface PatronPageProps

--- a/src/apps/patron-page/PatronPage.stories.tsx
+++ b/src/apps/patron-page/PatronPage.stories.tsx
@@ -28,6 +28,9 @@ const meta: Meta<typeof PatronPage> = {
     ...globalTextArgTypes,
     ...globalConfigArgTypes,
     // Config
+    userinfoUrl: {
+      control: { type: "text" }
+    },
     pauseReservationStartDateConfig: {
       control: { type: "text" }
     },
@@ -198,6 +201,9 @@ const meta: Meta<typeof PatronPage> = {
     ...globalTextArgs,
     ...globalConfigArgs,
     // Config
+    // The  userinfoUrl is not a part of serviceUrlArgs because of historic reasons
+    // and because it is not a serviceUrl, but a url to the userinfo endpoint
+    userinfoUrl: "https://login.bib.dk/userinfo",
     pauseReservationStartDateConfig: "2022-06-30",
     blacklistedPickupBranchesConfig:
       "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024",

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -13,12 +13,14 @@ import { usePatronData } from "../../core/utils/helpers/usePatronData";
 import PatronPageSkeleton from "./PatronPageSkeleton";
 import useSavePatron from "../../core/utils/useSavePatron";
 import { Patron } from "../../core/utils/types/entities";
+import useUserInfo from "../../core/adgangsplatformen/useUserInfo";
 
 const PatronPage: FC = () => {
   const t = useText();
   const u = useUrls();
   const deletePatronUrl = u("deletePatronUrl");
   const { data: patronData, isLoading } = usePatronData();
+  const { data: userInfo } = useUserInfo();
   const [patron, setPatron] = useState<Patron | null>(null);
   const [pin, setPin] = useState<string | null>(null);
   const [isPinChangeValid, setIsPinChangeValid] = useState<boolean>(true);
@@ -29,6 +31,7 @@ const PatronPage: FC = () => {
   const [NotificationComponent, handleNotificationMessage] =
     useNotificationMessage();
   const { savePatron, savePincode } = useSavePatron({
+    userInfo,
     patron: patron || undefined,
     fetchHandlers: {
       savePatron: {

--- a/src/core/adgangsplatformen/useUserInfo.ts
+++ b/src/core/adgangsplatformen/useUserInfo.ts
@@ -9,7 +9,7 @@ import { ErrorType, fetcher } from "./fetcher";
 import { useUrls } from "../utils/url";
 import { getUserToken } from "../utils/helpers/user";
 
-type UserInfoData = {
+export type UserInfoData = {
   attributes: {
     cpr: number;
     userId: string;
@@ -21,6 +21,7 @@ type UserInfoData = {
     }[];
     municipality: `${number}`;
     municipalityAgencyId: `${number}`;
+    pincode: string;
   };
 };
 


### PR DESCRIPTION
#### Link to issue
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1808

#### Description
Update `useSavePatron` to comply with new FBS API requirements 
Following the API migration, `pincode` and `libraryCardNumber` must be provided to modify user data.