### PR TITLE
DDFSAL-85 - Use UTC date formatting for eMaterials

### DIFF
--- a/src/apps/loan-list/list/loan-list.test.ts
+++ b/src/apps/loan-list/list/loan-list.test.ts
@@ -484,7 +484,7 @@ describe("Loan list", () => {
       .find(".list-reservation")
       .eq(0)
       .find(".list-reservation__deadline p")
-      .should("have.text", "Due date 24-10-2022 08:32");
+      .should("have.text", "Due date 24-10-2022 06:32");
 
     // 2.c.ii. Loans have...
     // ID 42 2.a. Material cover
@@ -553,21 +553,21 @@ describe("Loan list", () => {
       .find(".list-reservation")
       .eq(0)
       .find(".list-reservation__deadline p")
-      .should("have.text", "Due date 24-10-2022 08:32");
+      .should("have.text", "Due date 24-10-2022 06:32");
 
     cy.get(".list-reservation-container")
       .eq(1)
       .find(".list-reservation")
       .eq(2)
       .find(".list-reservation__deadline p")
-      .should("have.text", "Due date 28-10-2022 08:32");
+      .should("have.text", "Due date 28-10-2022 06:32");
 
     cy.get(".list-reservation-container")
       .eq(1)
       .find(".list-reservation")
       .eq(2)
       .find(".list-reservation__deadline p")
-      .should("have.text", "Due date 28-10-2022 08:32");
+      .should("have.text", "Due date 28-10-2022 06:32");
   });
 
   it("It opens loans group modal (physical)", () => {

--- a/src/apps/loan-list/materials/stackable-material/material-status.tsx
+++ b/src/apps/loan-list/materials/stackable-material/material-status.tsx
@@ -7,7 +7,7 @@ import { useText } from "../../../../core/utils/text";
 import ArrowButton from "../../../../components/Buttons/ArrowButton";
 import {
   formatDate,
-  formatDateTime
+  formatDateTimeUtc
 } from "../../../../core/utils/helpers/date";
 import StatusMessage from "../selectable-material/StatusMessage";
 
@@ -72,7 +72,7 @@ const MaterialStatus: FC<MaterialStatusProps> = ({
           <p className="text-small-caption color-secondary-gray">
             {isDigital(loan)
               ? t("loanListToBeDeliveredDigitalMaterialText", {
-                  placeholders: { "@date": formatDateTime(dueDate) }
+                  placeholders: { "@date": formatDateTimeUtc(dueDate) }
                 })
               : t("loanListToBeDeliveredText", {
                   placeholders: { "@date": formatDate(dueDate) }

--- a/src/apps/reservation-list/list/reservation-list.test.ts
+++ b/src/apps/reservation-list/list/reservation-list.test.ts
@@ -507,7 +507,7 @@ describe("Reservation list", () => {
 
         cy.getBySel("info-label").should(
           "have.text",
-          "Borrow before 27-01-2023 20:37"
+          "Borrow before 27-01-2023 19:37"
         );
 
         cy.get(".list-reservation__deadline .text-small-caption").should(

--- a/src/apps/reservation-list/modal/reservation-details/digital-list-details.tsx
+++ b/src/apps/reservation-list/modal/reservation-details/digital-list-details.tsx
@@ -5,7 +5,7 @@ import { useText } from "../../../../core/utils/text";
 import { ReservationType } from "../../../../core/utils/types/reservation-type";
 import { MaterialProps } from "../../../loan-list/materials/utils/material-fetch-hoc";
 import ListDetails from "../../../../components/list-details/list-details";
-import { formatDateTime } from "../../../../core/utils/helpers/date";
+import { formatDateTimeUtc } from "../../../../core/utils/helpers/date";
 
 export interface DigitalListDetailsProps {
   reservation: ReservationType;
@@ -25,7 +25,7 @@ const DigitalListDetails: FC<DigitalListDetailsProps & MaterialProps> = ({
           icon={ReservationsIcon}
           title={t("reservationDetailsStatusTitleText")}
           labels={t("reservationDetailsExpiresText", {
-            placeholders: { "@date": formatDateTime(expiryDate) }
+            placeholders: { "@date": formatDateTimeUtc(expiryDate) }
           })}
         />
       )}
@@ -34,14 +34,14 @@ const DigitalListDetails: FC<DigitalListDetailsProps & MaterialProps> = ({
           icon={ReservationsIcon}
           title={t("reservationDetailsStatusTitleText")}
           labels={t("reservationDetailsBorrowBeforeText", {
-            placeholders: { "@date": formatDateTime(pickupDeadline) }
+            placeholders: { "@date": formatDateTimeUtc(pickupDeadline) }
           })}
         />
       )}
       {dateOfReservation && (
         <ListDetails
           icon={LoansIcon}
-          labels={formatDateTime(dateOfReservation)}
+          labels={formatDateTimeUtc(dateOfReservation)}
           title={t("reservationDetailsDateOfReservationTitleText")}
         />
       )}

--- a/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
+++ b/src/apps/reservation-list/modal/reservation-details/reservation-details.test.ts
@@ -212,7 +212,7 @@ describe("Reservation details modal", () => {
     cy.getBySel("reservation-form-list-item")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Your reservation expires 27-01-2023 23:37!");
+      .should("have.text", "Your reservation expires 27-01-2023 22:37!");
 
     // ID 17 2.f. header "date of reservation"
     cy.getBySel("reservation-form-list-item")
@@ -224,7 +224,7 @@ describe("Reservation details modal", () => {
     cy.getBySel("reservation-form-list-item")
       .eq(1)
       .find(".text-small-caption")
-      .should("have.text", "16-08-2022 12:52");
+      .should("have.text", "16-08-2022 10:52");
 
     cy.getBySel("remove-digital-reservation-button")
       .eq(0)
@@ -338,7 +338,7 @@ describe("Reservation details modal", () => {
     cy.getBySel("reservation-form-list-item")
       .eq(0)
       .find(".text-small-caption")
-      .should("have.text", "Borrow before 27-01-2023 23:37");
+      .should("have.text", "Borrow before 27-01-2023 22:37");
   });
 
   it("It shows physical reservation details modal", () => {

--- a/src/core/utils/helpers/date.ts
+++ b/src/core/utils/helpers/date.ts
@@ -2,6 +2,7 @@ import { upperFirst } from "lodash";
 import dayjs from "dayjs";
 import "dayjs/locale/da";
 import weekOfYear from "dayjs/plugin/weekOfYear";
+import utc from "dayjs/plugin/utc";
 import {
   dateFormatCustom,
   dateFormatDash,
@@ -16,6 +17,7 @@ import {
 
 dayjs.locale("da");
 dayjs.extend(weekOfYear);
+dayjs.extend(utc);
 
 const getCurrentUnixTime = () => Math.floor(Date.now() / 1000);
 
@@ -83,6 +85,10 @@ export const formatDateTime = (date: string) => {
   return dayjs(date).format(dateFormatDashWithTime);
 };
 
+export const formatDateTimeUtc = (date: string) => {
+  return dayjs(date).utc().format(dateFormatDashWithTime);
+};
+
 export const formatDayMonth = (date: string | Date) => {
   return dayjs(date).format(dateFormatSlashDayMonth);
 };
@@ -109,7 +115,7 @@ export const formatDateDependingOnDigitalMaterial = ({
   date: string;
   isDigital: boolean;
 }) => {
-  return isDigital ? formatDateTime(date) : formatDate(date);
+  return isDigital ? formatDateTimeUtc(date) : formatDate(date);
 };
 
 // Date calculation functions: Get dates relative to today


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-85

#### Test
https://varnish.pr-2532.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2532

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2532

#### Description
Publizon, which sends the relevant emails, does not support local timezone formatting. This update applies UTC formatting to ensure consistency across all eMaterials.
