### PR TITLE
DDFSAL-253 - Ensure that reviewByLibrarians is shown

### DIFF
--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -77,6 +77,7 @@ interface MaterialEntryTextProps {
   instantLoanTitleText: string;
   instantLoanUnderlineDescriptionText: string;
   interestPeriodsConfig: string;
+  libraryAssessmentText: string;
   librariesHaveTheMaterialText: string;
   listenOnlineText: string;
   loadingText: string;

--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -491,6 +491,10 @@ const meta: Meta<typeof MaterialEntry> = {
       description: "Close Reservation modal",
       control: { type: "text" }
     },
+    libraryAssessmentText: {
+      description: "Library assessment text shown in review metadata",
+      control: { type: "text" }
+    },
     librariesHaveTheMaterialText: {
       description: "Libraries have the material",
       control: { type: "text" }
@@ -967,6 +971,7 @@ const meta: Meta<typeof MaterialEntry> = {
     missingDataText: "Missing data",
     reservationModalScreenReaderModalDescriptionText: "Modal for reservation",
     reservationModalCloseModalAriaLabelText: "Close reservation modal",
+    libraryAssessmentText: "Library assessment",
     librariesHaveTheMaterialText: "libraries have material",
     findOnShelfModalScreenReaderModalDescriptionText: "Modal for reservation",
     findOnShelfModalCloseModalAriaLabelText: "Close reservation modal",

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -500,7 +500,7 @@ describe("Material", () => {
     cy.getBySel("material-reviews-disclosure").should("be.visible").click();
     cy.getBySel("material-reviews").should(
       "contain",
-      "Dorthe Marlene Jørgensen, 2016"
+      "Dorthe Marlene Jørgensen - Library assessment, 2016"
     );
   });
 

--- a/src/components/material/MaterialReviews.tsx
+++ b/src/components/material/MaterialReviews.tsx
@@ -39,14 +39,15 @@ export const MaterialReviews: React.FC<MaterialReviewsProps> = ({
     if (review?.access.some((access) => access.__typename === "AccessUrl")) {
       return "external";
     }
-    if (
-      review?.access.some(
-        (access) => access.__typename === "InterLibraryLoan"
-      ) ||
-      // Check if the review has reviewByLibrarians data even if access is empty
-      review?.review?.reviewByLibrarians?.length
-    ) {
+    // Only classify as librarian if there's actual review content in reviewByLibrarians array.
+    if (review?.review?.reviewByLibrarians?.length) {
       return "librarian";
+    }
+    // Reviews with InterLibraryLoan access but no librarian content are external reviews
+    if (
+      review?.access.some((access) => access.__typename === "InterLibraryLoan")
+    ) {
+      return "external";
     }
     return null;
   };

--- a/src/components/material/MaterialReviews.tsx
+++ b/src/components/material/MaterialReviews.tsx
@@ -40,7 +40,11 @@ export const MaterialReviews: React.FC<MaterialReviewsProps> = ({
       return "external";
     }
     if (
-      review?.access.some((access) => access.__typename === "InterLibraryLoan")
+      review?.access.some(
+        (access) => access.__typename === "InterLibraryLoan"
+      ) ||
+      // Check if the review has reviewByLibrarians data even if access is empty
+      review?.review?.reviewByLibrarians?.length
     ) {
       return "librarian";
     }

--- a/src/components/material/ReviewLibrarian.tsx
+++ b/src/components/material/ReviewLibrarian.tsx
@@ -34,6 +34,7 @@ const ReviewLibrarian: React.FC<ReviewLibrarianProps> = ({
           author={authors}
           date={date}
           publication={publication}
+          isLibrarian={true}
         />
       )}
       {review?.reviewByLibrarians &&

--- a/src/components/material/ReviewMetadata.tsx
+++ b/src/components/material/ReviewMetadata.tsx
@@ -2,12 +2,14 @@ import dayjs from "dayjs";
 import React from "react";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import LinkNoStyle from "../atoms/links/LinkNoStyle";
+import { useText } from "../../core/utils/text";
 
 export interface ReviewMetadataProps {
   author?: string | null;
   date?: string | null;
   publication?: string | null;
   url?: URL;
+  isLibrarian?: boolean;
 }
 
 export const usDateStringToDateObj = (date: string): Date => {
@@ -19,34 +21,40 @@ const ReviewMetadata: React.FC<ReviewMetadataProps> = ({
   author,
   date,
   publication,
-  url
+  url,
+  isLibrarian
 }) => {
+  const t = useText();
   const metaDataText = (
     returnAuthor: string | null | undefined,
     returnHost: string | null | undefined,
-    returnDate: string | null | undefined
+    returnDate: string | null | undefined,
+    isLibrarian: boolean | null | undefined
   ) => {
     const authorText = returnAuthor || "";
     const hostText = returnHost || "";
     const authorAndHostSeparator = authorText && hostText ? " - " : "";
     const dateText = returnDate && `, ${returnDate}`;
+    const isLibrarianText = isLibrarian
+      ? ` - ${t("libraryAssessmentText")}`
+      : "";
 
     return `
-    ${authorText}${authorAndHostSeparator}${hostText}${dateText}
+    ${authorText}${authorAndHostSeparator}${hostText}${dateText}${isLibrarianText}
     `;
   };
 
   if (url) {
     return (
       <LinkNoStyle url={url} className="link-tag text-small-caption mb-8">
-        {metaDataText(author, publication, date)}
+        {metaDataText(author, publication, date, isLibrarian)}
       </LinkNoStyle>
     );
   }
 
   return (
     <div className="review__meta mb-8">
-      {metaDataText(author, publication, date)}
+      {metaDataText(author, publication, date, isLibrarian)}
     </div>
   );
 };

--- a/src/components/material/ReviewMetadata.tsx
+++ b/src/components/material/ReviewMetadata.tsx
@@ -33,14 +33,13 @@ const ReviewMetadata: React.FC<ReviewMetadataProps> = ({
   ) => {
     const authorText = returnAuthor || "";
     const hostText = returnHost || "";
-    const authorAndHostSeparator = authorText && hostText ? " - " : "";
+    const isLibrarianText = isLibrarian ? t("libraryAssessmentText") : "";
+    const authorAndHostSeparator =
+      authorText && (hostText || isLibrarianText) ? " - " : "";
     const dateText = returnDate && `, ${returnDate}`;
-    const isLibrarianText = isLibrarian
-      ? ` - ${t("libraryAssessmentText")}`
-      : "";
 
     return `
-    ${authorText}${authorAndHostSeparator}${hostText}${dateText}${isLibrarianText}
+    ${authorText}${authorAndHostSeparator}${hostText}${isLibrarianText}${dateText}
     `;
   };
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-253

#### Test
https://varnish.pr-2633.dpl-cms.dplplat01.dpl.reload.dk/work/work-of:870970-basis:06309801?type=lydbog+%28online%29 

https://varnish.pr-2633.dpl-cms.dplplat01.dpl.reload.dk/work/work-of:870970-basis:81188645?type=film+%28online%29

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2633

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2633

#### Description
This pull request updates the `MaterialReviews` component to enhance the logic for determining review types. The most significant change is the addition of a check for `reviewByLibrarians` data, ensuring the "librarian" type is returned even when access is empty.
