### PR TITLE
DDFSAL-104 - Reservation on pause deletes contact information

### DIFF
--- a/src/apps/reservation-list/list/reservation-list.tsx
+++ b/src/apps/reservation-list/list/reservation-list.tsx
@@ -131,7 +131,7 @@ const ReservationList: FC<ReservationListProps> = ({ pageSize }) => {
       {/* Modals */}
       {userData?.patron && (
         <PauseReservation
-          user={userData?.patron}
+          user={userData.patron}
           id={pauseReservation as string}
         />
       )}

--- a/src/core/utils/useSavePatron.tsx
+++ b/src/core/utils/useSavePatron.tsx
@@ -46,8 +46,10 @@ const useSavePatron = ({ patron, fetchHandlers }: UseSavePatron) => {
             libraryCardNumber: patron.patronId.toString()
           },
           patron: {
-            ...patron,
-            ...convertPatronSettingsV4toV6(data)
+            ...convertPatronSettingsV4toV6({
+              ...patron,
+              ...data
+            })
           }
         }
       },


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-104


#### Description
This PR addresses an issue where customer contact information (email and phone number) was inadvertently omitted when a reservation was paused or unpaused. This occurred because only the `OnHold` field included in the `data` property was passed to `savePatron`, resulting in the email and phone number not being restructured.