### PR TITLE
DDFSAL-187 - Fix reservation pause dates

### DIFF
--- a/src/components/date-inputs/DateRangeInput.tsx
+++ b/src/components/date-inputs/DateRangeInput.tsx
@@ -37,12 +37,18 @@ const DateRangeInput: FC<DateRangeInputProps> = ({
     refLabel.current?.scrollIntoView();
   };
 
+  // Disable past dates - only allow today and future dates
+  // Using disable instead of minDate because minDate causes unexpected behavior
+  // where existing date ranges don't display correctly
+  const isPastDate = (date: Date) => {
+    return dayjs(date).isBefore(dayjs(), "day");
+  };
+
   // We only create a default date if both start and end date are set
-  // Because it is about defing a range.
-  // Use hour(12) to avoid timezone issues when parsing date strings
+  // Because it is about defining a range.
   const value =
     startDate && endDate
-      ? [dayjs(startDate).hour(12).toDate(), dayjs(endDate).hour(12).toDate()]
+      ? [dayjs(startDate).toDate(), dayjs(endDate).toDate()]
       : undefined;
 
   return (
@@ -64,7 +70,7 @@ const DateRangeInput: FC<DateRangeInputProps> = ({
           options={{
             altInput: true,
             altFormat: "j. F Y",
-            minDate: dayjs().toDate(),
+            disable: [isPastDate],
             locale: Danish,
             dateFormat: "d-m-Y",
             static: true,

--- a/src/components/date-inputs/DateRangeInput.tsx
+++ b/src/components/date-inputs/DateRangeInput.tsx
@@ -39,9 +39,10 @@ const DateRangeInput: FC<DateRangeInputProps> = ({
 
   // We only create a default date if both start and end date are set
   // Because it is about defing a range.
+  // Use hour(12) to avoid timezone issues when parsing date strings
   const value =
     startDate && endDate
-      ? [dayjs(startDate).toDate(), dayjs(endDate).toDate()]
+      ? [dayjs(startDate).hour(12).toDate(), dayjs(endDate).hour(12).toDate()]
       : undefined;
 
   return (


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-187

#### Test
https://varnish.pr-2664.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2664

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2664

#### Description

<s>This pull request ensures that date ranges returned from the `/external/agencyid/patrons/patronid/v4` `onHold` field are correctly passed into the `DateRangeInput` component and parsed consistently across timezones by setting the time to noon using `.hour(12)`.

Previously, parsing a date like "2025-08-06" without a time component defaulted to midnight UTC, which could cause the date to shift to the previous day in local timezones. </s>

This pull request fixes issues with date range handling in the `DateRangeInput` component, particularly around Flatpickr behavior when rendering reservation pause dates.

---

## Problem

1. **Date range not displaying correctly**  
   Selecting a range like "today to today" failed to show the value in the input field.

2. **Calendar opens to the wrong year**  
   Flatpickr would sometimes jump a year ahead (e.g., to 2026 instead of 2025).

3. **Incorrect use of `minDate`**  
   Setting `minDate` caused valid existing date ranges to be hidden or misinterpreted by Flatpickr.

## Solution

- Removed the `.hour(12)` workaround, which incorrectly assumed a timezone issue when parsing raw date strings like `"2025-08-06"`. The real culprit was Flatpickr’s rendering logic when using `minDate`.
- Replaced `minDate` with Flatpickr’s `disable` option to prevent selection of past dates while preserving visibility of already selected ranges.

## Why It Works

- **`.hour(12)`** masked the issue by mitigating timezone shifts caused by parsing date strings as UTC midnight. This was a symptom, not the cause.
- **`disable`** offers a better approach: it prevents date selection in the past but does not interfere with rendering valid input values—unlike `minDate`, which enforces constraints that clash with existing data.