### PR TITLE
DDFSAL-91 - Implement email validation for OpenOrder reservations

### DIFF
--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -174,6 +174,7 @@ interface MaterialEntryTextProps {
   readArticleText: string;
   receiveEmailWhenMaterialReadyText: string;
   receiveSmsWhenMaterialReadyText: string;
+  reservableFromAnotherLibraryMissingEmailText: string;
   reservableFromAnotherLibraryText: string;
   reservationDetailsPickUpAtTitleText: string;
   reservationErrorsDescriptionText: string;

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -175,6 +175,7 @@ interface MaterialEntryTextProps {
   receiveEmailWhenMaterialReadyText: string;
   receiveSmsWhenMaterialReadyText: string;
   reservableFromAnotherLibraryMissingEmailText: string;
+  reservableFromAnotherLibraryExtraInfoText: string;
   reservableFromAnotherLibraryText: string;
   reservationDetailsPickUpAtTitleText: string;
   reservationErrorsDescriptionText: string;

--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -111,6 +111,10 @@ const meta: Meta<typeof MaterialEntry> = {
       description: "Reserve",
       control: { type: "text" }
     },
+    reservableFromAnotherLibraryMissingEmailText: {
+      description: "Reservable on another library - need to add email",
+      control: { type: "text" }
+    },
     reservableFromAnotherLibraryText: {
       description: "Reservable on another library",
       control: { type: "text" }
@@ -823,6 +827,8 @@ const meta: Meta<typeof MaterialEntry> = {
     reserveBookText: "Reserve book",
     reserveText: "Reserve",
     reserveWithMaterialTypeText: "Reserve @materialType",
+    reservableFromAnotherLibraryMissingEmailText:
+      "You need to add an email address to reserve from another library.",
     reservableFromAnotherLibraryText: "Ordered from another library.",
     findOnBookshelfText: "Find on shelf",
     descriptionHeadlineText: "Description",

--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -115,6 +115,10 @@ const meta: Meta<typeof MaterialEntry> = {
       description: "Reservable on another library - need to add email",
       control: { type: "text" }
     },
+    reservableFromAnotherLibraryExtraInfoText: {
+      description: "Reservable on another library - extra info",
+      control: { type: "text" }
+    },
     reservableFromAnotherLibraryText: {
       description: "Reservable on another library",
       control: { type: "text" }
@@ -829,6 +833,8 @@ const meta: Meta<typeof MaterialEntry> = {
     reserveWithMaterialTypeText: "Reserve @materialType",
     reservableFromAnotherLibraryMissingEmailText:
       "You need to add an email address to reserve from another library.",
+    reservableFromAnotherLibraryExtraInfoText:
+      "NOTE! This material is ordered from another library. Therefore, it may take a few days before it appears on your list of reservations.",
     reservableFromAnotherLibraryText: "Ordered from another library.",
     findOnBookshelfText: "Find on shelf",
     descriptionHeadlineText: "Description",

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -266,6 +266,8 @@ export const ReservationModalBody = ({
       instantLoanThreshold
     );
 
+  const userHasEmail = Boolean(patron?.emailAddress);
+
   return (
     <>
       {!reservationResults && !openOrderResponse && (
@@ -287,7 +289,11 @@ export const ReservationModalBody = ({
             <div className="reservation-modal-submit">
               <MaterialAvailabilityTextParagraph>
                 {materialIsReservableFromAnotherLibrary ? (
-                  t("reservableFromAnotherLibraryText")
+                  userHasEmail ? (
+                    t("reservableFromAnotherLibraryText")
+                  ) : (
+                    t("reservableFromAnotherLibraryMissingEmailText")
+                  )
                 ) : (
                   <StockAndReservationInfo
                     stockCount={holdings}
@@ -300,7 +306,10 @@ export const ReservationModalBody = ({
                 label={t("approveReservationText")}
                 buttonType="none"
                 variant="filled"
-                disabled={reservationStatus === "pending"}
+                disabled={
+                  reservationStatus === "pending" ||
+                  (materialIsReservableFromAnotherLibrary && !userHasEmail)
+                }
                 collapsible={false}
                 size="small"
                 onClick={saveReservation}

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -290,7 +290,7 @@ export const ReservationModalBody = ({
               <MaterialAvailabilityTextParagraph>
                 {materialIsReservableFromAnotherLibrary ? (
                   userHasEmail ? (
-                    t("reservableFromAnotherLibraryText")
+                    t("reservableFromAnotherLibraryExtraInfoText")
                   ) : (
                     t("reservableFromAnotherLibraryMissingEmailText")
                   )


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-91
https://reload.atlassian.net/browse/DDFSAL-128

#### Test
https://varnish.pr-2405.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2405

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2405

#### Description
This pull request introduces a new feature to handle cases where a user without an email address attempts to reserve materials from another library. 

