### PR TITLE
DDFSAL-49 - Correct data for `materialAudience` mapp traking

### DIFF
--- a/src/apps/material/__snapshots__/helper.ts.snap
+++ b/src/apps/material/__snapshots__/helper.ts.snap
@@ -17,6 +17,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
       ],
       "audience": {
         "ages": [],
+        "childrenOrAdults": [],
         "generalAudience": [],
       },
       "catalogueCodes": {
@@ -110,6 +111,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
       ],
       "audience": {
         "ages": [],
+        "childrenOrAdults": [],
         "generalAudience": [
           "Text Difficulty 3 - Text Difficulty 5",
           "UG/Upper grades (9th-12)",
@@ -208,6 +210,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
       ],
       "audience": {
         "ages": [],
+        "childrenOrAdults": [],
         "generalAudience": [
           "Text Difficulty 3 - Text Difficulty 4",
           "820. Lexile",
@@ -308,6 +311,7 @@ exports[`divideManifestationsByMaterialType > should divide manifestations by ma
       ],
       "audience": {
         "ages": [],
+        "childrenOrAdults": [],
         "generalAudience": [],
       },
       "catalogueCodes": {

--- a/src/apps/material/__vitest_data__/helper.ts
+++ b/src/apps/material/__vitest_data__/helper.ts
@@ -69,7 +69,8 @@ export default {
         },
         audience: {
           generalAudience: [],
-          ages: []
+          ages: [],
+          childrenOrAdults: []
         },
         notes: [
           {
@@ -162,7 +163,8 @@ export default {
             "820. Lexile",
             "6.1. ATOS Level"
           ],
-          ages: []
+          ages: [],
+          childrenOrAdults: []
         },
         notes: [
           {
@@ -256,7 +258,8 @@ export default {
             "Text Difficulty 3 - Text Difficulty 4",
             "820. Lexile"
           ],
-          ages: []
+          ages: [],
+          childrenOrAdults: []
         },
         notes: [
           {
@@ -341,7 +344,8 @@ export default {
         dateFirstEdition: null,
         audience: {
           generalAudience: [],
-          ages: []
+          ages: [],
+          childrenOrAdults: []
         },
         notes: [],
         physicalDescription: {

--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -134,6 +134,16 @@ export const getManifestationAudience = (
     : generalAudience || formattedAges;
 };
 
+export const getManifestationChildrenOrAdults = (
+  manifestation: Manifestation
+) => {
+  return (
+    first(manifestation.audience?.childrenOrAdults)?.display ||
+    // This should never happen, so it's only for debugging.
+    `No 'childrenOrAdults' data available for ${manifestation.pid}`
+  );
+};
+
 export const getManifestationIsbn = (manifestation: Manifestation) => {
   return manifestation.identifiers?.[0]?.value ?? "";
 };

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -37,7 +37,7 @@ import {
   getDetailsListData,
   getFirstManifestation,
   getInfomediaIds,
-  getManifestationAudience,
+  getManifestationChildrenOrAdults,
   getManifestationsOrderByTypeAndYear,
   isParallelReservation
 } from "./helper";
@@ -47,7 +47,6 @@ import PlayerModal from "../../components/material/player-modal/PlayerModal";
 import useReaderPlayer from "../../core/utils/useReaderPlayer";
 import OnlineInternalModal from "../../components/reservation/OnlineInternalModal";
 import MaterialGridRelated from "../../components/material-grid-related/MaterialGridRelated";
-import { first } from "lodash";
 
 export interface MaterialProps {
   wid: WorkId;
@@ -100,12 +99,11 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
         trackedData: data.work.dk5MainEntry.display
       });
     }
-    if (data?.work?.manifestations.bestRepresentation.audience) {
+    if (data?.work?.manifestations.bestRepresentation) {
       collectPageStatistics({
         ...statistics.materialAudience,
-        trackedData: getManifestationAudience(
-          data.work.manifestations.bestRepresentation as Manifestation,
-          t
+        trackedData: getManifestationChildrenOrAdults(
+          data.work.manifestations.bestRepresentation as Manifestation
         )
       });
     }
@@ -118,19 +116,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
     // In this case we only want to track once - on work data load
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
-
-  // Track the audience whenever the selected manifestation changes
-  useUpdateEffect(() => {
-    if (first(selectedManifestations)) {
-      collectPageStatistics({
-        ...statistics.materialAudience,
-        trackedData: getManifestationAudience(
-          first(selectedManifestations) as Manifestation,
-          t
-        )
-      });
-    }
-  }, [selectedManifestations]);
 
   useEffect(() => {
     if (!data?.work) return;

--- a/src/components/find-on-shelf/mocked-data.ts
+++ b/src/components/find-on-shelf/mocked-data.ts
@@ -65,7 +65,8 @@ export const mockedManifestationData: Manifestation[] = [
     },
     audience: {
       generalAudience: [],
-      ages: []
+      ages: [],
+      childrenOrAdults: []
     },
     notes: [],
     physicalDescription: {
@@ -159,7 +160,8 @@ export const mockedManifestationData: Manifestation[] = [
     },
     audience: {
       generalAudience: [],
-      ages: []
+      ages: [],
+      childrenOrAdults: []
     },
     notes: [
       {
@@ -236,7 +238,8 @@ export const mockedPeriodicalManifestationData: Manifestation[] = [
     },
     audience: {
       generalAudience: [],
-      ages: []
+      ages: [],
+      childrenOrAdults: []
     },
     notes: [
       {

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -92,6 +92,10 @@ fragment ManifestationsSimpleFields on Manifestation {
     ages {
       display
     }
+    childrenOrAdults {
+      display
+      code
+    }
   }
   notes {
     display

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -214,6 +214,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "urlText",
+            "description": "Description/type of URL",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -7710,58 +7722,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "MusicalExercise",
-        "description": null,
-        "isOneOf": null,
-        "fields": [
-          {
-            "name": "display",
-            "description": "The types of instrument 'schools' intended to practise with",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "forExercise",
-            "description": "Information whether material is intended for practising and in combination with an instrument",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Mutation",
         "description": null,
         "isOneOf": null,
@@ -7955,6 +7915,22 @@
               "ofType": {
                 "kind": "ENUM",
                 "name": "NoteTypeEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "urls",
+            "description": "A link and possible link text",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccessUrl",
                 "ofType": null
               }
             },
@@ -9962,7 +9938,7 @@
           },
           {
             "name": "url",
-            "description": "URL of the related publication",
+            "description": "The first URL of the urls in related publications",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -9980,6 +9956,26 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "urls",
+            "description": "Alle urls of the related publication",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12102,6 +12098,18 @@
             "deprecationReason": null
           },
           {
+            "name": "forMusicalExercise",
+            "description": "I this node for exercises",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "instruments",
             "description": "The types of instruments material covers",
             "args": [],
@@ -12121,18 +12129,6 @@
                   }
                 }
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "musicalExercises",
-            "description": "Material intended to practice with",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "MusicalExercise",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/core/dbc-gateway/generated/graphql.ts
+++ b/src/core/dbc-gateway/generated/graphql.ts
@@ -69,6 +69,8 @@ export type AccessUrl = {
   type?: Maybe<AccessUrlTypeEnum>;
   /** The url where manifestation is located */
   url: Scalars["String"]["output"];
+  /** Description/type of URL */
+  urlText?: Maybe<Scalars["String"]["output"]>;
 };
 
 export enum AccessUrlTypeEnum {
@@ -1176,14 +1178,6 @@ export type MoodTagRecommendResponse = {
   work: Work;
 };
 
-export type MusicalExercise = {
-  __typename?: "MusicalExercise";
-  /** The types of instrument 'schools' intended to practise with */
-  display: Array<Scalars["String"]["output"]>;
-  /** Information whether material is intended for practising and in combination with an instrument */
-  forExercise: Scalars["Boolean"]["output"];
-};
-
 export type Mutation = {
   __typename?: "Mutation";
   elba: ElbaServices;
@@ -1211,6 +1205,8 @@ export type Note = {
   heading?: Maybe<Scalars["String"]["output"]>;
   /** The type of note - e.g. note about language, genre etc, NOT_SPECIFIED if not known.  */
   type: NoteTypeEnum;
+  /** A link and possible link text */
+  urls?: Maybe<Array<Maybe<AccessUrl>>>;
 };
 
 export enum NoteTypeEnum {
@@ -1491,10 +1487,12 @@ export type RelatedPublication = {
   issn?: Maybe<Scalars["String"]["output"]>;
   /** Title of the related periodical/journal */
   title: Array<Scalars["String"]["output"]>;
-  /** URL of the related publication */
+  /** The first URL of the urls in related publications */
   url?: Maybe<Scalars["String"]["output"]>;
   /** Note regarding the URL of the related publication */
   urlText?: Maybe<Scalars["String"]["output"]>;
+  /** Alle urls of the related publication */
+  urls: Array<Maybe<Scalars["String"]["output"]>>;
 };
 
 export type Relations = {
@@ -1747,10 +1745,10 @@ export type SheetMusicCategory = {
   chamberMusicTypes: Array<Scalars["String"]["output"]>;
   /** The types of choir material covers */
   choirTypes: Array<Scalars["String"]["output"]>;
+  /** I this node for exercises */
+  forMusicalExercise?: Maybe<Scalars["Boolean"]["output"]>;
   /** The types of instruments material covers */
   instruments: Array<Scalars["String"]["output"]>;
-  /** Material intended to practice with */
-  musicalExercises?: Maybe<MusicalExercise>;
   /** The types of orchestra material covers */
   orchestraTypes: Array<Scalars["String"]["output"]>;
 };
@@ -2287,6 +2285,11 @@ export type GetSmallWorkQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -2411,6 +2414,11 @@ export type GetSmallWorkQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -2535,6 +2543,11 @@ export type GetSmallWorkQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -2910,6 +2923,11 @@ export type GetMaterialQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -3034,6 +3052,11 @@ export type GetMaterialQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -3158,6 +3181,11 @@ export type GetMaterialQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -3387,6 +3415,11 @@ export type GetMaterialGloballyQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -3511,6 +3544,11 @@ export type GetMaterialGloballyQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -3635,6 +3673,11 @@ export type GetMaterialGloballyQuery = {
           __typename?: "Audience";
           generalAudience: Array<string>;
           ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
         } | null;
         notes: Array<{ __typename?: "Note"; display: Array<string> }>;
         languages?: {
@@ -3908,6 +3951,11 @@ export type RecommendFromFaustQuery = {
               __typename?: "Audience";
               generalAudience: Array<string>;
               ages: Array<{ __typename?: "Range"; display: string }>;
+              childrenOrAdults: Array<{
+                __typename?: "ChildOrAdult";
+                display: string;
+                code: ChildOrAdultCodeEnum;
+              }>;
             } | null;
             notes: Array<{ __typename?: "Note"; display: Array<string> }>;
             languages?: {
@@ -4032,6 +4080,11 @@ export type RecommendFromFaustQuery = {
               __typename?: "Audience";
               generalAudience: Array<string>;
               ages: Array<{ __typename?: "Range"; display: string }>;
+              childrenOrAdults: Array<{
+                __typename?: "ChildOrAdult";
+                display: string;
+                code: ChildOrAdultCodeEnum;
+              }>;
             } | null;
             notes: Array<{ __typename?: "Note"; display: Array<string> }>;
             languages?: {
@@ -4156,6 +4209,11 @@ export type RecommendFromFaustQuery = {
               __typename?: "Audience";
               generalAudience: Array<string>;
               ages: Array<{ __typename?: "Range"; display: string }>;
+              childrenOrAdults: Array<{
+                __typename?: "ChildOrAdult";
+                display: string;
+                code: ChildOrAdultCodeEnum;
+              }>;
             } | null;
             notes: Array<{ __typename?: "Note"; display: Array<string> }>;
             languages?: {
@@ -4342,6 +4400,11 @@ export type SearchWithPaginationQuery = {
             __typename?: "Audience";
             generalAudience: Array<string>;
             ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
           } | null;
           notes: Array<{ __typename?: "Note"; display: Array<string> }>;
           languages?: {
@@ -4466,6 +4529,11 @@ export type SearchWithPaginationQuery = {
             __typename?: "Audience";
             generalAudience: Array<string>;
             ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
           } | null;
           notes: Array<{ __typename?: "Note"; display: Array<string> }>;
           languages?: {
@@ -4590,6 +4658,11 @@ export type SearchWithPaginationQuery = {
             __typename?: "Audience";
             generalAudience: Array<string>;
             ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
           } | null;
           notes: Array<{ __typename?: "Note"; display: Array<string> }>;
           languages?: {
@@ -4823,6 +4896,11 @@ export type ComplexSearchWithPaginationQuery = {
             __typename?: "Audience";
             generalAudience: Array<string>;
             ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
           } | null;
           notes: Array<{ __typename?: "Note"; display: Array<string> }>;
           languages?: {
@@ -4947,6 +5025,11 @@ export type ComplexSearchWithPaginationQuery = {
             __typename?: "Audience";
             generalAudience: Array<string>;
             ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
           } | null;
           notes: Array<{ __typename?: "Note"; display: Array<string> }>;
           languages?: {
@@ -5071,6 +5154,11 @@ export type ComplexSearchWithPaginationQuery = {
             __typename?: "Audience";
             generalAudience: Array<string>;
             ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
           } | null;
           notes: Array<{ __typename?: "Note"; display: Array<string> }>;
           languages?: {
@@ -5334,6 +5422,11 @@ export type ManifestationsSimpleFragment = {
       __typename?: "Audience";
       generalAudience: Array<string>;
       ages: Array<{ __typename?: "Range"; display: string }>;
+      childrenOrAdults: Array<{
+        __typename?: "ChildOrAdult";
+        display: string;
+        code: ChildOrAdultCodeEnum;
+      }>;
     } | null;
     notes: Array<{ __typename?: "Note"; display: Array<string> }>;
     languages?: {
@@ -5452,6 +5545,11 @@ export type ManifestationsSimpleFragment = {
       __typename?: "Audience";
       generalAudience: Array<string>;
       ages: Array<{ __typename?: "Range"; display: string }>;
+      childrenOrAdults: Array<{
+        __typename?: "ChildOrAdult";
+        display: string;
+        code: ChildOrAdultCodeEnum;
+      }>;
     } | null;
     notes: Array<{ __typename?: "Note"; display: Array<string> }>;
     languages?: {
@@ -5570,6 +5668,11 @@ export type ManifestationsSimpleFragment = {
       __typename?: "Audience";
       generalAudience: Array<string>;
       ages: Array<{ __typename?: "Range"; display: string }>;
+      childrenOrAdults: Array<{
+        __typename?: "ChildOrAdult";
+        display: string;
+        code: ChildOrAdultCodeEnum;
+      }>;
     } | null;
     notes: Array<{ __typename?: "Note"; display: Array<string> }>;
     languages?: {
@@ -5720,6 +5823,11 @@ export type ManifestationsSimpleFieldsFragment = {
     __typename?: "Audience";
     generalAudience: Array<string>;
     ages: Array<{ __typename?: "Range"; display: string }>;
+    childrenOrAdults: Array<{
+      __typename?: "ChildOrAdult";
+      display: string;
+      code: ChildOrAdultCodeEnum;
+    }>;
   } | null;
   notes: Array<{ __typename?: "Note"; display: Array<string> }>;
   languages?: {
@@ -5977,6 +6085,11 @@ export type WorkSmallFragment = {
         __typename?: "Audience";
         generalAudience: Array<string>;
         ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
       } | null;
       notes: Array<{ __typename?: "Note"; display: Array<string> }>;
       languages?: {
@@ -6101,6 +6214,11 @@ export type WorkSmallFragment = {
         __typename?: "Audience";
         generalAudience: Array<string>;
         ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
       } | null;
       notes: Array<{ __typename?: "Note"; display: Array<string> }>;
       languages?: {
@@ -6225,6 +6343,11 @@ export type WorkSmallFragment = {
         __typename?: "Audience";
         generalAudience: Array<string>;
         ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
       } | null;
       notes: Array<{ __typename?: "Note"; display: Array<string> }>;
       languages?: {
@@ -6447,6 +6570,11 @@ export type WorkMediumFragment = {
         __typename?: "Audience";
         generalAudience: Array<string>;
         ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
       } | null;
       notes: Array<{ __typename?: "Note"; display: Array<string> }>;
       languages?: {
@@ -6571,6 +6699,11 @@ export type WorkMediumFragment = {
         __typename?: "Audience";
         generalAudience: Array<string>;
         ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
       } | null;
       notes: Array<{ __typename?: "Note"; display: Array<string> }>;
       languages?: {
@@ -6695,6 +6828,11 @@ export type WorkMediumFragment = {
         __typename?: "Audience";
         generalAudience: Array<string>;
         ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
       } | null;
       notes: Array<{ __typename?: "Note"; display: Array<string> }>;
       languages?: {
@@ -6974,6 +7112,10 @@ export const ManifestationsSimpleFieldsFragmentDoc = `
     generalAudience
     ages {
       display
+    }
+    childrenOrAdults {
+      display
+      code
     }
   }
   notes {


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-49

#### Test
https://varnish.pr-2399.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2399

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2399

#### Description

This pull request updates the data sent for Mapp `materialAudience` tracking.
Previously, the necessary data was not available in the dbc Fbi dataset. I’ve added the required field to the GraphQL schema, generated new types and updated the relevant mocks accordingly.
