### PR TITLE
Use mostRelevant manifestation

### DIFF
--- a/src/components/autosuggest/autosuggest.graphql
+++ b/src/components/autosuggest/autosuggest.graphql
@@ -19,6 +19,10 @@ query suggestionsFromQueryString($q: String!) {
             pid
             ...WithLanguages
           }
+          mostRelevant {
+            pid
+            ...WithLanguages
+          }
         }
       }
     }

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -8,6 +8,9 @@ fragment ManifestationsSimple on Manifestations {
   bestRepresentation {
     ...ManifestationsSimpleFields
   }
+  mostRelevant {
+    ...ManifestationsSimpleFields
+  }
 }
 
 fragment ManifestationsAccess on Manifestations {

--- a/src/core/dbc-gateway/generated/graphql.schema.json
+++ b/src/core/dbc-gateway/generated/graphql.schema.json
@@ -5312,8 +5312,8 @@
               "name": "ManifestationParts",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use 'Manifestation.contents' instead expires: 01/11-2025"
           },
           {
             "name": "marc",
@@ -5608,8 +5608,8 @@
               "name": "TableOfContent",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use 'Manifestation.contents' instead expires: 01/11-2025"
           },
           {
             "name": "titles",

--- a/src/core/dbc-gateway/generated/graphql.ts
+++ b/src/core/dbc-gateway/generated/graphql.ts
@@ -849,7 +849,10 @@ export type Manifestation = {
   latestPrinting?: Maybe<Printing>;
   /** Identification of the local id of this manifestation */
   localId?: Maybe<Scalars["String"]["output"]>;
-  /** Tracks on music album, sheet music content, or articles/short stories etc. in this manifestation */
+  /**
+   * Tracks on music album, sheet music content, or articles/short stories etc. in this manifestation
+   * @deprecated Use 'Manifestation.contents' instead expires: 01/11-2025
+   */
   manifestationParts?: Maybe<ManifestationParts>;
   /** Field for presenting bibliographic records in MARC format */
   marc?: Maybe<MarcRecord>;
@@ -883,7 +886,10 @@ export type Manifestation = {
   source: Array<Scalars["String"]["output"]>;
   /** Subjects for this manifestation */
   subjects: SubjectContainer;
-  /** Quotation of the manifestation's table of contents or a similar content list */
+  /**
+   * Quotation of the manifestation's table of contents or a similar content list
+   * @deprecated Use 'Manifestation.contents' instead expires: 01/11-2025
+   */
   tableOfContents?: Maybe<TableOfContent>;
   /** Different kinds of titles for this work */
   titles: ManifestationTitles;
@@ -2609,6 +2615,135 @@ export type GetSmallWorkQuery = {
           otherCatalogues: Array<string>;
         };
       };
+      mostRelevant: Array<{
+        __typename?: "Manifestation";
+        pid: string;
+        genreAndForm: Array<string>;
+        source: Array<string>;
+        publisher: Array<string>;
+        titles: {
+          __typename?: "ManifestationTitles";
+          main: Array<string>;
+          original?: Array<string> | null;
+        };
+        fictionNonfiction?: {
+          __typename?: "FictionNonfiction";
+          display: string;
+          code: FictionNonfictionCodeEnum;
+        } | null;
+        materialTypes: Array<{
+          __typename?: "MaterialType";
+          materialTypeSpecific: {
+            __typename?: "SpecificMaterialType";
+            display: string;
+          };
+        }>;
+        creators: Array<
+          | { __typename: "Corporation"; display: string; nameSort: string }
+          | { __typename: "Person"; display: string; nameSort: string }
+        >;
+        identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+        contributors: Array<
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+        >;
+        edition?: {
+          __typename?: "Edition";
+          summary: string;
+          publicationYear?: {
+            __typename?: "PublicationYear";
+            display: string;
+          } | null;
+        } | null;
+        dateFirstEdition?: {
+          __typename?: "PublicationYear";
+          display: string;
+          year?: number | null;
+        } | null;
+        audience?: {
+          __typename?: "Audience";
+          generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
+        } | null;
+        physicalDescription?: {
+          __typename?: "PhysicalUnitDescription";
+          summaryFull?: string | null;
+          numberOfPages?: number | null;
+        } | null;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
+        accessTypes: Array<{
+          __typename?: "AccessType";
+          code: AccessTypeCodeEnum;
+        }>;
+        access: Array<
+          | {
+              __typename: "AccessUrl";
+              origin: string;
+              url: string;
+              loginRequired: boolean;
+              status: LinkStatusEnum;
+            }
+          | { __typename: "DigitalArticleService"; issn: string }
+          | {
+              __typename: "Ereol";
+              origin: string;
+              url: string;
+              canAlwaysBeLoaned: boolean;
+            }
+          | { __typename: "InfomediaService"; id: string }
+          | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+        >;
+        shelfmark?: {
+          __typename?: "Shelfmark";
+          postfix?: string | null;
+          shelfmark: string;
+        } | null;
+        workYear?: {
+          __typename?: "PublicationYear";
+          year?: number | null;
+        } | null;
+        catalogueCodes: {
+          __typename?: "CatalogueCodes";
+          nationalBibliography: Array<string>;
+          otherCatalogues: Array<string>;
+        };
+      }>;
     };
   } | null;
 };
