### PR TITLE
DDFSAL-261 - Search by author or subject

### DIFF
--- a/src/apps/search-result/helper.ts
+++ b/src/apps/search-result/helper.ts
@@ -29,4 +29,24 @@ export const getFirstMaterialTypeFromFilters = (
     : undefined;
 };
 
+export const formatSearchDisplayQuery = ({
+  q,
+  creator,
+  subject,
+  t
+}: {
+  q?: string;
+  creator?: string;
+  subject?: string;
+  t: (key: string) => string;
+}): string => {
+  return [
+    q || null,
+    creator ? `${t("byAuthorText")}: ${creator}` : null,
+    subject ? `${t("facetSubjectsText")}: ${subject}` : null
+  ]
+    .filter(Boolean)
+    .join("; ");
+};
+
 export default {};

--- a/src/apps/search-result/helper.ts
+++ b/src/apps/search-result/helper.ts
@@ -41,7 +41,7 @@ export const formatSearchDisplayQuery = ({
   t: (key: string) => string;
 }): string => {
   return [
-    q || null,
+    q,
     creator ? `${t("byAuthorText")}: ${creator}` : null,
     subject ? `${t("facetSubjectsText")}: ${subject}` : null
   ]

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -92,7 +92,11 @@ const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
     mobile: pageSizeMobile
   });
 
-  const hasSearchQuery = searchQuery || creatorQuery || subjectQuery;
+  const hasSearchQuery = Boolean(
+    (searchQuery && searchQuery.length > 0) ||
+      (creatorQuery && creatorQuery.length > 0) ||
+      (subjectQuery && subjectQuery.length > 0)
+  );
 
   return (
     <div>

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -93,9 +93,9 @@ const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
   });
 
   const hasSearchQuery = Boolean(
-    (searchQuery && searchQuery.length > 0) ||
-      (creatorQuery && creatorQuery.length > 0) ||
-      (subjectQuery && subjectQuery.length > 0)
+    searchQuery !== undefined ||
+      creatorQuery !== undefined ||
+      subjectQuery !== undefined
   );
 
   return (

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -92,11 +92,10 @@ const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
     mobile: pageSizeMobile
   });
 
