### PR TITLE
DDFSAL-278

### DIFF
--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -173,7 +173,10 @@ export const ReservationModalBody = ({
   const materialType = getMaterialType(selectedManifestations);
 
   const saveReservation = () => {
-    if (manifestationsToReserve?.length) {
+    if (
+      manifestationsToReserve?.length &&
+      !materialIsReservableFromAnotherLibrary
+    ) {
       setReservationStatus("pending");
       // Save reservation to FBS.
       mutateAddReservations(

--- a/src/components/reservation/ReservationModalBody.tsx
+++ b/src/components/reservation/ReservationModalBody.tsx
@@ -209,9 +209,7 @@ export const ReservationModalBody = ({
           }
         }
       );
-    }
-
-    if (materialIsReservableFromAnotherLibrary && patron) {
+    } else if (materialIsReservableFromAnotherLibrary && patron) {
       setReservationStatus("pending");
       const { patronId, name, emailAddress, preferredPickupBranch } = patron;
       // Save reservation to open order.

--- a/src/core/utils/useReservableFromAnotherLibrary.tsx
+++ b/src/core/utils/useReservableFromAnotherLibrary.tsx
@@ -13,7 +13,7 @@ const useReservableFromAnotherLibrary = (
   const config = useConfig();
   const { data: holdingsData } = useGetHoldings({
     faustIds: getAllFaustIds(manifestations),
-    blacklist: "both",
+    blacklist: "availability",
     config
   });
 


### PR DESCRIPTION
#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-278

#### Test
https://varnish.pr-2668.dpl-cms.dplplat01.dpl.reload.dk/

#### Dev links
https://ui.lagoon.dplplat01.dpl.reload.dk/projects/dpl-cms/dpl-cms-pr-2668

https://github.com/danskernesdigitalebibliotek/dpl-cms/pull/2668

#### Description

This pull request updates reservation logic and data fetching for the reservation modal. The main changes improve how reservations are processed depending on the material's availability and update the holdings data query to better reflect actual reservability.

**Reservation logic improvements:**

* In `ReservationModalBody.tsx`, the logic in `saveReservation` now prevents reserving materials from another library through the default reservation flow, ensuring such reservations are handled separately.
* The conditional for handling reservations from another library is now an `else if`, preventing both reservation flows from being triggered for the same material.

**Holdings data query update:**

* In `useReservableFromAnotherLibrary.tsx`, the holdings data query changes the `blacklist` parameter from `"both"` to `"availability"`, which refines the data to only exclude unavailable items, improving reservation accuracy.



#### Related
https://github.com/danskernesdigitalebibliotek/dpl-react/pull/1956