### PR TITLE
Add ´onshelf´ URL param to the filters of MaterialGridLinkAutomatic

### DIFF
--- a/src/apps/material-grid/link-automatic/MaterialGridLinkAutomatic.stories.tsx
+++ b/src/apps/material-grid/link-automatic/MaterialGridLinkAutomatic.stories.tsx
@@ -95,6 +95,24 @@ export const Primary: Story = {
   }
 };
 
+export const WithoutOnshelf: Story = {
+  args: {
+    ...Primary.args,
+    title: "All Availability",
+    description: "Includes materials regardless of on-shelf status",
+    link: "https://dapple-cms.docker/advanced-search?advancedSearchCql=%28lix%3D2+OR+lix%3D3+OR+lix%3D4+OR+lix%3D5+OR+let%3D8+OR+let%3D9+OR+let%3D10%29+AND+term.childrenoradults%3D%22til+b%C3%B8rn%22&linked=true"
+  }
+};
+
+export const WithOnshelfTrue: Story = {
+  args: {
+    ...Primary.args,
+    title: "On-Shelf Only",
+    description: "Filtered to show only materials currently on shelf",
+    link: "https://dapple-cms.docker/advanced-search?advancedSearchCql=%28lix%3D2+OR+lix%3D3+OR+lix%3D4+OR+lix%3D5+OR+let%3D8+OR+let%3D9+OR+let%3D10%29+AND+term.childrenoradults%3D%22til+b%C3%B8rn%22&onshelf=true&linked=true"
+  }
+};
+
 export const Skeleton: Story = {
   render: () => <MaterialGridSkeleton />
 };

--- a/src/apps/material-grid/link-automatic/MaterialGridLinkAutomatic.tsx
+++ b/src/apps/material-grid/link-automatic/MaterialGridLinkAutomatic.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
-import { useComplexSearchWithPaginationQuery } from "../../../core/dbc-gateway/generated/graphql";
-import useGetCleanBranches from "../../../core/utils/branches";
 import MaterialGrid from "../../../components/material-grid/MaterialGrid";
 import MaterialGridSkeleton from "../../../components/material-grid/MaterialGridSkeleton";
 import { ValidSelectedIncrements } from "../../../components/material-grid/materiel-grid-util";
+import {
+  HoldingsStatusEnum,
+  useComplexSearchWithPaginationQuery
+} from "../../../core/dbc-gateway/generated/graphql";
+import useGetCleanBranches from "../../../core/utils/branches";
 import { getQueryParams } from "../../../core/utils/helpers/url";
-import { commaSeparatedStringToArray } from "../../advanced-search/helpers";
-import { WorkId } from "../../../core/utils/types/ids";
 import { useText } from "../../../core/utils/text";
+import { WorkId } from "../../../core/utils/types/ids";
+import { commaSeparatedStringToArray } from "../../advanced-search/helpers";
 
 export type MaterialGridLinkAutomaticProps = {
   link: URL;
@@ -25,7 +28,8 @@ const MaterialGridLinkAutomatic: React.FC<MaterialGridLinkAutomaticProps> = ({
   const t = useText();
   const buttonText = t("buttonText");
   const cleanBranches = useGetCleanBranches();
-  const { advancedSearchCql, location, sublocation } = getQueryParams(link);
+  const { advancedSearchCql, location, sublocation, onshelf } =
+    getQueryParams(link);
 
   const { data, isLoading } = useComplexSearchWithPaginationQuery(
     {
@@ -39,7 +43,8 @@ const MaterialGridLinkAutomatic: React.FC<MaterialGridLinkAutomaticProps> = ({
           : {}),
         ...(sublocation
           ? { sublocation: commaSeparatedStringToArray(sublocation) }
-          : {})
+          : {}),
+        ...(onshelf === "true" ? { status: [HoldingsStatusEnum.Onshelf] } : {})
       }
     },
     {


### PR DESCRIPTION
#### Link to issue

[DDFSAL-89](https://reload.atlassian.net/browse/DDFSAL-89)

cms: https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2345

#### Description

This PR applies a fix for the `MaterialGridLinkAutomatic` URL links. This component/paragraph is supposed to consider the onshelf URL search param as specified [in this ticket](https://reload.atlassian.net/browse/DDFLSBP-654). It should do that now. 

Please test yourself by performing CQL search with onshelf on or not. Exampels can be found in the ticket. See stories aswell. 


lagoon test here https://varnish.pr-2345.dpl-cms.dplplat01.dpl.reload.dk/en-side-med-onshelf


[DDFSAL-89]: https://reload.atlassian.net/browse/DDFSAL-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