### PR TITLE
fix: disable user info fetching for anonymous users

### DIFF
--- a/src/apps/create-patron-user-info/CreatePatron.tsx
+++ b/src/apps/create-patron-user-info/CreatePatron.tsx
@@ -4,6 +4,7 @@ import { useText } from "../../core/utils/text";
 import { useConfig } from "../../core/utils/config";
 import useUserInfo from "../../core/adgangsplatformen/useUserInfo";
 import RedirectToLoginMessage from "./RedirectToLoginMessage";
+import { isAnonymous } from "../../core/utils/helpers/user";
 
 export interface CreatePatronProps {
   cpr?: string;
@@ -23,7 +24,7 @@ const CreatePatron: FC<CreatePatronProps> = ({ cpr }) => {
   });
   // Fetch user info data (only if not in storybook context).
   const { data: userInfo, isLoading } = useUserInfo({
-    enabled: !cpr
+    enabled: !cpr && !isAnonymous()
   });
 
   useEffect(() => {

--- a/src/components/material/infomedia/InfomediaModal.tsx
+++ b/src/components/material/infomedia/InfomediaModal.tsx
@@ -14,6 +14,7 @@ import {
   getManifestationTitle
 } from "../../../apps/material/helper";
 import { first } from "lodash";
+import { isAnonymous } from "../../../core/utils/helpers/user";
 
 export const infomediaModalId = (pid: Pid) => `infomedia-modal-${pid}`;
 
@@ -29,7 +30,9 @@ const InfomediaModal: React.FunctionComponent<InfomediaModalProps> = ({
   const t = useText();
   const config = useConfig();
   const [shouldFetchData, setShouldFetchData] = useState(false);
-  const { data: userInfo, isLoading: isLoadingUserInfo } = useUserInfo();
+  const { data: userInfo, isLoading: isLoadingUserInfo } = useUserInfo({
+    enabled: !isAnonymous()
+  });
   const siteAgencyId = config("agencyIdConfig");
 
   useEffect(() => {

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineDigitalArticle.tsx
@@ -12,6 +12,7 @@ import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
 import { isResident } from "../../../../core/utils/helpers/userInfo";
 import useUserInfo from "../../../../core/adgangsplatformen/useUserInfo";
 import { useConfig } from "../../../../core/utils/config";
+import { isAnonymous } from "../../../../core/utils/helpers/user";
 
 export interface MaterialButtonOnlineDigitalArticleProps {
   pid: Pid;
@@ -29,7 +30,10 @@ const MaterialButtonOnlineDigitalArticle: FC<
   const siteAgencyId = config("agencyIdConfig");
 
   const [isUserResident, setIsUserResident] = useState<null | boolean>(null);
-  const { isLoading, data: userInfo } = useUserInfo();
+  const { isLoading, data: userInfo } = useUserInfo({
+    enabled: !isAnonymous()
+  });
+
   const { openGuarded } = useModalButtonHandler();
 
   useDeepCompareEffect(() => {

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
@@ -11,6 +11,7 @@ import { isResident } from "../../../../core/utils/helpers/userInfo";
 import MaterialButtonLoading from "../generic/MaterialButtonLoading";
 import MaterialButtonDisabled from "../generic/MaterialButtonDisabled";
 import useUserInfo from "../../../../core/adgangsplatformen/useUserInfo";
+import { isAnonymous } from "../../../../core/utils/helpers/user";
 
 export interface MaterialButtonOnlineInfomediaArticleProps {
   size?: ButtonSize;
@@ -33,7 +34,9 @@ const MaterialButtonOnlineInfomediaArticle: FC<
   const authUrl = u("authUrl");
   const siteAgencyId = config("agencyIdConfig");
 
-  const { isLoading: isLoadingUserInfo, data: userInfo } = useUserInfo();
+  const { isLoading: isLoadingUserInfo, data: userInfo } = useUserInfo({
+    enabled: !isAnonymous()
+  });
   const { openGuarded } = useModalButtonHandler();
   const isUserResident =
     userInfo && siteAgencyId ? isResident(userInfo, siteAgencyId) : null;
@@ -79,6 +82,10 @@ const MaterialButtonOnlineInfomediaArticle: FC<
       dataCy={dataCy}
     />
   );
+};
+
+const loggedInButton = () => {
+  return <div>Logged in button</div>;
 };
 
 export default MaterialButtonOnlineInfomediaArticle;

--- a/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
+++ b/src/components/material/material-buttons/online/MaterialButtonOnlineInfomediaArticle.tsx
@@ -84,8 +84,4 @@ const MaterialButtonOnlineInfomediaArticle: FC<
   );
 };
 
-const loggedInButton = () => {
-  return <div>Logged in button</div>;
-};
-
 export default MaterialButtonOnlineInfomediaArticle;

--- a/src/core/adgangsplatformen/useUserInfo.ts
+++ b/src/core/adgangsplatformen/useUserInfo.ts
@@ -27,11 +27,13 @@ export type UserInfoData = {
 
 const getUserInfoQueryKey = (url: string) => {
   const userToken = getUserToken();
+
   if (!userToken) {
-    throw new Error("User token is missing");
+    // eslint-disable-next-line no-console
+    console.error("userToken is missing");
   }
 
-  return `${url}:${userToken}`;
+  return userToken ? `${url}:${userToken}` : url;
 };
 
 type UserInfoFunction = () => Promise<UserInfoData | null | undefined>;

--- a/src/core/utils/useSavePatron.tsx
+++ b/src/core/utils/useSavePatron.tsx
@@ -10,6 +10,7 @@ import {
   useUpdateV8
 } from "../fbs/fbs";
 import useUserInfo from "../adgangsplatformen/useUserInfo";
+import { isAnonymous } from "./helpers/user";
 
 export interface FetchHandlers {
   onSuccess?: () => void;
@@ -25,7 +26,9 @@ interface UseSavePatron {
 }
 
 const useSavePatron = ({ patron, fetchHandlers }: UseSavePatron) => {
-  const { data: userInfo } = useUserInfo();
+  const { data: userInfo } = useUserInfo({
+    enabled: !isAnonymous()
+  });
   const { mutate } = useUpdateV8();
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
#### Link to issue

https://reload.atlassian.net/browse/DDFSAL-419

#### Description

- Disable user info fetching for anonymous users
- Remove error throwing to prevent the site from failing hard when anonymous users tries to get userData which is not possible as they are not logged in
