### PR TITLE
DDFSAL-188 - Add friendly card number to PatronPage

### DIFF
--- a/src/apps/patron-page/PatronPage.entry.tsx
+++ b/src/apps/patron-page/PatronPage.entry.tsx
@@ -32,6 +32,7 @@ interface PatronPageTextProps {
   patronPageBasicDetailsAddressLabelText: string;
   patronPageBasicDetailsHeaderText: string;
   patronPageBasicDetailsNameLabelText: string;
+  patronPageBasicFriendlyCardNumberLabelText: string;
   patronPageChangePickupBodyText: string;
   patronPageChangePickupHeaderText: string;
   patronPageChangePincodeBodyText: string;

--- a/src/apps/patron-page/PatronPage.stories.tsx
+++ b/src/apps/patron-page/PatronPage.stories.tsx
@@ -80,6 +80,9 @@ const meta: Meta<typeof PatronPage> = {
     patronPageBasicDetailsNameLabelText: {
       control: { type: "text" }
     },
+    patronPageBasicFriendlyCardNumberLabelText: {
+      control: { type: "text" }
+    },
     patronPageBasicDetailsAddressLabelText: {
       control: { type: "text" }
     },
@@ -222,6 +225,7 @@ const meta: Meta<typeof PatronPage> = {
     pauseReservationModalCancelButtonLabelText: "Cancel pause",
     patronPageBasicDetailsHeaderText: "Basic details",
     patronPageBasicDetailsNameLabelText: "Name",
+    patronPageBasicFriendlyCardNumberLabelText: "Card number",
     patronPageBasicDetailsAddressLabelText: "Address",
     patronContactInfoHeaderText: "Contact information",
     patronContactPhoneLabelText: "Phone number",

--- a/src/apps/patron-page/PatronPage.tsx
+++ b/src/apps/patron-page/PatronPage.tsx
@@ -13,12 +13,19 @@ import { usePatronData } from "../../core/utils/helpers/usePatronData";
 import PatronPageSkeleton from "./PatronPageSkeleton";
 import useSavePatron from "../../core/utils/useSavePatron";
 import { Patron } from "../../core/utils/types/entities";
+import { useGetV1UserCardnumberFriendly } from "../../core/publizon/publizon";
+import { FriendlyCardResult } from "../../core/publizon/model";
 
 const PatronPage: FC = () => {
   const t = useText();
   const u = useUrls();
   const deletePatronUrl = u("deletePatronUrl");
   const { data: patronData, isLoading } = usePatronData();
+  const { data: patronCardNumber } = useGetV1UserCardnumberFriendly({
+    query: {
+      enabled: !!patronData
+    }
+  });
   const [patron, setPatron] = useState<Patron | null>(null);
   const [pin, setPin] = useState<string | null>(null);
   const [isPinChangeValid, setIsPinChangeValid] = useState<boolean>(true);
@@ -100,7 +107,13 @@ const PatronPage: FC = () => {
     <form className="dpl-patron-page" onSubmit={(e) => handleSubmit(e)}>
       <h1 className="text-header-h1 my-32">{t("patronPageHeaderText")}</h1>
       <NotificationComponent />
-      {patron && <BasicDetailsSection patron={patron} />}
+      {patron && (
+        <BasicDetailsSection
+          patron={patron}
+          // Cast patronCardNumber to FriendlyCardResult (Api dose not an array)
+          patronCardNumber={patronCardNumber as FriendlyCardResult}
+        />
+      )}
       <div className="patron-page-info">
         {patron && (
           <ContactInfoSection

--- a/src/apps/patron-page/sections/BasicDetailsSection.tsx
+++ b/src/apps/patron-page/sections/BasicDetailsSection.tsx
@@ -1,12 +1,17 @@
 import React, { FC } from "react";
 import { PatronV5 } from "../../../core/fbs/model";
 import { useText } from "../../../core/utils/text";
+import { FriendlyCardResult } from "../../../core/publizon/model";
 
 interface BasicDetailsSectionProps {
   patron: PatronV5;
+  patronCardNumber?: FriendlyCardResult | null;
 }
 
-const BasicDetailsSection: FC<BasicDetailsSectionProps> = ({ patron }) => {
+const BasicDetailsSection: FC<BasicDetailsSectionProps> = ({
+  patron,
+  patronCardNumber
+}) => {
   const t = useText();
   const {
     address: { coName, street, postalCode, city, country } = {
@@ -25,6 +30,16 @@ const BasicDetailsSection: FC<BasicDetailsSectionProps> = ({ patron }) => {
         {t("patronPageBasicDetailsHeaderText")}
       </h2>
       <div className="dpl-patron-info">
+        {patronCardNumber?.friendlyCardNumber && (
+          <>
+            <h3 className="dpl-patron-info__label text-header-h4">
+              {t("patronPageBasicFriendlyCardNumberLabelText")}
+            </h3>
+            <div className="dpl-patron-info__text">
+              {patronCardNumber.friendlyCardNumber}
+            </div>
+          </>
+        )}
         <h3 className="dpl-patron-info__label text-header-h4">
           {t("patronPageBasicDetailsNameLabelText")}
         </h3>


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-188

#### Test
https://varnish.pr-2587.dpl-cms.dplplat01.dpl.reload.dk/user/me

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2587

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2587

#### Description
This PR adds support for displaying the friendly card number on the `PatronPage`, improving the user experience for patrons encountering issues with Publizon.

Publizon's API returns a `FriendlyCardResult` object rather than an array. To handle this correctly, the response is cast to `FriendlyCardResult`, ensuring proper access to the required data.
