### PR TITLE
Temporarily switch action-gh-release version

### DIFF
--- a/.github/workflows/create-release-on-branch-changes.yml
+++ b/.github/workflows/create-release-on-branch-changes.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         with:
           target_commitish: ${{ env.RELEASE_SHA }}
           tag_name: ${{ env.TAG_NAME }}

--- a/.github/workflows/create-release-on-tag.yml
+++ b/.github/workflows/create-release-on-tag.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         with:
           files: ${{ env.DIST_FILENAME }}
 


### PR DESCRIPTION
#### Description

There is a bug with version `2.3.0` of `softprops/action-gh-release`. The solution I found on GitHub is to temporarily switch to a specific commit of the action.

This pull request updates the GitHub Actions workflows to use a specific commit hash for the `softprops/action-gh-release` action, instead of relying on the `v2` version tag.

Refs:
- https://github.com/softprops/action-gh-release/issues/627
- https://github.com/softprops/action-gh-release/issues/628