@@ -3247,6 +3382,135 @@ export type GetMaterialQuery = {
           otherCatalogues: Array<string>;
         };
       };
+      mostRelevant: Array<{
+        __typename?: "Manifestation";
+        pid: string;
+        genreAndForm: Array<string>;
+        source: Array<string>;
+        publisher: Array<string>;
+        titles: {
+          __typename?: "ManifestationTitles";
+          main: Array<string>;
+          original?: Array<string> | null;
+        };
+        fictionNonfiction?: {
+          __typename?: "FictionNonfiction";
+          display: string;
+          code: FictionNonfictionCodeEnum;
+        } | null;
+        materialTypes: Array<{
+          __typename?: "MaterialType";
+          materialTypeSpecific: {
+            __typename?: "SpecificMaterialType";
+            display: string;
+          };
+        }>;
+        creators: Array<
+          | { __typename: "Corporation"; display: string; nameSort: string }
+          | { __typename: "Person"; display: string; nameSort: string }
+        >;
+        identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+        contributors: Array<
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+        >;
+        edition?: {
+          __typename?: "Edition";
+          summary: string;
+          publicationYear?: {
+            __typename?: "PublicationYear";
+            display: string;
+          } | null;
+        } | null;
+        dateFirstEdition?: {
+          __typename?: "PublicationYear";
+          display: string;
+          year?: number | null;
+        } | null;
+        audience?: {
+          __typename?: "Audience";
+          generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
+        } | null;
+        physicalDescription?: {
+          __typename?: "PhysicalUnitDescription";
+          summaryFull?: string | null;
+          numberOfPages?: number | null;
+        } | null;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
+        accessTypes: Array<{
+          __typename?: "AccessType";
+          code: AccessTypeCodeEnum;
+        }>;
+        access: Array<
+          | {
+              __typename: "AccessUrl";
+              origin: string;
+              url: string;
+              loginRequired: boolean;
+              status: LinkStatusEnum;
+            }
+          | { __typename: "DigitalArticleService"; issn: string }
+          | {
+              __typename: "Ereol";
+              origin: string;
+              url: string;
+              canAlwaysBeLoaned: boolean;
+            }
+          | { __typename: "InfomediaService"; id: string }
+          | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+        >;
+        shelfmark?: {
+          __typename?: "Shelfmark";
+          postfix?: string | null;
+          shelfmark: string;
+        } | null;
+        workYear?: {
+          __typename?: "PublicationYear";
+          year?: number | null;
+        } | null;
+        catalogueCodes: {
+          __typename?: "CatalogueCodes";
+          nationalBibliography: Array<string>;
+          otherCatalogues: Array<string>;
+        };
+      }>;
     };
   } | null;
 };
@@ -3739,6 +4003,135 @@ export type GetMaterialGloballyQuery = {
           otherCatalogues: Array<string>;
         };
       };
