### PR TITLE
DDFSAL-62 - Campaign tracking

### DIFF
--- a/src/components/campaign/Campaign.tsx
+++ b/src/components/campaign/Campaign.tsx
@@ -1,34 +1,29 @@
 import * as React from "react";
 import { FC } from "react";
 import { CampaignMatchPOST200Data } from "../../core/dpl-cms/model";
-import { statistics } from "../../core/statistics/statistics";
-import { useEventStatistics } from "../../core/statistics/useStatistics";
-import { redirectTo } from "../../core/utils/helpers/url";
+import { useUrlStatistics } from "../../core/statistics/useStatistics";
 
 export interface CampaignProps {
   campaignData: CampaignMatchPOST200Data;
 }
 
 const Campaign: FC<CampaignProps> = ({ campaignData }) => {
-  const { track } = useEventStatistics();
+  const { redirectWithUrlTracking } = useUrlStatistics();
   if (!campaignData.title) {
     return null;
   }
   // campaignData.title will always be defined because we exit the component if
   // not, but Typescript still thinks it might so we assign it with "as string"
-  const trackClick = () => {
-    return track("click", {
-      id: statistics.campaignClick.id,
-      name: statistics.campaignClick.name,
-      trackedData: campaignData.title as string
-    });
-  };
 
   const onClick = () => {
-    if (campaignData.url) {
-      const url = new URL(campaignData.url);
-      trackClick().then(() => redirectTo(url, true));
+    if (!campaignData.url) {
+      return;
     }
+
+    redirectWithUrlTracking({
+      campaignUrl: campaignData.url,
+      parameterValue: campaignData.title as string
+    });
   };
 
   const onKeyUp = (event: React.KeyboardEvent) => {

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -82,11 +82,6 @@ export const statistics: Statistics = {
     name: "Søgning - Resultatnummer klik",
     parameterName: ""
   },
-  campaignClick: {
-    id: 48,
-    name: "Kampagneklik",
-    parameterName: ""
-  },
   reservation: {
     id: 50,
     name: "Reserver",

--- a/src/core/statistics/statistics.ts
+++ b/src/core/statistics/statistics.ts
@@ -103,12 +103,10 @@ export const statistics: Statistics = {
     parameterName: ""
   },
   campaignShown: {
-    // This may be worng: see https://reload.atlassian.net/browse/DDFSAL-62
-    id: 62,
+    id: 69,
     name: "KampagnePlus Titel",
-    parameterName: "u_navigatedby_kp"
+    parameterName: "p_campaign_show"
   },
-
   // Loaner status, user profile
   renewSelectedMaterials: {
     id: 55,
@@ -125,7 +123,6 @@ export const statistics: Statistics = {
     name: "Tilføj til liste",
     parameterName: ""
   },
-
   // Material
   orderFromAnotherLibrary: {
     id: 70,

--- a/src/core/statistics/useStatistics.ts
+++ b/src/core/statistics/useStatistics.ts
@@ -1,4 +1,5 @@
 import { useConfig } from "../utils/config";
+import { isUrlValid, redirectTo } from "../utils/helpers/url";
 import { injectMappScript, removeMappScript } from "./tiLoader.min";
 // Useful resources for Mapp tracking:
 // https://documentation.mapp.com/1.0/en/manual-track-request-25105181.html
@@ -143,6 +144,35 @@ export const useEventStatistics = () => {
   return {
     track
   };
+};
+
+// URL tracking
+// This function redirects to a campaign URL with a specified parameter `u_navigatedby` and value.
+// When the Mapp script is loaded, this URL parameter will automatically be captured
+// and sent in the same way as page parameters.s
+export const useUrlStatistics = () => {
+  const redirectWithUrlTracking = ({
+    campaignUrl,
+    parameterValue,
+    openInNewTab = true
+  }: {
+    campaignUrl: string;
+    parameterValue: string;
+    openInNewTab?: boolean;
+  }) => {
+    if (!isUrlValid(campaignUrl)) {
+      return;
+    }
+
+    const url = new URL(campaignUrl);
+    const params = new URLSearchParams(url.search);
+    params.set("u_navigatedby", parameterValue);
+    url.search = params.toString();
+
+    redirectTo(url, openInNewTab);
+  };
+
+  return { redirectWithUrlTracking };
 };
 
 export default {};

--- a/src/core/statistics/useStatistics.ts
+++ b/src/core/statistics/useStatistics.ts
@@ -149,7 +149,7 @@ export const useEventStatistics = () => {
 // URL tracking
 // This function redirects to a campaign URL with a specified parameter `u_navigatedby` and value.
 // When the Mapp script is loaded, this URL parameter will automatically be captured
-// and sent in the same way as page parameters.s
+// and sent in the same way as page parameters
 export const useUrlStatistics = () => {
   const redirectWithUrlTracking = ({
     campaignUrl,


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-62

#### Test
https://varnish.pr-2395.dpl-cms.dplplat01.dpl.reload.dk/


#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2395

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2395

#### Description
This pull request refactors the campaign tracking logic by introducing a new URL tracking utility and updating the campaign statistics configuration to align with the settings in Mapp.

- Introduced a new `useUrlStatistics` hook in `useStatistics.ts` to manage redirections to campaign URLs with tracking parameters. This includes URL validation and appending the `u_navigatedby` parameter before redirection.

- Replaced `useEventStatistics` with `useUrlStatistics` in `Campaign.tsx`, removing the obsolete `trackClick` function and using the new `redirectWithUrlTracking` method to handle campaign clicks.

- Removed the `campaignClick` statistic entry, as it is no longer relevant under the updated tracking logic.

- Updated the `campaignShown` statistic entry to correct the id and parameterName values.