### PR TITLE
Conditionally display webSearchText and webSearchTotal in SearchResul…

### DIFF
--- a/src/components/search-bar/search-result-header/SearchResultHeader.tsx
+++ b/src/components/search-bar/search-result-header/SearchResultHeader.tsx
@@ -42,7 +42,9 @@ const SearchResultHeader: React.FC<SearchResultHeaderProps> = ({
             className="link-tag text-body-medium-medium"
             href={webSearchConfig.webSearchUrl}
           >
-            {webSearchConfig.webSearchText} ({webSearchConfig.webSearchTotal})
+            {webSearchConfig.webSearchText &&
+              webSearchConfig.webSearchTotal &&
+              `${webSearchConfig.webSearchText} (${webSearchConfig.webSearchTotal})`}
           </a>
         </h2>
       )}


### PR DESCRIPTION

#### Link to issue

#### Description
This pull request makes a small improvement to the rendering logic in the `SearchResultHeader` component. The change ensures that both `webSearchText` and `webSearchTotal` are present before displaying the link text, preventing potential display of incomplete information.

* Only render the web search link text if both `webSearchText` and `webSearchTotal` are defined in `SearchResultHeader.tsx`.