+      mostRelevant: Array<{
+        __typename?: "Manifestation";
+        pid: string;
+        genreAndForm: Array<string>;
+        source: Array<string>;
+        publisher: Array<string>;
+        titles: {
+          __typename?: "ManifestationTitles";
+          main: Array<string>;
+          original?: Array<string> | null;
+        };
+        fictionNonfiction?: {
+          __typename?: "FictionNonfiction";
+          display: string;
+          code: FictionNonfictionCodeEnum;
+        } | null;
+        materialTypes: Array<{
+          __typename?: "MaterialType";
+          materialTypeSpecific: {
+            __typename?: "SpecificMaterialType";
+            display: string;
+          };
+        }>;
+        creators: Array<
+          | { __typename: "Corporation"; display: string; nameSort: string }
+          | { __typename: "Person"; display: string; nameSort: string }
+        >;
+        identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+        contributors: Array<
+          | {
+              __typename?: "Corporation";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+          | {
+              __typename?: "Person";
+              display: string;
+              roles: Array<{
+                __typename?: "Role";
+                function: { __typename?: "Translation"; singular: string };
+              }>;
+            }
+        >;
+        edition?: {
+          __typename?: "Edition";
+          summary: string;
+          publicationYear?: {
+            __typename?: "PublicationYear";
+            display: string;
+          } | null;
+        } | null;
+        dateFirstEdition?: {
+          __typename?: "PublicationYear";
+          display: string;
+          year?: number | null;
+        } | null;
+        audience?: {
+          __typename?: "Audience";
+          generalAudience: Array<string>;
+          ages: Array<{ __typename?: "Range"; display: string }>;
+          childrenOrAdults: Array<{
+            __typename?: "ChildOrAdult";
+            display: string;
+            code: ChildOrAdultCodeEnum;
+          }>;
+        } | null;
+        notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+        languages?: {
+          __typename?: "Languages";
+          notes?: Array<string> | null;
+          main?: Array<{
+            __typename?: "Language";
+            display: string;
+            isoCode: string;
+          }> | null;
+        } | null;
+        physicalDescription?: {
+          __typename?: "PhysicalUnitDescription";
+          summaryFull?: string | null;
+          numberOfPages?: number | null;
+        } | null;
+        hostPublication?: {
+          __typename?: "HostPublication";
+          summary: string;
+        } | null;
+        manifestationParts?: {
+          __typename?: "ManifestationParts";
+          parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+        } | null;
+        accessTypes: Array<{
+          __typename?: "AccessType";
+          code: AccessTypeCodeEnum;
+        }>;
+        access: Array<
+          | {
+              __typename: "AccessUrl";
+              origin: string;
+              url: string;
+              loginRequired: boolean;
+              status: LinkStatusEnum;
+            }
+          | { __typename: "DigitalArticleService"; issn: string }
+          | {
+              __typename: "Ereol";
+              origin: string;
+              url: string;
+              canAlwaysBeLoaned: boolean;
+            }
+          | { __typename: "InfomediaService"; id: string }
+          | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+        >;
+        shelfmark?: {
+          __typename?: "Shelfmark";
+          postfix?: string | null;
+          shelfmark: string;
+        } | null;
+        workYear?: {
+          __typename?: "PublicationYear";
+          year?: number | null;
+        } | null;
+        catalogueCodes: {
+          __typename?: "CatalogueCodes";
+          nationalBibliography: Array<string>;
+          otherCatalogues: Array<string>;
+        };
+      }>;
     };
   } | null;
 };
@@ -4275,6 +4668,135 @@ export type RecommendFromFaustQuery = {
               otherCatalogues: Array<string>;
             };
           };
