### PR TITLE
DDFSAL-201 - Ensure that only the openOrder mutation is called

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -173,7 +173,10 @@ export const ReservationModalBody = ({
   const materialType = getMaterialType(selectedManifestations);
 
   const saveReservation = () => {
-    if (manifestationsToReserve?.length) {
+    if (
+      manifestationsToReserve?.length &&
+      !materialIsReservableFromAnotherLibrary
+    ) {
       setReservationStatus("pending");
       // Save reservation to FBS.
       mutateAddReservations(


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-201

#### Test
https://varnish.pr-1956.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-1956

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/1956

#### Description
If the material should be reserved from another library, it must exclusively use the openOrder mutation. However, for some materials (e.g., `work-of:870970-basis:24363104`), the `manifestationsToReserve?.length` returns true, causing both mutations to be triggered.

To prevent this, I've added a check for `!materialIsReservableFromAnotherLibrary` to ensure that the "normal" reservation mutation (`mutateAddReservations`) is not called in such cases.


#### Related
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1999