### PR TITLE
Update @testing-library/react to version 16.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@storybook/react": "^8.4.7",
     "@storybook/react-webpack5": "^8.6.14",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.1.0",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@tsconfig/create-react-app": "^2.0.5",
     "@types/node": "^20.16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,10 +3272,10 @@
     "@babel/runtime" "^7.12.5"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react@^16.1.0":
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.1.0.tgz#aa0c61398bac82eaf89776967e97de41ac742d71"
-  integrity sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==
+"@testing-library/react@^16.3.0":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.0.tgz#3a85bb9bdebf180cd76dba16454e242564d598a6"
+  integrity sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFNEXT-261


#### Description
This pull request includes a small update to the `package.json` file. The change upgrades the `@testing-library/react` dependency from version `16.1.0` to `16.3.0`.