+          mostRelevant: Array<{
+            __typename?: "Manifestation";
+            pid: string;
+            genreAndForm: Array<string>;
+            source: Array<string>;
+            publisher: Array<string>;
+            titles: {
+              __typename?: "ManifestationTitles";
+              main: Array<string>;
+              original?: Array<string> | null;
+            };
+            fictionNonfiction?: {
+              __typename?: "FictionNonfiction";
+              display: string;
+              code: FictionNonfictionCodeEnum;
+            } | null;
+            materialTypes: Array<{
+              __typename?: "MaterialType";
+              materialTypeSpecific: {
+                __typename?: "SpecificMaterialType";
+                display: string;
+              };
+            }>;
+            creators: Array<
+              | { __typename: "Corporation"; display: string; nameSort: string }
+              | { __typename: "Person"; display: string; nameSort: string }
+            >;
+            identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+            contributors: Array<
+              | {
+                  __typename?: "Corporation";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
+              | {
+                  __typename?: "Person";
+                  display: string;
+                  roles: Array<{
+                    __typename?: "Role";
+                    function: { __typename?: "Translation"; singular: string };
+                  }>;
+                }
+            >;
+            edition?: {
+              __typename?: "Edition";
+              summary: string;
+              publicationYear?: {
+                __typename?: "PublicationYear";
+                display: string;
+              } | null;
+            } | null;
+            dateFirstEdition?: {
+              __typename?: "PublicationYear";
+              display: string;
+              year?: number | null;
+            } | null;
+            audience?: {
+              __typename?: "Audience";
+              generalAudience: Array<string>;
+              ages: Array<{ __typename?: "Range"; display: string }>;
+              childrenOrAdults: Array<{
+                __typename?: "ChildOrAdult";
+                display: string;
+                code: ChildOrAdultCodeEnum;
+              }>;
+            } | null;
+            notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+            languages?: {
+              __typename?: "Languages";
+              notes?: Array<string> | null;
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
+            } | null;
+            physicalDescription?: {
+              __typename?: "PhysicalUnitDescription";
+              summaryFull?: string | null;
+              numberOfPages?: number | null;
+            } | null;
+            hostPublication?: {
+              __typename?: "HostPublication";
+              summary: string;
+            } | null;
+            manifestationParts?: {
+              __typename?: "ManifestationParts";
+              parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+            } | null;
+            accessTypes: Array<{
+              __typename?: "AccessType";
+              code: AccessTypeCodeEnum;
+            }>;
+            access: Array<
+              | {
+                  __typename: "AccessUrl";
+                  origin: string;
+                  url: string;
+                  loginRequired: boolean;
+                  status: LinkStatusEnum;
+                }
+              | { __typename: "DigitalArticleService"; issn: string }
+              | {
+                  __typename: "Ereol";
+                  origin: string;
+                  url: string;
+                  canAlwaysBeLoaned: boolean;
+                }
+              | { __typename: "InfomediaService"; id: string }
+              | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+            >;
+            shelfmark?: {
+              __typename?: "Shelfmark";
+              postfix?: string | null;
+              shelfmark: string;
+            } | null;
+            workYear?: {
+              __typename?: "PublicationYear";
+              year?: number | null;
+            } | null;
+            catalogueCodes: {
+              __typename?: "CatalogueCodes";
+              nationalBibliography: Array<string>;
+              otherCatalogues: Array<string>;
+            };
+          }>;
         };
       };
     }>;
@@ -4724,6 +5246,135 @@ export type SearchWithPaginationQuery = {
             otherCatalogues: Array<string>;
           };
         };
