### PR TITLE
Fix facet browser z-index

### DIFF
--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -32,6 +32,8 @@ export interface ModalIdsProps {
   };
 }
 
+const MODAL_Z_INDEX = 400;
+
 function Modal({
   modalId,
   closeModalAriaLabelText,
@@ -96,7 +98,7 @@ function Modal({
             // so we add 20 to the z-index of the modal (20 is the highest z-index - header).
             // The index of the modalid is used, so the newest modal is always on top of
             // the remaining modals
-            zIndex: modalIds.indexOf(modalId) + 20
+            zIndex: modalIds.indexOf(modalId) + MODAL_Z_INDEX
           }}
           onClick={() => {
             close();
@@ -115,7 +117,7 @@ function Modal({
           data-cy={dataCy}
           style={{
             // same as comment above
-            zIndex: modalIds.indexOf(modalId) + 21
+            zIndex: modalIds.indexOf(modalId) + MODAL_Z_INDEX + 1
           }}
         >
           <div
@@ -131,7 +133,7 @@ function Modal({
             }`}
             style={{
               // same as comment above
-              zIndex: modalIds.indexOf(modalId) + 20
+              zIndex: modalIds.indexOf(modalId) + MODAL_Z_INDEX
             }}
             aria-label={closeModalAriaLabelText}
             onClick={() => {


### PR DESCRIPTION
Refactor facet browser to use MODAL_Z_INDEX

Ensures proper stacking context following recent design system changes: https://github.com/danskernesdigitalebibliotek/dpl-design-system/pull/907


<img width="1192" height="2007" alt="Skærmbillede 2025-08-05 kl  13 40 03" src="https://github.com/user-attachments/assets/8a049cd2-1781-434f-bf1e-4507c12c060b" />


