### PR TITLE
DDFSAL-109 - Fix e-materials modal not opening under all conditions

### DIFF
--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -35,7 +35,6 @@ import {
   divideManifestationsByMaterialType,
   getBestMaterialTypeForWork,
   getDetailsListData,
-  getFirstManifestation,
   getInfomediaIds,
   getManifestationChildrenOrAdults,
   getManifestationsOrderByTypeAndYear,
@@ -43,8 +42,6 @@ import {
 } from "./helper";
 import MaterialDisclosure from "./MaterialDisclosure";
 import ReservationFindOnShelfModals from "./ReservationFindOnShelfModals";
-import PlayerModal from "../../components/material/player-modal/PlayerModal";
-import useReaderPlayer from "../../core/utils/useReaderPlayer";
 import OnlineInternalModal from "../../components/reservation/OnlineInternalModal";
 import MaterialGridRelated from "../../components/material-grid-related/MaterialGridRelated";
 
@@ -64,11 +61,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
   const [isUserBlocked, setIsUserBlocked] = useState<boolean | null>(null);
   const { updatePageStatistics } = usePageStatistics();
   const { collectPageStatistics } = useCollectPageStatistics();
-  const {
-    type: readerPlayerType,
-    identifier,
-    orderId
-  } = useReaderPlayer(getFirstManifestation(selectedManifestations || []));
 
   useUpdateEffect(() => {
     updatePageStatistics({ waitTime: 2500 });
@@ -212,12 +204,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
               work={work}
               setSelectedPeriodical={setSelectedPeriodical}
             />
-          )}
-          {readerPlayerType === "player" && (
-            <>
-              {identifier && <PlayerModal identifier={identifier} />}
-              {orderId && <PlayerModal orderId={orderId} />}
-            </>
           )}
         </MaterialHeader>
         <MaterialDescription pid={pid} work={work} />

--- a/src/apps/material/material.tsx
+++ b/src/apps/material/material.tsx
@@ -176,14 +176,20 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
           isGlobalMaterial={workType === "global"}
         >
           {manifestations.map((manifestation) => (
-            <ReservationFindOnShelfModals
-              key={manifestation.pid}
-              patron={userData?.patron}
-              manifestations={[manifestation]}
-              selectedPeriodical={selectedPeriodical}
-              work={work}
-              setSelectedPeriodical={setSelectedPeriodical}
-            />
+            <>
+              <ReservationFindOnShelfModals
+                key={manifestation.pid}
+                patron={userData?.patron}
+                manifestations={[manifestation]}
+                selectedPeriodical={selectedPeriodical}
+                work={work}
+                setSelectedPeriodical={setSelectedPeriodical}
+              />
+              <OnlineInternalModal
+                workId={wid}
+                selectedManifestations={[manifestation]}
+              />
+            </>
           ))}
           {infomediaIds.length > 0 && !isAnonymous() && !isUserBlocked && (
             <InfomediaModal
@@ -212,12 +218,6 @@ const Material: React.FC<MaterialProps> = ({ wid }) => {
               {identifier && <PlayerModal identifier={identifier} />}
               {orderId && <PlayerModal orderId={orderId} />}
             </>
-          )}
-          {(readerPlayerType === "reader" || readerPlayerType === "player") && (
-            <OnlineInternalModal
-              workId={wid}
-              selectedManifestations={selectedManifestations}
-            />
           )}
         </MaterialHeader>
         <MaterialDescription pid={pid} work={work} />

--- a/src/components/material/material-buttons/online/MaterialButtonsOnlineInternal.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonsOnlineInternal.tsx
@@ -21,6 +21,7 @@ import { getFirstManifestation } from "../../../../apps/material/helper";
 import { WorkId } from "../../../../core/utils/types/ids";
 import { useEventStatistics } from "../../../../core/statistics/useStatistics";
 import { statistics } from "../../../../core/statistics/statistics";
+import PlayerModal from "../../player-modal/PlayerModal";
 
 type MaterialButtonsOnlineInternalType = {
   size?: ButtonSize;
@@ -201,25 +202,28 @@ const MaterialButtonsOnlineInternal: FC<MaterialButtonsOnlineInternalType> = ({
 
     if (isAlreadyLoaned && orderId) {
       return (
-        <Button
-          dataCy={`${dataCy}-player`}
-          label={t("onlineMaterialPlayerText", {
-            placeholders: { "@materialType": manifestationType }
-          })}
-          buttonType="none"
-          variant="filled"
-          size={size || "large"}
-          onClick={() => {
-            track("click", {
-              id: statistics.publizonReadListen.id,
-              name: statistics.publizonReadListen.name,
-              trackedData: workId
-            });
-            open(playerModalId(orderId));
-          }}
-          disabled={false}
-          collapsible={false}
-        />
+        <>
+          <PlayerModal orderId={orderId} />
+          <Button
+            dataCy={`${dataCy}-player`}
+            label={t("onlineMaterialPlayerText", {
+              placeholders: { "@materialType": manifestationType }
+            })}
+            buttonType="none"
+            variant="filled"
+            size={size || "large"}
+            onClick={() => {
+              track("click", {
+                id: statistics.publizonReadListen.id,
+                name: statistics.publizonReadListen.name,
+                trackedData: workId
+              });
+              open(playerModalId(orderId));
+            }}
+            disabled={false}
+            collapsible={false}
+          />
+        </>
       );
     }
 
@@ -246,20 +250,23 @@ const MaterialButtonsOnlineInternal: FC<MaterialButtonsOnlineInternalType> = ({
 
     if (identifier) {
       return (
-        <MaterialSecondaryButton
-          label={tryLabel}
-          size={size || "large"}
-          onClick={() => {
-            track("click", {
-              id: statistics.publizonTry.id,
-              name: statistics.publizonTry.name,
-              trackedData: workId
-            });
-            open(playerModalId(identifier));
-          }}
-          dataCy={`${dataCy}-player-teaser`}
-          ariaDescribedBy={t("onlineMaterialTeaserText")}
-        />
+        <>
+          <PlayerModal identifier={identifier} />
+          <MaterialSecondaryButton
+            label={tryLabel}
+            size={size || "large"}
+            onClick={() => {
+              track("click", {
+                id: statistics.publizonTry.id,
+                name: statistics.publizonTry.name,
+                trackedData: workId
+              });
+              open(playerModalId(identifier));
+            }}
+            dataCy={`${dataCy}-player-teaser`}
+            ariaDescribedBy={t("onlineMaterialTeaserText")}
+          />
+        </>
       );
     }
     return null;


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-109

#### Test
https://varnish.pr-2483.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2483

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2483

#### Description

There were two main issues:

1. The `<OnlineInternalModal />` was only rendered when the selected manifestation was an e-book or e-audiobook. This prevented the modal from opening via the buttons in the editions list when a physical book was selected.

2. We were only rendering a modal for the selected manifestation’s Faust ID. As a result, if a user selected an e-book or audiobook, only that specific modal was available — others were not.

This update ensures that:
- A modal is rendered for each Faust ID, regardless of the selected manifestation.
- Users can always open the correct modal when interacting with loan/reservation buttons for e-materials.

**Additional Fix**

The same issue existed for the <PlayerModal /> component. This update ensures that when a “Listen” or “Try Audiobook” button is rendered, the corresponding <PlayerModal /> is also available.