+        mostRelevant: Array<{
+          __typename?: "Manifestation";
+          pid: string;
+          genreAndForm: Array<string>;
+          source: Array<string>;
+          publisher: Array<string>;
+          titles: {
+            __typename?: "ManifestationTitles";
+            main: Array<string>;
+            original?: Array<string> | null;
+          };
+          fictionNonfiction?: {
+            __typename?: "FictionNonfiction";
+            display: string;
+            code: FictionNonfictionCodeEnum;
+          } | null;
+          materialTypes: Array<{
+            __typename?: "MaterialType";
+            materialTypeSpecific: {
+              __typename?: "SpecificMaterialType";
+              display: string;
+            };
+          }>;
+          creators: Array<
+            | { __typename: "Corporation"; display: string; nameSort: string }
+            | { __typename: "Person"; display: string; nameSort: string }
+          >;
+          identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+          contributors: Array<
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+          >;
+          edition?: {
+            __typename?: "Edition";
+            summary: string;
+            publicationYear?: {
+              __typename?: "PublicationYear";
+              display: string;
+            } | null;
+          } | null;
+          dateFirstEdition?: {
+            __typename?: "PublicationYear";
+            display: string;
+            year?: number | null;
+          } | null;
+          audience?: {
+            __typename?: "Audience";
+            generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
+          } | null;
+          physicalDescription?: {
+            __typename?: "PhysicalUnitDescription";
+            summaryFull?: string | null;
+            numberOfPages?: number | null;
+          } | null;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
+          accessTypes: Array<{
+            __typename?: "AccessType";
+            code: AccessTypeCodeEnum;
+          }>;
+          access: Array<
+            | {
+                __typename: "AccessUrl";
+                origin: string;
+                url: string;
+                loginRequired: boolean;
+                status: LinkStatusEnum;
+              }
+            | { __typename: "DigitalArticleService"; issn: string }
+            | {
+                __typename: "Ereol";
+                origin: string;
+                url: string;
+                canAlwaysBeLoaned: boolean;
+              }
+            | { __typename: "InfomediaService"; id: string }
+            | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+          >;
+          shelfmark?: {
+            __typename?: "Shelfmark";
+            postfix?: string | null;
+            shelfmark: string;
+          } | null;
+          workYear?: {
+            __typename?: "PublicationYear";
+            year?: number | null;
+          } | null;
+          catalogueCodes: {
+            __typename?: "CatalogueCodes";
+            nationalBibliography: Array<string>;
+            otherCatalogues: Array<string>;
+          };
+        }>;
       };
     }>;
   };
@@ -5220,6 +5871,135 @@ export type ComplexSearchWithPaginationQuery = {
             otherCatalogues: Array<string>;
           };
         };
+        mostRelevant: Array<{
+          __typename?: "Manifestation";
+          pid: string;
+          genreAndForm: Array<string>;
+          source: Array<string>;
+          publisher: Array<string>;
+          titles: {
+            __typename?: "ManifestationTitles";
+            main: Array<string>;
+            original?: Array<string> | null;
+          };
+          fictionNonfiction?: {
+            __typename?: "FictionNonfiction";
+            display: string;
+            code: FictionNonfictionCodeEnum;
+          } | null;
+          materialTypes: Array<{
+            __typename?: "MaterialType";
+            materialTypeSpecific: {
+              __typename?: "SpecificMaterialType";
+              display: string;
+            };
+          }>;
+          creators: Array<
+            | { __typename: "Corporation"; display: string; nameSort: string }
+            | { __typename: "Person"; display: string; nameSort: string }
+          >;
+          identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+          contributors: Array<
+            | {
+                __typename?: "Corporation";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+            | {
+                __typename?: "Person";
+                display: string;
+                roles: Array<{
+                  __typename?: "Role";
+                  function: { __typename?: "Translation"; singular: string };
+                }>;
+              }
+          >;
+          edition?: {
+            __typename?: "Edition";
+            summary: string;
+            publicationYear?: {
+              __typename?: "PublicationYear";
+              display: string;
+            } | null;
+          } | null;
+          dateFirstEdition?: {
+            __typename?: "PublicationYear";
+            display: string;
+            year?: number | null;
+          } | null;
+          audience?: {
+            __typename?: "Audience";
+            generalAudience: Array<string>;
+            ages: Array<{ __typename?: "Range"; display: string }>;
+            childrenOrAdults: Array<{
+              __typename?: "ChildOrAdult";
+              display: string;
+              code: ChildOrAdultCodeEnum;
+            }>;
+          } | null;
+          notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+          languages?: {
+            __typename?: "Languages";
+            notes?: Array<string> | null;
+            main?: Array<{
+              __typename?: "Language";
+              display: string;
+              isoCode: string;
+            }> | null;
+          } | null;
+          physicalDescription?: {
+            __typename?: "PhysicalUnitDescription";
+            summaryFull?: string | null;
+            numberOfPages?: number | null;
+          } | null;
+          hostPublication?: {
+            __typename?: "HostPublication";
+            summary: string;
+          } | null;
+          manifestationParts?: {
+            __typename?: "ManifestationParts";
+            parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+          } | null;
+          accessTypes: Array<{
+            __typename?: "AccessType";
+            code: AccessTypeCodeEnum;
+          }>;
+          access: Array<
+            | {
+                __typename: "AccessUrl";
+                origin: string;
+                url: string;
+                loginRequired: boolean;
+                status: LinkStatusEnum;
+              }
+            | { __typename: "DigitalArticleService"; issn: string }
+            | {
+                __typename: "Ereol";
+                origin: string;
+                url: string;
+                canAlwaysBeLoaned: boolean;
+              }
+            | { __typename: "InfomediaService"; id: string }
+            | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+          >;
+          shelfmark?: {
+            __typename?: "Shelfmark";
+            postfix?: string | null;
+            shelfmark: string;
+          } | null;
+          workYear?: {
+            __typename?: "PublicationYear";
+            year?: number | null;
+          } | null;
+          catalogueCodes: {
+            __typename?: "CatalogueCodes";
+            nationalBibliography: Array<string>;
+            otherCatalogues: Array<string>;
+          };
+        }>;
       };
     }>;
   };
