### PR TITLE
DDFSAL-252 - Display `dk5MainEntry` (DK5) on foreign fiction

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -199,6 +199,12 @@ export const getManifestationOriginalTitle = (manifestation: Manifestation) => {
   return "Unknown title";
 };
 
+export const materialContainsDanish = (work: Work) => {
+  return work.mainLanguages?.some(({ isoCode }) =>
+    isoCode?.toLowerCase().includes("dan")
+  );
+};
+
 export const getManifestationTitle = ({ titles }: Manifestation): string => {
   // For manifestations, we use the main title if available, as it is translated.
   // Otherwise, we fall back to the original title.
@@ -632,11 +638,8 @@ export const getManifestationBasedOnType = (
   return bestRepresentation;
 };
 
-export const getWorkTitle = ({
-  titles,
-  mainLanguages,
-  manifestations
-}: Work): string => {
+export const getWorkTitle = (work: Work): string => {
+  const { titles, mainLanguages, manifestations } = work;
   // If the work is a movie, we prefer using the translated full title.
   // Avoid showing language details here as it might lead users to think there are no subtitles.
   if (manifestations?.all && isMovie(manifestations.all)) {
@@ -661,11 +664,7 @@ export const getWorkTitle = ({
 
   // If Danish is among the main languages and a full title exists,
   // we prefer showing the full title because it is translated.
-  const containsDanish = mainLanguages.some(({ isoCode }) =>
-    isoCode?.toLowerCase().includes("dan")
-  );
-
-  if (containsDanish && titles.full) {
+  if (materialContainsDanish(work) && titles.full) {
     return titles.full.join(", ");
   }
 

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {
   getUniqueMovies,
-  getDbcVerifiedSubjectsFirst
+  getDbcVerifiedSubjectsFirst,
+  materialContainsDanish
 } from "../../apps/material/helper";
 import { useItemHasBeenVisible } from "../../core/utils/helpers/lazy-load";
 import {
@@ -30,6 +31,10 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
   const { fictionNonfiction, series, subjects, relations, dk5MainEntry } = work;
 
   const isFiction = materialIsFiction(work);
+
+  // Show DK5 for all non-fiction works OR fiction works in non-Danish languages
+  const shouldShowDk5 =
+    !isFiction || (isFiction && !materialContainsDanish(work));
 
   const seriesMembersList =
     (series &&
@@ -81,7 +86,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
             </p>
           )}
           <div className="material-description__links mt-32">
-            {!isFiction && dk5MainEntry && (
+            {shouldShowDk5 && dk5MainEntry && (
               <HorizontalTermLine
                 title={t("subjectNumberText")}
                 linkList={[


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-252

#### Test
https://varnish.pr-2614.dpl-cms.dplplat01.dpl.reload.dk/work/work-of:870970-basis:43310771?type=bog 

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2614

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2614

#### Description

This pull request displays the Subject Number (DK5) on foreign fiction

#### AI
This pull request introduces a helper function, `materialContainsDanish`, to centralize the logic for detecting Danish language presence in `Work` objects. It also refactors existing code to utilize this new helper, improving readability and maintainability. Additionally, it updates the `MaterialDescription` component to conditionally display DK5 entries based on fiction status and language.

### Helper Function Addition:
* [`src/apps/material/helper.ts`](diffhunk://#diff-90b8b65f9f667d6cb947cf9bb9944a3218ac688a2bc46d4139feceebe5e73900R202-R207): Added `materialContainsDanish(work)` function to check if Danish is among the main languages of a `Work` object.

### Code Refactoring:
* [`src/apps/material/helper.ts`](diffhunk://#diff-90b8b65f9f667d6cb947cf9bb9944a3218ac688a2bc46d4139feceebe5e73900L664-R667): Updated `getWorkTitle` to use `materialContainsDanish(work)` instead of inline logic for detecting Danish language presence.

### Component Updates:
* [`src/components/material/MaterialDescription.tsx`](diffhunk://#diff-0b2aac36f7c1e018c54f64d0277e72e8f95bf1eae0d9d3d94d057cddbb90e218R35-R38): Integrated `materialContainsDanish(work)` in the `MaterialDescription` component to determine whether DK5 entries should be displayed, based on fiction status and language. [[1]](diffhunk://#diff-0b2aac36f7c1e018c54f64d0277e72e8f95bf1eae0d9d3d94d057cddbb90e218R35-R38) [[2]](diffhunk://#diff-0b2aac36f7c1e018c54f64d0277e72e8f95bf1eae0d9d3d94d057cddbb90e218L84-R89)