### PR TITLE
fix: fallbackFocus is required in case of async components inside the…

### DIFF
--- a/src/core/utils/modal.tsx
+++ b/src/core/utils/modal.tsx
@@ -14,7 +14,6 @@ import {
   currentLocationWithParametersUrl,
   redirectToLoginAndBack
 } from "./helpers/url";
-import { isVitestEnvironment } from "./helpers/vitest";
 import { isEnterOrSpacePressed } from "./helpers/general";
 
 type ModalId = string;
@@ -97,8 +96,8 @@ function Modal({
   return (
     <FocusTrap
       focusTrapOptions={{
-        // Set fallbackFocus when running vitest to avoid focus trap errors.
-        fallbackFocus: isVitestEnvironment ? "body" : undefined
+        // Set fallbackFocus to avoid focus trap errors.
+        fallbackFocus: "body"
       }}
     >
       <div>


### PR DESCRIPTION
… children of focusTrap

#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-391

#### Description

To prevent errors in audio book player we added a fallback to document body. This change prevents focusTrap to throw an error which previously made the material page non-interactive and showed an error banner. 

This is further described in: https://github.com/focus-trap/focus-trap?tab=readme-ov-file#fallbackfocus