@@ -5260,6 +6040,18 @@ export type SuggestionsFromQueryStringQuery = {
               }> | null;
             } | null;
           };
+          mostRelevant: Array<{
+            __typename?: "Manifestation";
+            pid: string;
+            languages?: {
+              __typename?: "Languages";
+              main?: Array<{
+                __typename?: "Language";
+                display: string;
+                isoCode: string;
+              }> | null;
+            } | null;
+          }>;
         };
       } | null;
     }>;
@@ -5728,6 +6520,129 @@ export type ManifestationsSimpleFragment = {
       otherCatalogues: Array<string>;
     };
   };
+  mostRelevant: Array<{
+    __typename?: "Manifestation";
+    pid: string;
+    genreAndForm: Array<string>;
+    source: Array<string>;
+    publisher: Array<string>;
+    titles: {
+      __typename?: "ManifestationTitles";
+      main: Array<string>;
+      original?: Array<string> | null;
+    };
+    fictionNonfiction?: {
+      __typename?: "FictionNonfiction";
+      display: string;
+      code: FictionNonfictionCodeEnum;
+    } | null;
+    materialTypes: Array<{
+      __typename?: "MaterialType";
+      materialTypeSpecific: {
+        __typename?: "SpecificMaterialType";
+        display: string;
+      };
+    }>;
+    creators: Array<
+      | { __typename: "Corporation"; display: string; nameSort: string }
+      | { __typename: "Person"; display: string; nameSort: string }
+    >;
+    identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+    contributors: Array<
+      | {
+          __typename?: "Corporation";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
+      | {
+          __typename?: "Person";
+          display: string;
+          roles: Array<{
+            __typename?: "Role";
+            function: { __typename?: "Translation"; singular: string };
+          }>;
+        }
+    >;
+    edition?: {
+      __typename?: "Edition";
+      summary: string;
+      publicationYear?: {
+        __typename?: "PublicationYear";
+        display: string;
+      } | null;
+    } | null;
+    dateFirstEdition?: {
+      __typename?: "PublicationYear";
+      display: string;
+      year?: number | null;
+    } | null;
+    audience?: {
+      __typename?: "Audience";
+      generalAudience: Array<string>;
+      ages: Array<{ __typename?: "Range"; display: string }>;
+      childrenOrAdults: Array<{
+        __typename?: "ChildOrAdult";
+        display: string;
+        code: ChildOrAdultCodeEnum;
+      }>;
+    } | null;
+    notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+    languages?: {
+      __typename?: "Languages";
+      notes?: Array<string> | null;
+      main?: Array<{
+        __typename?: "Language";
+        display: string;
+        isoCode: string;
+      }> | null;
+    } | null;
+    physicalDescription?: {
+      __typename?: "PhysicalUnitDescription";
+      summaryFull?: string | null;
+      numberOfPages?: number | null;
+    } | null;
+    hostPublication?: {
+      __typename?: "HostPublication";
+      summary: string;
+    } | null;
+    manifestationParts?: {
+      __typename?: "ManifestationParts";
+      parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+    } | null;
+    accessTypes: Array<{ __typename?: "AccessType"; code: AccessTypeCodeEnum }>;
+    access: Array<
+      | {
+          __typename: "AccessUrl";
+          origin: string;
+          url: string;
+          loginRequired: boolean;
+          status: LinkStatusEnum;
+        }
+      | { __typename: "DigitalArticleService"; issn: string }
+      | {
+          __typename: "Ereol";
+          origin: string;
+          url: string;
+          canAlwaysBeLoaned: boolean;
+        }
+      | { __typename: "InfomediaService"; id: string }
+      | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+    >;
+    shelfmark?: {
+      __typename?: "Shelfmark";
+      postfix?: string | null;
+      shelfmark: string;
+    } | null;
+    workYear?: { __typename?: "PublicationYear"; year?: number | null } | null;
+    catalogueCodes: {
+      __typename?: "CatalogueCodes";
+      nationalBibliography: Array<string>;
+      otherCatalogues: Array<string>;
+    };
+  }>;
 };
 
 export type ManifestationsAccessFragment = {
@@ -6409,6 +7324,135 @@ export type WorkSmallFragment = {
         otherCatalogues: Array<string>;
       };
     };
