### PR TITLE
DDFSAL-270 - Infomedia should be consulted with municipality agency

### DIFF
--- a/cypress/fixtures/material/userinfo.json
+++ b/cypress/fixtures/material/userinfo.json
@@ -1,0 +1,17 @@
+{
+  "attributes": {
+    "cpr": 1234567890,
+    "userId": "testuser123",
+    "uniqueId": "12345678-1234-5678-9012-123456789012",
+    "agencies": [
+      {
+        "agencyId": "710100",
+        "userId": "testuser123",
+        "userIdType": "CPR"
+      }
+    ],
+    "municipality": "101",
+    "municipalityAgencyId": "710100",
+    "pincode": "1234"
+  }
+}

--- a/src/apps/material/material.entry.tsx
+++ b/src/apps/material/material.entry.tsx
@@ -204,6 +204,7 @@ interface MaterialEntryTextProps {
 }
 
 interface MaterialEntryConfigProps {
+  agencyIdConfig: string;
   blacklistedAvailabilityBranchesConfig?: string;
   blacklistedInstantLoanBranchesConfig: string;
   blacklistedPickupBranchesConfig?: string;

--- a/src/apps/material/material.stories.tsx
+++ b/src/apps/material/material.stories.tsx
@@ -51,6 +51,10 @@ const meta: Meta<typeof MaterialEntry> = {
       description: "Work ID",
       control: { type: "text" }
     },
+    agencyIdConfig: {
+      description: "Agency ID from OpenID Connect configuration",
+      control: { type: "text" }
+    },
     smsNotificationsForReservationsEnabledConfig: {
       description: "SMS notifications for reservations is enabled",
       control: { type: "text" }
@@ -844,6 +848,7 @@ const meta: Meta<typeof MaterialEntry> = {
     searchUrl: "/search",
     materialUrl: "/work/:workid",
     wid: "work-of:870970-basis:52557240",
+    agencyIdConfig: "710100",
     smsNotificationsForReservationsEnabledConfig: "1",
     blacklistedPickupBranchesConfig:
       "FBS-751032,FBS-751031,FBS-751009,FBS-751027,FBS-751024,DK-775164",

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -278,6 +278,14 @@ describe("Material", () => {
       fixtureFilePath: "material/infomedia-fbi-api.json"
     });
 
+    cy.interceptRest({
+      aliasName: "UserInfo",
+      url: "**/userinfo",
+      fixtureFilePath: "material/userinfo.json"
+    });
+
+    cy.createFakeAuthenticatedSession();
+
     cy.visit(
       "/iframe.html?args=&id=apps-material--infomedia&viewMode=story&type=artikel"
     );

--- a/src/apps/material/order-digital-copy.test.ts
+++ b/src/apps/material/order-digital-copy.test.ts
@@ -28,6 +28,12 @@ describe("Material - Order digital copy", () => {
       fixtureFilePath: "material/holdings.json"
     });
 
+    cy.interceptRest({
+      aliasName: "UserInfo",
+      url: "**/userinfo",
+      fixtureFilePath: "material/userinfo.json"
+    });
+
     cy.intercept("HEAD", "**/list/default/**", {
       statusCode: 404
     }).as("Favorite list service");

--- a/src/components/material/infomedia/InfomediaModal.tsx
+++ b/src/components/material/infomedia/InfomediaModal.tsx
@@ -7,7 +7,7 @@ import { Pid } from "../../../core/utils/types/ids";
 import InfomediaModalBody from "./InfomediaModalBody";
 import { Manifestation } from "../../../core/utils/types/entities";
 import InfomediaSkeleton from "./InfomediaSkeleton";
-import { isResident } from "../../../core/utils/helpers/user";
+import { isResident } from "../../../core/utils/helpers/userInfo";
 import useUserInfo from "../../../core/adgangsplatformen/useUserInfo";
 import {
   getManifestationAuthors,

--- a/src/components/material/infomedia/InfomediaModal.tsx
+++ b/src/components/material/infomedia/InfomediaModal.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import { useGetInfomediaQuery } from "../../../core/dbc-gateway/generated/graphql";
 import Modal from "../../../core/utils/modal";
 import { useText } from "../../../core/utils/text";
+import { useConfig } from "../../../core/utils/config";
 import { Pid } from "../../../core/utils/types/ids";
 import InfomediaModalBody from "./InfomediaModalBody";
 import { Manifestation } from "../../../core/utils/types/entities";
 import InfomediaSkeleton from "./InfomediaSkeleton";
-import { usePatronData } from "../../../core/utils/helpers/usePatronData";
+import { isResident } from "../../../core/utils/helpers/user";
+import useUserInfo from "../../../core/adgangsplatformen/useUserInfo";
 import {
   getManifestationAuthors,
   getManifestationTitle
@@ -25,14 +27,17 @@ const InfomediaModal: React.FunctionComponent<InfomediaModalProps> = ({
   infoMediaId
 }) => {
   const t = useText();
+  const config = useConfig();
   const [shouldFetchData, setShouldFetchData] = useState(false);
-  const { data: patronData, isLoading: isLoadingPatron } = usePatronData();
+  const { data: userInfo, isLoading: isLoadingUserInfo } = useUserInfo();
+  const siteAgencyId = config("agencyIdConfig");
 
   useEffect(() => {
-    if (patronData?.patron?.resident !== undefined) {
-      setShouldFetchData(patronData.patron.resident);
+    if (userInfo && siteAgencyId) {
+      const userIsResident = isResident(userInfo, siteAgencyId);
+      setShouldFetchData(userIsResident);
     }
-  }, [patronData]);
+  }, [userInfo, siteAgencyId]);
 
   const {
     data,
@@ -64,7 +69,7 @@ const InfomediaModal: React.FunctionComponent<InfomediaModalProps> = ({
       closeModalAriaLabelText={t("infomediaModalCloseModalAriaLabelText")}
       dataCy="infomedia-modal"
     >
-      {isLoadingPatron || (isLoadingInfomedia && <InfomediaSkeleton />)}
+      {(isLoadingUserInfo || isLoadingInfomedia) && <InfomediaSkeleton />}
       {data?.infomedia?.article && data.infomedia.article.text && (
         <InfomediaModalBody
           headLine={title}

--- a/src/components/material/material-buttons/material-buttons.test.ts
+++ b/src/components/material/material-buttons/material-buttons.test.ts
@@ -141,6 +141,12 @@ describe("Material buttons", () => {
       fixtureFilePath:
         "material-buttons/material-buttons-order-digital-fbi-api.json"
     });
+    cy.interceptRest({
+      aliasName: "UserInfo",
+      url: "**/userinfo",
+      fixtureFilePath: "material/userinfo.json"
+    });
+    cy.createFakeAuthenticatedSession();
     cy.visit(
       "/iframe.html?id=apps-material--digital&viewMode=story&type=artikel"
     )
@@ -190,6 +196,12 @@ describe("Material buttons", () => {
       url: "**fbs-openplatform.dbc.dk/external/agencyid/patrons/patronid/v4",
       fixtureFilePath: "cover/cover.json"
     });
+    cy.interceptRest({
+      aliasName: "UserInfo",
+      url: "**/userinfo",
+      fixtureFilePath: "material/userinfo.json"
+    });
+    cy.createFakeAuthenticatedSession();
     cy.visit(
       "/iframe.html?id=apps-material--digital&viewMode=story&type=artikel"
     )
@@ -207,6 +219,12 @@ describe("Material buttons", () => {
       fixtureFilePath:
         "material-buttons/material-buttons-infomedia-fbi-api.json"
     });
+    cy.interceptRest({
+      aliasName: "UserInfo",
+      url: "**/userinfo",
+      fixtureFilePath: "material/userinfo.json"
+    });
+    cy.createFakeAuthenticatedSession();
     cy.visit("/iframe.html?id=apps-material--infomedia&viewMode=story")
       .getBySel("material-description")
       .scrollIntoView({ duration: 300 });

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
@@ -9,7 +9,7 @@ import { Button } from "../../../Buttons/Button";
 import { createDigitalModalId } from "../../digital-modal/helper";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
-import { isResident } from "../../../../core/utils/helpers/user";
+import { isResident } from "../../../../core/utils/helpers/userInfo";
 import useUserInfo from "../../../../core/adgangsplatformen/useUserInfo";
 import { useConfig } from "../../../../core/utils/config";
 

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
@@ -10,7 +10,8 @@ import { createDigitalModalId } from "../../digital-modal/helper";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
 import { isResident } from "../../../../core/utils/helpers/user";
-import { usePatronData } from "../../../../core/utils/helpers/usePatronData";
+import useUserInfo from "../../../../core/adgangsplatformen/useUserInfo";
+import { useConfig } from "../../../../core/utils/config";
 
 export interface MaterialButtonOnlineDigitalArticleProps {
   pid: Pid;
@@ -24,17 +25,19 @@ const MaterialButtonOnlineDigitalArticle: FC<
   const t = useText();
   const u = useUrls();
   const authUrl = u("authUrl");
+  const config = useConfig();
+  const siteAgencyId = config("agencyIdConfig");
 
   const [isUserResident, setIsUserResident] = useState<null | boolean>(null);
-  const { isLoading, data: userData } = usePatronData();
+  const { isLoading, data: userInfo } = useUserInfo();
   const { openGuarded } = useModalButtonHandler();
 
   useDeepCompareEffect(() => {
-    if (!userData || !userData.patron) {
+    if (!userInfo) {
       return;
     }
-    setIsUserResident(isResident(userData?.patron));
-  }, [userData]);
+    setIsUserResident(isResident(userInfo, siteAgencyId));
+  }, [userInfo, siteAgencyId]);
 
   const onClick = () => {
     openGuarded({

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
@@ -7,7 +7,7 @@ import { Manifestation } from "../../../../core/utils/types/entities";
 import { useUrls } from "../../../../core/utils/url";
 import { Button } from "../../../Buttons/Button";
 import { infomediaModalId } from "../../infomedia/InfomediaModal";
-import { isResident } from "../../../../core/utils/helpers/user";
+import { isResident } from "../../../../core/utils/helpers/userInfo";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
 import useUserInfo from "../../../../core/adgangsplatformen/useUserInfo";

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import { useModalButtonHandler } from "../../../../core/utils/modal";
 import { useText } from "../../../../core/utils/text";
+import { useConfig } from "../../../../core/utils/config";
 import { ButtonSize } from "../../../../core/utils/types/button";
 import { Manifestation } from "../../../../core/utils/types/entities";
 import { useUrls } from "../../../../core/utils/url";
@@ -9,7 +10,7 @@ import { infomediaModalId } from "../../infomedia/InfomediaModal";
 import { isResident } from "../../../../core/utils/helpers/user";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
-import { usePatronData } from "../../../../core/utils/helpers/usePatronData";
+import useUserInfo from "../../../../core/adgangsplatformen/useUserInfo";
 
 export interface MaterialButtonOnlineInfomediaArticleProps {
   size?: ButtonSize;
@@ -28,12 +29,14 @@ const MaterialButtonOnlineInfomediaArticle: FC<
 }) => {
   const t = useText();
   const u = useUrls();
+  const config = useConfig();
   const authUrl = u("authUrl");
+  const siteAgencyId = config("agencyIdConfig");
 
-  const { isLoading, data: userData } = usePatronData();
+  const { isLoading: isLoadingUserInfo, data: userInfo } = useUserInfo();
   const { openGuarded } = useModalButtonHandler();
   const isUserResident =
-    userData && userData?.patron ? isResident(userData.patron) : null;
+    userInfo && siteAgencyId ? isResident(userInfo, siteAgencyId) : null;
 
   if (manifestations.length < 1) {
     return null;
@@ -50,7 +53,7 @@ const MaterialButtonOnlineInfomediaArticle: FC<
     });
   };
 
-  if (isLoading) {
+  if (isLoadingUserInfo) {
     return <MaterialButtonLoading />;
   }
 

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -1,13 +1,11 @@
 import { isEmpty } from "lodash";
 import { Patron } from "../types/entities";
-
 import {
   getToken,
   TOKEN_UNREGISTERED_USER_KEY,
   TOKEN_USER_KEY,
   hasToken
 } from "../../token";
-import { UserInfoData } from "../../adgangsplatformen/useUserInfo";
 
 export const isAnonymous = () => {
   return !hasToken("user");
@@ -19,10 +17,6 @@ export const isUnregistered = () => {
 
 export const isBlocked = (patron: Patron) => {
   return !isEmpty(patron.blockStatus);
-};
-
-export const isResident = (userData: UserInfoData, siteAgencyId: string) => {
-  return userData.attributes.municipalityAgencyId === siteAgencyId;
 };
 
 export const getUserToken = () => {

--- a/src/core/utils/helpers/user.ts
+++ b/src/core/utils/helpers/user.ts
@@ -1,11 +1,13 @@
 import { isEmpty } from "lodash";
 import { Patron } from "../types/entities";
+
 import {
   getToken,
   TOKEN_UNREGISTERED_USER_KEY,
   TOKEN_USER_KEY,
   hasToken
 } from "../../token";
+import { UserInfoData } from "../../adgangsplatformen/useUserInfo";
 
 export const isAnonymous = () => {
   return !hasToken("user");
@@ -19,8 +21,8 @@ export const isBlocked = (patron: Patron) => {
   return !isEmpty(patron.blockStatus);
 };
 
-export const isResident = (patron: Patron) => {
-  return patron.resident;
+export const isResident = (userData: UserInfoData, siteAgencyId: string) => {
+  return userData.attributes.municipalityAgencyId === siteAgencyId;
 };
 
 export const getUserToken = () => {

--- a/src/core/utils/helpers/userInfo.ts
+++ b/src/core/utils/helpers/userInfo.ts
@@ -1,0 +1,5 @@
+import { UserInfoData } from "../../adgangsplatformen/useUserInfo";
+
+export const isResident = (userData: UserInfoData, siteAgencyId: string) => {
+  return userData.attributes.municipalityAgencyId === siteAgencyId;
+};


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-270

#### Test
https://varnish.pr-2646.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2646

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2646

#### Description
This pull request ensures that users who are permitted by their municipality can read online and Infomedia articles.

Previously, we relied on patron.resident to determine access. However, some municipalities allow other users to access Infomedia articles as well. Therefore, we now check whether siteAgencyId matches municipalityAgencyId to determine eligibility.