### PR TITLE
DDFSAL-92 - Add CQL search external help link

### DIFF
--- a/src/apps/advanced-search/AdvancedSearch.entry.tsx
+++ b/src/apps/advanced-search/AdvancedSearch.entry.tsx
@@ -75,6 +75,7 @@ interface AdvancedSearchEntryTextProps {
   advancedSearchFilterLocationDescriptionText: string;
   advancedSearchFilterSublocationText: string;
   advancedSearchFilterSublocationDescriptionText: string;
+  cqlSearchExternalHelpLinkText: string;
 }
 
 interface AdvancedSearchEntryConfigProps {

--- a/src/apps/advanced-search/AdvancedSearch.stories.tsx
+++ b/src/apps/advanced-search/AdvancedSearch.stories.tsx
@@ -323,6 +323,10 @@ const meta: Meta<typeof AdvancedSearchEntry> = {
     advancedSearchFilterSublocationDescriptionText: {
       description: "Advanced search filter - sublocation description",
       control: { type: "text" }
+    },
+    cqlSearchExternalHelpLinkText: {
+      description: "CQL search external help link text",
+      control: { type: "text" }
     }
   }
 };
@@ -415,6 +419,7 @@ export const Primary: Story = {
       "Add a comma separated list for multiple locations",
     advancedSearchFilterSublocationText: "Sublocation",
     advancedSearchFilterSublocationDescriptionText:
-      "Add a comma separated list for multiple sublocations"
+      "Add a comma separated list for multiple sublocations",
+    cqlSearchExternalHelpLinkText: "Find out more about CQL search"
   }
 };

--- a/src/apps/advanced-search/CqlSearchHeader.tsx
+++ b/src/apps/advanced-search/CqlSearchHeader.tsx
@@ -4,6 +4,7 @@ import CheckBox from "../../components/checkbox/Checkbox";
 import { LocationFilter } from "./LocationFilter";
 import Textarea from "../../components/forms/textarea/Textarea";
 import TextInput from "../../components/forms/input/TextInput";
+import Link from "../../components/atoms/links/Link";
 
 export type CqlSearchHeaderProps = {
   dataCy?: string;
@@ -68,17 +69,26 @@ const CqlSearchHeader: React.FC<CqlSearchHeaderProps> = ({
         {t("cqlSearchTitleText")}
       </h1>
       <form className="advanced-search-cql-form">
-        <Textarea
-          id="cql"
-          label="CQL"
-          className="advanced-search-cql-form__input focus-styling__input"
-          cols={100}
-          rows={5}
-          placeholder="e.g. term.title=snemand*”"
-          dataCy={`${dataCy}-input`}
-          onChange={(e) => setCql(e.target.value)}
-          defaultValue={initialCql}
-        />
+        <div>
+          <Textarea
+            id="cql"
+            label="CQL"
+            className="advanced-search-cql-form__input focus-styling__input"
+            cols={100}
+            rows={5}
+            placeholder="e.g. term.title=snemand*”"
+            dataCy={`${dataCy}-input`}
+            onChange={(e) => setCql(e.target.value)}
+            defaultValue={initialCql}
+          />
+          <Link
+            className="link-tag"
+            href={new URL("https://danbib.dk/soegekoder-complex-search")}
+            isNewTab
+          >
+            {t("cqlSearchExternalHelpLinkText")}
+          </Link>
+        </div>
         <TextInput
           id="location"
           label={t("advancedSearchFilterLocationText")}


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-92


#### Description
This pull request introduces a new feature to display a help link for CQL (Contextual Query Language) search in the advanced search interface. It includes updates to the component props, storybook configuration, and UI implementation to support this feature.

### Updates to Advanced Search Props and Storybook:

* [`src/apps/advanced-search/AdvancedSearch.entry.tsx`](diffhunk://#diff-9081c03c4adaffc510371e982f99fcd50e570294f1c74cffcf832250947d1971R78): Added a new prop `cqlSearchExternalHelpLinkText` to the `AdvancedSearchEntryTextProps` interface to support the external help link text.
* [`src/apps/advanced-search/AdvancedSearch.stories.tsx`](diffhunk://#diff-e4e02d06c58ca8b25ab9a18251e0ebaa40218d0330e6b9ab3cf6bb2b06c84440R326-R329): Updated the storybook configuration to include `cqlSearchExternalHelpLinkText` in the `Meta` object and the `Primary` story, allowing the help link text to be customized in the storybook. [[1]](diffhunk://#diff-e4e02d06c58ca8b25ab9a18251e0ebaa40218d0330e6b9ab3cf6bb2b06c84440R326-R329) [[2]](diffhunk://#diff-e4e02d06c58ca8b25ab9a18251e0ebaa40218d0330e6b9ab3cf6bb2b06c84440L418-R423)

### Implementation of Help Link in CQL Search Header:

* `src/apps/advanced-search/CqlSearchHeader.tsx`: 
  - Imported the `Link` component to create the external help link.
  - Added a `Link` element below the `Textarea` for the CQL input, which points to the external help page and displays the `cqlSearchExternalHelpLinkText` value. [[1]](diffhunk://#diff-a1b5dc73d5fe03370ab5cca6169c9287e4e2a7b45b1c80d20d2d2eb5ea7447d7R72) [[2]](diffhunk://#diff-a1b5dc73d5fe03370ab5cca6169c9287e4e2a7b45b1c80d20d2d2eb5ea7447d7R84-R91)