+    mostRelevant: Array<{
+      __typename?: "Manifestation";
+      pid: string;
+      genreAndForm: Array<string>;
+      source: Array<string>;
+      publisher: Array<string>;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      fictionNonfiction?: {
+        __typename?: "FictionNonfiction";
+        display: string;
+        code: FictionNonfictionCodeEnum;
+      } | null;
+      materialTypes: Array<{
+        __typename?: "MaterialType";
+        materialTypeSpecific: {
+          __typename?: "SpecificMaterialType";
+          display: string;
+        };
+      }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string; nameSort: string }
+        | { __typename: "Person"; display: string; nameSort: string }
+      >;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+      >;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
+      } | null;
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
+      } | null;
+      physicalDescription?: {
+        __typename?: "PhysicalUnitDescription";
+        summaryFull?: string | null;
+        numberOfPages?: number | null;
+      } | null;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
+      accessTypes: Array<{
+        __typename?: "AccessType";
+        code: AccessTypeCodeEnum;
+      }>;
+      access: Array<
+        | {
+            __typename: "AccessUrl";
+            origin: string;
+            url: string;
+            loginRequired: boolean;
+            status: LinkStatusEnum;
+          }
+        | { __typename: "DigitalArticleService"; issn: string }
+        | {
+            __typename: "Ereol";
+            origin: string;
+            url: string;
+            canAlwaysBeLoaned: boolean;
+          }
+        | { __typename: "InfomediaService"; id: string }
+        | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+      >;
+      shelfmark?: {
+        __typename?: "Shelfmark";
+        postfix?: string | null;
+        shelfmark: string;
+      } | null;
+      workYear?: {
+        __typename?: "PublicationYear";
+        year?: number | null;
+      } | null;
+      catalogueCodes: {
+        __typename?: "CatalogueCodes";
+        nationalBibliography: Array<string>;
+        otherCatalogues: Array<string>;
+      };
+    }>;
   };
 };
 
@@ -6894,6 +7938,135 @@ export type WorkMediumFragment = {
         otherCatalogues: Array<string>;
       };
     };
