### PR TITLE
DDFSAL-375 - Fix label differences due to PR merge timing

### DIFF
--- a/src/apps/advanced-search/CqlSearchHeader.tsx
+++ b/src/apps/advanced-search/CqlSearchHeader.tsx
@@ -133,6 +133,7 @@ const CqlSearchHeader: React.FC<CqlSearchHeaderProps> = ({
           </Link>
         </div>
         <TextInput
+          labelClassName="advanced-search-cql-form__label"
           id="branch"
           label={t("advancedSearchFilterBranchText")}
           description={t("advancedSearchFilterBranchDescriptionText")}
@@ -141,6 +142,7 @@ const CqlSearchHeader: React.FC<CqlSearchHeaderProps> = ({
           value={inputValues.branch}
         />
         <TextInput
+          labelClassName="advanced-search-cql-form__label"
           id="department"
           label={t("advancedSearchFilterDepartmentText")}
           description={t("advancedSearchFilterDepartmentDescriptionText")}


### PR DESCRIPTION


#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-375

#### Description
The label differences are caused by merge timing - PR #1968 was merged on July 16th before PR #1979 which was merged on July 22nd.