-  const hasSearchQuery = Boolean(
+  const hasSearchQuery =
     searchQuery !== undefined ||
-      creatorQuery !== undefined ||
-      subjectQuery !== undefined
-  );
+    creatorQuery !== undefined ||
+    subjectQuery !== undefined;
 
   return (
     <div>

--- a/src/apps/search-result/search-result.entry.tsx
+++ b/src/apps/search-result/search-result.entry.tsx
@@ -63,18 +63,27 @@ export interface SearchResultEntryProps
     SearchResultEntryTextProps,
     MappArgs {
   q?: string;
+  creator?: string;
+  subject?: string;
   pageSizeDesktop?: number;
   pageSizeMobile?: number;
 }
 
 const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
   q,
+  creator,
+  subject,
   pageSizeDesktop,
   pageSizeMobile
 }) => {
-  // If a q string has been defined as a data attribute use that
-  // otherwise use the one from the url query parameter.
-  const { q: searchQuery } = getParams({ q });
+  // If search parameters have been defined as data attributes use those,
+  // otherwise use the ones from the url query parameters.
+  const {
+    q: searchQuery,
+    creator: creatorQuery,
+    subject: subjectQuery
+  } = getParams({ q, creator, subject });
+
   // Get number of result items to be shown.
   // If the number of items has been defined with data attributes use those
   // otherwise get them from the configuration.
@@ -83,12 +92,19 @@ const SearchResultEntry: React.FC<SearchResultEntryProps> = ({
     mobile: pageSizeMobile
   });
 
+  const hasSearchQuery = searchQuery || creatorQuery || subjectQuery;
+
   return (
     <div>
       {/* We still want to render the app, even if the search query is an empty string */}
-      {(searchQuery || searchQuery === "") && (
+      {hasSearchQuery && (
         <GuardedApp app="search-result">
-          <SearchResult q={searchQuery} pageSize={pageSize} />
+          <SearchResult
+            q={searchQuery}
+            creator={creatorQuery}
+            subject={subjectQuery}
+            pageSize={pageSize}
+          />
         </GuardedApp>
       )}
     </div>

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -195,6 +195,9 @@ const SearchResult: React.FC<SearchResultProps> = ({
   const shouldShowZeroHits = () => {
     return !isLoading && hitcount === 0;
   };
+
+  const combinedQuery = [q, creator, subject].filter(Boolean).join(", ");
+
   // We are handling loading state for every element separately inside this return(),
   // because then we achieve smoother experience using the filters - not having
   // to loose the filter modal upon selecting a filter.
@@ -206,11 +209,8 @@ const SearchResult: React.FC<SearchResultProps> = ({
 
       {!isLoading && !shouldShowZeroHits() && resultItems && (
         <>
-          <SearchResultHeader
-            hitcount={hitcount}
-            q={[q, creator, subject].filter(Boolean).join(", ")}
-          />
-          <FacetLine q={q} />
+          <SearchResultHeader hitcount={hitcount} q={combinedQuery} />
+          <FacetLine q={combinedQuery} />
           {campaignData && campaignData.data && (
             <Campaign campaignData={campaignData.data} />
           )}

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -226,7 +226,7 @@ const SearchResult: React.FC<SearchResultProps> = ({
         </>
       )}
       {/* We know we can show the facet browser after the first valid search. */}
-      {resultItems !== null && <FacetBrowserModal q={q} />}
+      {resultItems !== null && <FacetBrowserModal q={facetsQuery} />}
     </div>
   );
 };

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -27,11 +27,13 @@ import {
   getUrlQueryParam,
   buildSearchQueryObject
 } from "../../core/utils/helpers/url";
+import { useText } from "../../core/utils/text";
 import useGetCleanBranches from "../../core/utils/branches";
 import useFilterHandler from "./useFilterHandler";
 import SearchResultSkeleton from "./search-result-skeleton";
 import SearchResultZeroHits from "./search-result-zero-hits";
 import SearchResultInvalidSearch from "./search-result-not-valid-search";
+import { formatSearchDisplayQuery } from "./helper";
 
 interface SearchResultProps {
   q: string;
@@ -49,6 +51,7 @@ const SearchResult: React.FC<SearchResultProps> = ({
   const { filters, clearFilter, addFilterFromUrlParamListener } =
     useFilterHandler();
   const cleanBranches = useGetCleanBranches();
+  const t = useText();
   const [resultItems, setResultItems] = useState<Work[] | null>(null);
   const [hitcount, setHitCount] = useState<number>(0);
   const [canWeTrackHitcount, setCanWeTrackHitcount] = useState<boolean>(false);
@@ -196,7 +199,8 @@ const SearchResult: React.FC<SearchResultProps> = ({
     return !isLoading && hitcount === 0;
   };
 
-  const combinedQuery = [q, creator, subject].filter(Boolean).join(", ");
+  const displayQuery = formatSearchDisplayQuery({ q, creator, subject, t });
+  const facetQuery = [q, creator, subject].find(Boolean) || "";
 
   // We are handling loading state for every element separately inside this return(),
   // because then we achieve smoother experience using the filters - not having
@@ -209,8 +213,8 @@ const SearchResult: React.FC<SearchResultProps> = ({
 
       {!isLoading && !shouldShowZeroHits() && resultItems && (
         <>
-          <SearchResultHeader hitcount={hitcount} q={combinedQuery} />
-          <FacetLine q={combinedQuery} />
+          <SearchResultHeader hitcount={hitcount} q={displayQuery} />
+          <FacetLine q={facetQuery} />
           {campaignData && campaignData.data && (
             <Campaign campaignData={campaignData.data} />
           )}

--- a/src/apps/search-result/search-result.tsx
+++ b/src/apps/search-result/search-result.tsx
@@ -200,7 +200,6 @@ const SearchResult: React.FC<SearchResultProps> = ({
   };
 
   const displayQuery = formatSearchDisplayQuery({ q, creator, subject, t });
-  const facetQuery = [q, creator, subject].find(Boolean) || "";
 
   // We are handling loading state for every element separately inside this return(),
   // because then we achieve smoother experience using the filters - not having
@@ -214,7 +213,7 @@ const SearchResult: React.FC<SearchResultProps> = ({
       {!isLoading && !shouldShowZeroHits() && resultItems && (
         <>
           <SearchResultHeader hitcount={hitcount} q={displayQuery} />
-          <FacetLine q={facetQuery} />
+          <FacetLine q={facetsQuery} />
           {campaignData && campaignData.data && (
             <Campaign campaignData={campaignData.data} />
           )}

--- a/src/components/material/MaterialDescription.tsx
+++ b/src/components/material/MaterialDescription.tsx
@@ -7,7 +7,8 @@ import {
 import { useItemHasBeenVisible } from "../../core/utils/helpers/lazy-load";
 import {
   constructMaterialUrl,
-  constructSearchUrl
+  constructSearchUrl,
+  constructSubjectSearchUrl
 } from "../../core/utils/helpers/url";
 import { useText } from "../../core/utils/text";
 import { Work } from "../../core/utils/types/entities";
@@ -49,7 +50,7 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
     [];
 
   const subjectsList = getDbcVerifiedSubjectsFirst(subjects).map((item) => ({
-    url: constructSearchUrl(searchUrl, item),
+    url: constructSubjectSearchUrl(searchUrl, item),
     term: item
   }));
 
@@ -91,7 +92,10 @@ const MaterialDescription: React.FC<MaterialDescriptionProps> = ({ work }) => {
                 title={t("subjectNumberText")}
                 linkList={[
                   {
-                    url: constructSearchUrl(searchUrl, dk5MainEntry.display),
+                    url: constructSubjectSearchUrl(
+                      searchUrl,
+                      dk5MainEntry.code
+                    ),
                     term: dk5MainEntry.display
                   }
                 ]}

--- a/src/components/material/MaterialHeaderText.tsx
+++ b/src/components/material/MaterialHeaderText.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { constructSearchUrl } from "../../core/utils/helpers/url";
+import { constructCreatorSearchUrl } from "../../core/utils/helpers/url";
 import { useText } from "../../core/utils/text";
 import { useUrls } from "../../core/utils/url";
 import LinkNoStyle from "../atoms/links/LinkNoStyle";
@@ -34,7 +34,7 @@ const MaterialHeaderText: React.FC<MaterialHeaderTextProps> = ({
         <p data-cy="material-header-author-text" className="text-body-large">
           <span>{t("materialHeaderAuthorByText")} </span>
           <LinkNoStyle
-            url={constructSearchUrl(searchUrl, author)}
+            url={constructCreatorSearchUrl(searchUrl, author)}
             className="arrow__link"
           >
             {author}

--- a/src/core/dbc-gateway/fragments.graphql
+++ b/src/core/dbc-gateway/fragments.graphql
@@ -290,6 +290,7 @@ fragment WorkMedium on Work {
   }
   dk5MainEntry {
     display
+    code
   }
   relations {
     hasReview {

--- a/src/core/dbc-gateway/generated/graphql.ts
+++ b/src/core/dbc-gateway/generated/graphql.ts
@@ -2893,7 +2893,11 @@ export type GetMaterialQuery = {
       display: string;
       code: FictionNonfictionCodeEnum;
     } | null;
-    dk5MainEntry?: { __typename?: "DK5MainEntry"; display: string } | null;
+    dk5MainEntry?: {
+      __typename?: "DK5MainEntry";
+      display: string;
+      code: string;
+    } | null;
     relations: {
       __typename?: "Relations";
       hasReview: Array<{ __typename?: "Manifestation"; pid: string }>;
@@ -3385,7 +3389,11 @@ export type GetMaterialGloballyQuery = {
       display: string;
       code: FictionNonfictionCodeEnum;
     } | null;
-    dk5MainEntry?: { __typename?: "DK5MainEntry"; display: string } | null;
+    dk5MainEntry?: {
+      __typename?: "DK5MainEntry";
+      display: string;
+      code: string;
+    } | null;
     relations: {
       __typename?: "Relations";
       hasReview: Array<{ __typename?: "Manifestation"; pid: string }>;
@@ -6606,7 +6614,11 @@ export type WorkMediumFragment = {
     display: string;
     code: FictionNonfictionCodeEnum;
   } | null;
-  dk5MainEntry?: { __typename?: "DK5MainEntry"; display: string } | null;
+  dk5MainEntry?: {
+    __typename?: "DK5MainEntry";
+    display: string;
+    code: string;
+  } | null;
   relations: {
     __typename?: "Relations";
     hasReview: Array<{ __typename?: "Manifestation"; pid: string }>;
@@ -7393,6 +7405,7 @@ export const WorkMediumFragmentDoc = `
   }
   dk5MainEntry {
     display
+    code
   }
   relations {
     hasReview {

--- a/src/core/utils/helpers/url.ts
+++ b/src/core/utils/helpers/url.ts
@@ -110,6 +110,16 @@ export const constructSearchUrl = (searchUrl: URL, q: string) =>
     q
   });
 
+export const constructCreatorSearchUrl = (searchUrl: URL, creator: string) =>
+  appendQueryParametersToUrl(searchUrl, {
+    creator
+  });
+
+export const constructSubjectSearchUrl = (searchUrl: URL, subject: string) =>
+  appendQueryParametersToUrl(searchUrl, {
+    subject
+  });
+
 export const constructAdvancedSearchUrl = (advancedSearchUrl: URL, q: string) =>
   appendQueryParametersToUrl(advancedSearchUrl, {
     advancedSearchCql: q
@@ -173,3 +183,35 @@ export const isUrlValid = (text: string) => {
 export const currentLocationWithParametersUrl = (
   params: Record<string, string>
 ) => appendQueryParametersToUrl(new URL(getCurrentLocation()), params);
+
+interface SearchQueryObject {
+  all?: string;
+  creator?: string;
+  subject?: string;
+}
+
+export const buildSearchQueryObject = ({
+  q,
+  creator,
+  subject
+}: {
+  q?: string;
+  creator?: string;
+  subject?: string;
+}): SearchQueryObject => {
+  const queryObj: SearchQueryObject = {};
+
+  if (q) {
+    queryObj.all = q;
+  }
+
+  if (creator) {
+    queryObj.creator = creator;
+  }
+
+  if (subject) {
+    queryObj.subject = subject;
+  }
+
+  return queryObj;
+};


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-261

#### Test
https://varnish.pr-2641.dpl-cms.dplplat01.dpl.reload.dk/
https://varnish.pr-2641.dpl-cms.dplplat01.dpl.reload.dk/search?subject=trolde
https://varnish.pr-2641.dpl-cms.dplplat01.dpl.reload.dk/search?creator=Joanne%2520K.%2520Rowling

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2641

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2641

#### Description
Problem:
Currently, when users click on author names or subject links in the material details, they are redirected to a broad free-text search using the q parameter. This results in irrelevant search results - for example, clicking on "Anthrax" (the band) would return results about the disease instead of works by the band.

Solution:
This PR implements field-specific search functionality that allows searches to target specific fields (creator or subject) instead of performing broad free-text searches across all fields.