+    mostRelevant: Array<{
+      __typename?: "Manifestation";
+      pid: string;
+      genreAndForm: Array<string>;
+      source: Array<string>;
+      publisher: Array<string>;
+      titles: {
+        __typename?: "ManifestationTitles";
+        main: Array<string>;
+        original?: Array<string> | null;
+      };
+      fictionNonfiction?: {
+        __typename?: "FictionNonfiction";
+        display: string;
+        code: FictionNonfictionCodeEnum;
+      } | null;
+      materialTypes: Array<{
+        __typename?: "MaterialType";
+        materialTypeSpecific: {
+          __typename?: "SpecificMaterialType";
+          display: string;
+        };
+      }>;
+      creators: Array<
+        | { __typename: "Corporation"; display: string; nameSort: string }
+        | { __typename: "Person"; display: string; nameSort: string }
+      >;
+      identifiers: Array<{ __typename?: "Identifier"; value: string }>;
+      contributors: Array<
+        | {
+            __typename?: "Corporation";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+        | {
+            __typename?: "Person";
+            display: string;
+            roles: Array<{
+              __typename?: "Role";
+              function: { __typename?: "Translation"; singular: string };
+            }>;
+          }
+      >;
+      edition?: {
+        __typename?: "Edition";
+        summary: string;
+        publicationYear?: {
+          __typename?: "PublicationYear";
+          display: string;
+        } | null;
+      } | null;
+      dateFirstEdition?: {
+        __typename?: "PublicationYear";
+        display: string;
+        year?: number | null;
+      } | null;
+      audience?: {
+        __typename?: "Audience";
+        generalAudience: Array<string>;
+        ages: Array<{ __typename?: "Range"; display: string }>;
+        childrenOrAdults: Array<{
+          __typename?: "ChildOrAdult";
+          display: string;
+          code: ChildOrAdultCodeEnum;
+        }>;
+      } | null;
+      notes: Array<{ __typename?: "Note"; display: Array<string> }>;
+      languages?: {
+        __typename?: "Languages";
+        notes?: Array<string> | null;
+        main?: Array<{
+          __typename?: "Language";
+          display: string;
+          isoCode: string;
+        }> | null;
+      } | null;
+      physicalDescription?: {
+        __typename?: "PhysicalUnitDescription";
+        summaryFull?: string | null;
+        numberOfPages?: number | null;
+      } | null;
+      hostPublication?: {
+        __typename?: "HostPublication";
+        summary: string;
+      } | null;
+      manifestationParts?: {
+        __typename?: "ManifestationParts";
+        parts: Array<{ __typename?: "ManifestationPart"; title: string }>;
+      } | null;
+      accessTypes: Array<{
+        __typename?: "AccessType";
+        code: AccessTypeCodeEnum;
+      }>;
+      access: Array<
+        | {
+            __typename: "AccessUrl";
+            origin: string;
+            url: string;
+            loginRequired: boolean;
+            status: LinkStatusEnum;
+          }
+        | { __typename: "DigitalArticleService"; issn: string }
+        | {
+            __typename: "Ereol";
+            origin: string;
+            url: string;
+            canAlwaysBeLoaned: boolean;
+          }
+        | { __typename: "InfomediaService"; id: string }
+        | { __typename: "InterLibraryLoan"; loanIsPossible: boolean }
+      >;
+      shelfmark?: {
+        __typename?: "Shelfmark";
+        postfix?: string | null;
+        shelfmark: string;
+      } | null;
+      workYear?: {
+        __typename?: "PublicationYear";
+        year?: number | null;
+      } | null;
+      catalogueCodes: {
+        __typename?: "CatalogueCodes";
+        nationalBibliography: Array<string>;
+        otherCatalogues: Array<string>;
+      };
+    }>;
   };
 };
 
@@ -7184,6 +8357,9 @@ export const ManifestationsSimpleFragmentDoc = `
     ...ManifestationsSimpleFields
   }
   bestRepresentation {
+    ...ManifestationsSimpleFields
+  }
+  mostRelevant {
     ...ManifestationsSimpleFields
   }
 }
@@ -7629,6 +8805,10 @@ export const SuggestionsFromQueryStringDocument = `
             pid
           }
           bestRepresentation {
+            pid
+            ...WithLanguages
+          }
+          mostRelevant {
             pid
             ...WithLanguages
           }


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFBRA-694

#### Description
This PR changes some of the logic connected to choosing the correct manifestation to show. Up until now we've been using `bestRepresentation`, and now we switch from that to use `mostRelevant` in the following places:
- when determining which manifestation to select upon selecting a suggestion from autosuggest 
- when determining which manifestation to select upon clicking on a search result card (unless user clicks on a specific manifestation on the card)

#### Screenshot of the result
-

#### Additional comments or questions
-
