### PR TITLE
Fix yearbooks and newspapers

### DIFF
--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -1081,6 +1081,20 @@ export const Periodical: Story = {
   }
 };
 
+export const yearbookPeriodical: Story = {
+  args: {
+    ...Default.args,
+    wid: "work-of:870970-basis:49236115"
+  }
+};
+
+export const newspaperPeriodical: Story = {
+  args: {
+    ...Default.args,
+    wid: "work-of:870970-basis:49294182"
+  }
+};
+
 export const Infomedia: Story = {
   args: {
     ...Default.args,

--- a/src/components/material/MaterialHeader.tsx
+++ b/src/components/material/MaterialHeader.tsx
@@ -36,6 +36,8 @@ import { isPeriodical, shouldShowMaterialAvailabilityText } from "./helper";
 import useAvailabilityData from "../availability-label/useAvailabilityData";
 import { AccessTypeCodeEnum } from "../../core/dbc-gateway/generated/graphql";
 import { first } from "lodash";
+import { hasCorrectMaterialType } from "./material-buttons/helper";
+import { ManifestationMaterialType } from "../../core/utils/types/material-type";
 
 interface MaterialHeaderProps {
   wid: WorkId;
@@ -96,6 +98,15 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
     // which we check inside shouldShowMaterialAvailabilityText() helper here.
     manifestText: "NOT AN ARTICLE"
   });
+  const isYearbook =
+    hasCorrectMaterialType(
+      ManifestationMaterialType.yearBook,
+      manifestations
+    ) ||
+    hasCorrectMaterialType(
+      ManifestationMaterialType.yearBookOnline,
+      manifestations
+    );
 
   useDeepCompareEffect(() => {
     collectPageStatistics({
@@ -156,6 +167,7 @@ const MaterialHeader: React.FC<MaterialHeaderProps> = ({
                 faustId={convertPostIdToFaustId(pid)}
                 selectedPeriodical={selectedPeriodical}
                 selectPeriodicalHandler={selectPeriodicalHandler}
+                isYearbook={isYearbook}
               />
             )}
             {selectedManifestations && (

--- a/src/components/material/helper.ts
+++ b/src/components/material/helper.ts
@@ -15,9 +15,20 @@ export const isPhysical = (manifestations: Manifestation[]) => {
 };
 
 export const isPeriodical = (manifestations: Manifestation[]) => {
-  return hasCorrectMaterialType(
-    ManifestationMaterialType.magazine,
-    manifestations
+  return (
+    hasCorrectMaterialType(
+      ManifestationMaterialType.magazine,
+      manifestations
+    ) ||
+    hasCorrectMaterialType(
+      ManifestationMaterialType.yearBook,
+      manifestations
+    ) ||
+    hasCorrectMaterialType(
+      ManifestationMaterialType.yearBookOnline,
+      manifestations
+    ) ||
+    hasCorrectMaterialType(ManifestationMaterialType.newspaper, manifestations)
   );
 };
 

--- a/src/components/material/periodical/MaterialPeriodical.tsx
+++ b/src/components/material/periodical/MaterialPeriodical.tsx
@@ -11,12 +11,14 @@ export interface MaterialPeriodicalProps {
   faustId: FaustId;
   selectedPeriodical: PeriodicalEdition | null;
   selectPeriodicalHandler: (selectedPeriodical: PeriodicalEdition) => void;
+  isYearbook?: boolean;
 }
 
 const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
   faustId,
   selectedPeriodical,
-  selectPeriodicalHandler
+  selectPeriodicalHandler,
+  isYearbook = false
 }) => {
   const config = useConfig();
 
@@ -58,6 +60,7 @@ const MaterialPeriodical: FC<MaterialPeriodicalProps> = ({
       groupList={groupByVolumeYear as GroupList}
       selectedPeriodical={selectedPeriodical}
       selectPeriodicalHandler={selectPeriodicalHandler}
+      isReleasedYearly={isYearbook}
     />
   );
 };

--- a/src/components/material/periodical/MaterialPeriodicalSelect.tsx
+++ b/src/components/material/periodical/MaterialPeriodicalSelect.tsx
@@ -13,12 +13,14 @@ interface MaterialPeriodicalSelectProps {
   groupList: GroupList;
   selectedPeriodical: PeriodicalEdition | null;
   selectPeriodicalHandler: (selectedPeriodical: PeriodicalEdition) => void;
+  isReleasedYearly?: boolean;
 }
 
 const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
   groupList,
   selectedPeriodical,
-  selectPeriodicalHandler
+  selectPeriodicalHandler,
+  isReleasedYearly = false
 }) => {
   const t = useText();
   const lastYear = Object.keys(groupList).sort().pop() || "";
@@ -35,12 +37,16 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
     if (firstFullPeriodicalEdition) {
       selectPeriodicalHandler(firstFullPeriodicalEdition);
     }
+    if (isReleasedYearly) {
+      selectPeriodicalHandler(groupList[year][0]);
+    }
   }, [
     selectPeriodicalHandler,
     selectedPeriodical,
     year,
     periodicalEditions,
-    groupList
+    groupList,
+    isReleasedYearly
   ]);
 
   const handleYearSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -79,7 +85,7 @@ const MaterialPeriodicalSelect: React.FC<MaterialPeriodicalSelectProps> = ({
         </div>
       </div>
 
-      {year && (
+      {year && !isReleasedYearly && (
         <div className="material-periodical-select">
           <label htmlFor="editions">{t("periodicalSelectEditionText")}</label>
           <div className="material-periodical-select__border-container">

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -114,7 +114,6 @@ export const ReservationModalBody = ({
     branches,
     blacklistBranchesInstantLoan.concat(blacklistPickupBranches)
   );
-
   const mainManifestationType = getMaterialType(selectedManifestations);
   const { reservableManifestations } = UseReservableManifestations({
     manifestations: selectedManifestations,

--- a/src/core/utils/types/material-type.ts
+++ b/src/core/utils/types/material-type.ts
@@ -21,9 +21,11 @@ export const enum ManifestationMaterialType {
   pictureBookOnline = "billedbog (online)",
   animatedSeriesOnline = "tegneserie (online)",
   yearBookOnline = "årbog (online)",
+  yearBook = "årbog",
   podcast = "podcast",
   musicOnline = "musik (online)",
-  audioBookTape = "lydbog (bånd)"
+  audioBookTape = "lydbog (bånd)",
+  newspaper = "avis"
 }
 
 export const enum AutosuggestCategory {


### PR DESCRIPTION
#### Link to issue
-

#### Description
- fixes reservation for yearbooks and newspaper manifestations
- - Yearbooks and newspapers are considered periodical materials, which means uset needs to be able to select an edition when reserving/loaning these materials, which wasn't possible in the past.
- adds stories for these materials for easier testing

#### Screenshot of the result
-

#### Additional comments or questions
-
