### PR TITLE
DDFSAL-251 - Option to have ‘Find on shelf’ always expanded by default.

### DIFF
--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -206,6 +206,7 @@ interface MaterialEntryConfigProps {
   blacklistedInstantLoanBranchesConfig: string;
   blacklistedPickupBranchesConfig?: string;
   branchesConfig: string;
+  findOnShelfDisclosuresDefaultOpenConfig: string;
   instantLoanConfig: string;
   smsNotificationsForReservationsEnabledConfig: string;
 }

--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -71,6 +71,10 @@ const meta: Meta<typeof MaterialEntry> = {
       description: "Branches",
       control: { type: "text" }
     },
+    findOnShelfDisclosuresDefaultOpenConfig: {
+      description: "Find on shelf disclosures default open",
+      control: { type: "text" }
+    },
     materialHeaderAllEditionsText: {
       description: "Text for the fiction edition text",
       control: { type: "text" }
@@ -841,6 +845,7 @@ const meta: Meta<typeof MaterialEntry> = {
       "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024,DK-775164",
     branchesConfig:
       '[\n   {\n      "branchId":"DK-775120",\n      "title":"Højbjerg"\n   },\n   {\n      "branchId":"DK-775122",\n      "title":"Beder-Malling"\n   },\n   {\n      "branchId":"DK-775144",\n      "title":"Gellerup"\n   },\n   {\n      "branchId":"DK-775167",\n      "title":"Lystrup"\n   },\n   {\n      "branchId":"DK-775146",\n      "title":"Harlev"\n   },\n   {\n      "branchId":"DK-775168",\n      "title":"Skødstrup"\n   },\n   {\n      "branchId":"FBS-751010",\n      "title":"Arresten"\n   },\n   {\n      "branchId":"DK-775147",\n      "title":"Hasle"\n   },\n   {\n      "branchId":"FBS-751032",\n      "title":"Må ikke benyttes"\n   },\n   {\n      "branchId":"FBS-751031",\n      "title":"Fjernlager 1"\n   },\n   {\n      "branchId":"DK-775126",\n      "title":"Solbjerg"\n   },\n   {\n      "branchId":"FBS-751030",\n      "title":"ITK"\n   },\n   {\n      "branchId":"DK-775149",\n      "title":"Sabro"\n   },\n   {\n      "branchId":"DK-775127",\n      "title":"Tranbjerg"\n   },\n   {\n      "branchId":"DK-775160",\n      "title":"Risskov"\n   },\n   {\n      "branchId":"DK-775162",\n      "title":"Hjortshøj"\n   },\n   {\n      "branchId":"DK-775140",\n      "title":"Åby"\n   },\n   {\n      "branchId":"FBS-751009",\n      "title":"Fjernlager 2"\n   },\n   {\n      "branchId":"FBS-751029",\n      "title":"Stadsarkivet"\n   },\n   {\n      "branchId":"FBS-751027",\n      "title":"Intern"\n   },\n   {\n      "branchId":"FBS-751026",\n      "title":"Fælles undervejs"\n   },\n   {\n      "branchId":"FBS-751025",\n      "title":"Fællessekretariatet"\n   },\n   {\n      "branchId":"DK-775133",\n      "title":"Bavnehøj"\n   },\n   {\n      "branchId":"FBS-751024",\n      "title":"Fjernlånte materialer"\n   },\n   {\n      "branchId":"DK-775100",\n      "title":"Hovedbiblioteket"\n   },\n   {\n      "branchId":"DK-775170",\n      "title":"Trige"\n   },\n   {\n      "branchId":"DK-775150",\n      "title":"Tilst"\n   },\n   {\n      "branchId":"DK-775130",\n      "title":"Viby"\n   },\n   {\n      "branchId":"DK-775164",\n      "title":"Egå"\n   }\n]',
+    findOnShelfDisclosuresDefaultOpenConfig: "0",
     materialHeaderAllEditionsText: "All editions",
     materialHeaderAuthorByText: "By",
     materialGridRelatedTitleText: "Other materials",

--- a/src/components/find-on-shelf/FindOnShelfModalBody.tsx
+++ b/src/components/find-on-shelf/FindOnShelfModalBody.tsx
@@ -26,6 +26,7 @@ import { PeriodicalEdition } from "../material/periodical/helper";
 import { useConfig } from "../../core/utils/config";
 import DisclosureSummary from "../Disclosures/DisclosureSummary";
 import { constructModalId } from "../../core/utils/helpers/modal-helpers";
+import { isConfigValueOne } from "../reservation/helper";
 
 export const findOnShelfModalId = (faustIds: FaustId[]) => {
   return constructModalId("find-on-shelf-modal", faustIds.sort());
@@ -47,6 +48,9 @@ const FindOnShelfModalBody: FC<FindOnShelfModalBodyProps> = ({
   setSelectedPeriodical
 }) => {
   const config = useConfig();
+  const findOnShelfDisclosuresIsOpen = isConfigValueOne(
+    config("findOnShelfDisclosuresDefaultOpenConfig")
+  );
   const t = useText();
   const pidArray = getManifestationsPids(manifestations);
   const faustIdArray = pidArray.map((manifestationPid) =>
@@ -209,7 +213,7 @@ const FindOnShelfModalBody: FC<FindOnShelfModalBodyProps> = ({
             return (
               <Disclosure
                 key={libraryBranch[0].holding.branch.branchId}
-                open={finalData.length === 1}
+                open={findOnShelfDisclosuresIsOpen || finalData.length === 1}
                 className="disclosure--full-width"
                 dataCy="find-on-shelf-modal-body-disclosure"
                 summary={


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-251

#### Test
https://varnish.pr-2613.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2613

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2613

#### Description

This pull request enables the functionality for the new `find_on_shelf_disclosures_default_open` setting from drupal.

It allows smaller libraries to configure all Find on Shelf disclosures to be open by default.

#### AI
This pull request introduces a new configuration option, `findOnShelfDisclosuresDefaultOpenConfig`, and integrates it across multiple files to control the default open state of disclosures in the "Find on Shelf" modal. The changes ensure the new configuration is properly added to the props, stories, and modal logic.

### Configuration Updates:

* Added `findOnShelfDisclosuresDefaultOpenConfig` to the `MaterialEntryConfigProps` interface in `src/apps/material/material.entry.tsx`. This allows the configuration to be passed as a prop.

* Updated `src/apps/material/material.stories.tsx` to include `findOnShelfDisclosuresDefaultOpenConfig` in the component's metadata, enabling control and description for the configuration in the storybook. [[1]](diffhunk://#diff-9b07f6fd121f5658144cea28c48892b10a418e8cfe2127f1f2d27ee7cef505d5R74-R77) [[2]](diffhunk://#diff-9b07f6fd121f5658144cea28c48892b10a418e8cfe2127f1f2d27ee7cef505d5R848)

### Modal Logic Enhancements:

* Imported `isConfigValueOne` in `src/components/find-on-shelf/FindOnShelfModalBody.tsx` to evaluate the `findOnShelfDisclosuresDefaultOpenConfig` value.

* Added logic in `FindOnShelfModalBody` to determine the default open state of disclosures using the `findOnShelfDisclosuresDefaultOpenConfig`. If the configuration value is set to "1", disclosures will open by default.

* Modified the `Disclosure` component's `open` prop in `FindOnShelfModalBody` to incorporate the new configuration, ensuring disclosures respect the default open state defined by `findOnShelfDisclosuresDefaultOpenConfig`.