### PR TITLE
DDFBRA-674 - Trim `instantLoanString` and `materialGroup.name` to prevent mismatches

### DIFF
--- a/src/components/reservation/helper.ts
+++ b/src/components/reservation/helper.ts
@@ -237,7 +237,8 @@ export const getInstantLoanBranchHoldings = (
         // and is available, it is an instant loan.
         return (
           instantLoanStrings.some(
-            (instantLoanString) => instantLoanString === materialGroup.name
+            (instantLoanString) =>
+              instantLoanString.trim() === materialGroup.name.trim()
           ) && available
         );
       });


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-674

#### Description
While working on DDFBRA-674, I discovered a bug related to instantloan that was not mentioned in the ticket.

At Frederiksberg Library, the value of `instantLoanString` was `"31filial/1xforny/ures"`, whereas `materialGroup.name` was `"31filial/1xforny/ures "` — note the trailing whitespace in the latter. This mismatch led to comparison issues.

To address this, I applied trim() to both values to ensure consistent comparison and prevent errors caused by unexpected whitespace.