### PR TITLE
Split availability label text for physical vs non-physical materials

### DIFF
--- a/cypress/page-objects/material/components/modal-find-on-shelf.ts
+++ b/cypress/page-objects/material/components/modal-find-on-shelf.ts
@@ -34,7 +34,7 @@ export class ModalFindOnShelfComponent extends ComponentObject {
     expectedCount
   }: {
     libraryName: string;
-    label: "Available" | "Unavailable";
+    label: "Available" | "At home" | "Unavailable";
     editionTitle: string;
     expectedCount: string;
   }) {

--- a/src/apps/material/material-page-object.test.ts
+++ b/src/apps/material/material-page-object.test.ts
@@ -106,15 +106,15 @@ describe("Material Page Object Test", () => {
       // Then: Should display 3 availability labels
       materialPage.elements.headerAvailabilityLabels().should("have.length", 3);
 
-      // And: First label (e-bog) should show type and availability
+      // And: First label (e-bog) should show type and availability (non-physical shows "Available")
       materialPage
         .getHeaderAvailabilityLabel(0)
         .shouldContainAll(["e-bog", "Available"]);
 
-      // And: Second label (bog) should show type and availability
+      // And: Second label (bog) should show type and availability (physical shows "At home")
       materialPage
         .getHeaderAvailabilityLabel(1)
-        .shouldContainAll(["bog", "Available"]);
+        .shouldContainAll(["bog", "At home"]);
 
       // And: Third label (lydbog) should show type and availability
       materialPage
@@ -322,10 +322,10 @@ describe("Material Page Object Test", () => {
           // Then: Should display 4 manifestations
           editions.elements.manifestationItems().should("have.length", 4);
 
-          // And: First manifestation (physical book) should have correct availability and buttons
+          // And: First manifestation (physical book) should have correct availability and buttons (physical shows "At home")
           editions
             .getManifestationItem(0)
-            .shouldContainAll(["bog", "Available", "Reserve", "Find on shelf"]);
+            .shouldContainAll(["bog", "At home", "Reserve", "Find on shelf"]);
 
           // And: Second manifestation (physical book unavailable) should have correct availability
           editions
@@ -592,27 +592,27 @@ describe("Material Page Object Test", () => {
           findOnShelf
             .verifyLibraryHolding({
               libraryName: "Hovedbiblioteket",
-              label: "Available",
+              label: "At home",
               editionTitle: "De syv søstre (2017)",
               expectedCount: "2"
             })
             .verifyLibraryHolding({
               libraryName: "Hovedbiblioteket",
-              label: "Available",
+              label: "At home",
               editionTitle: "De syv søstre (2016)",
               expectedCount: "0"
             });
 
           findOnShelf.verifyLibraryHolding({
             libraryName: "Fjernlager",
-            label: "Available",
+            label: "At home",
             editionTitle: "De syv søstre (2017)",
             expectedCount: "1"
           });
 
           findOnShelf.verifyLibraryHolding({
             libraryName: "Islands Brygge",
-            label: "Available",
+            label: "At home",
             editionTitle: "De syv søstre (2017)",
             expectedCount: "3"
           });
@@ -647,21 +647,21 @@ describe("Material Page Object Test", () => {
 
           findOnShelf.verifyLibraryHolding({
             libraryName: "Hovedbiblioteket",
-            label: "Available",
+            label: "At home",
             editionTitle: "De syv søstre (2017)",
             expectedCount: "2"
           });
 
           findOnShelf.verifyLibraryHolding({
             libraryName: "Fjernlager",
-            label: "Available",
+            label: "At home",
             editionTitle: "De syv søstre (2017)",
             expectedCount: "1"
           });
 
           findOnShelf.verifyLibraryHolding({
             libraryName: "Islands Brygge",
-            label: "Available",
+            label: "At home",
             editionTitle: "De syv søstre (2017)",
             expectedCount: "3"
           });
@@ -766,10 +766,10 @@ describe("Material Page Object Test", () => {
           .caption()
           .shouldContainAll(["1 libraries have material"]);
 
-        // And: Should show library holdings
+        // And: Should show library holdings (physical materials show "At home")
         findOnShelf.verifyLibraryHolding({
           libraryName: "Hovedbiblioteket",
-          label: "Available",
+          label: "At home",
           editionTitle: "Alt for damerne (1946)",
           expectedCount: "1"
         });

--- a/src/apps/material/material.test.ts
+++ b/src/apps/material/material.test.ts
@@ -93,7 +93,7 @@ describe("Material", () => {
       .should("have.length", 1);
   });
 
-  it("Shows the book availability as available", () => {
+  it("Shows the book availability as available (physical material shows 'At home')", () => {
     cy.interceptGraphql({
       operationName: "getMaterial",
       fixtureFilePath: "material/fbi-api.json"
@@ -103,12 +103,13 @@ describe("Material", () => {
 
     cy.getBySel("material-description").scrollIntoView({ duration: 100 });
 
+    // Physical materials (like books) show "At home" when available
     cy.getBySel("availability-label")
       .find('[data-cy="availability-label-type"]')
       .contains("bog")
       .parent()
       .find('[data-cy="availability-label-status"]')
-      .should("have.text", "Available");
+      .should("have.text", "At home");
   });
 
   it("Can open material details", () => {

--- a/src/components/Disclosures/DisclosureSummary.tsx
+++ b/src/components/Disclosures/DisclosureSummary.tsx
@@ -10,6 +10,8 @@ export type DisclosureSummaryProps = {
   headingLevel?: HeadingLevelType;
   mainIconPath?: string;
   isAvailable?: boolean;
+  /** Whether this material is non-physical (online/digital). Defaults to false (physical). */
+  isNonPhysical?: boolean;
   itemRef?: React.MutableRefObject<null>;
   className?: string;
   dataCy?: string;
@@ -20,11 +22,19 @@ const DisclosureSummary: React.FunctionComponent<DisclosureSummaryProps> = ({
   headingLevel = "h3",
   mainIconPath,
   isAvailable,
+  isNonPhysical = false,
   itemRef,
   className,
   dataCy = "disclosure-summary"
 }) => {
   const t = useText();
+
+  const getAvailableText = () => {
+    // Use different text for physical vs non-physical materials when available
+    return isNonPhysical
+      ? t("availabilityAvailableText")
+      : t("availabilityAvailablePhysicalText");
+  };
   return (
     <summary
       ref={itemRef}
@@ -48,9 +58,7 @@ const DisclosureSummary: React.FunctionComponent<DisclosureSummaryProps> = ({
       {isAvailable !== undefined && (
         <Pagefold
           text={
-            isAvailable
-              ? t("availabilityAvailableText")
-              : t("availabilityUnavailableText")
+            isAvailable ? getAvailableText() : t("availabilityUnavailableText")
           }
           state={isAvailable ? "success" : "alert"}
         />

--- a/src/components/availability-label/availability-label-visual.tsx
+++ b/src/components/availability-label/availability-label-visual.tsx
@@ -10,6 +10,8 @@ type AvailabilityLabelVisualProps = {
   cursorPointer?: boolean;
   isAvailable?: boolean;
   availabilityText?: string;
+  /** Whether this material is non-physical (online/digital). Defaults to false (physical). */
+  isNonPhysical?: boolean;
 };
 
 const AvailabilityLabelVisual: React.FunctionComponent<
@@ -20,15 +22,21 @@ const AvailabilityLabelVisual: React.FunctionComponent<
   cursorPointer,
   isAvailable,
   quantity,
-  availabilityText
+  availabilityText,
+  isNonPhysical = false
 }) => {
   const t = useText();
 
-  const getAvailabilityText =
-    availabilityText ||
-    (isAvailable
+  const getAvailableText = () => {
+    // Use different text for physical vs non-physical materials when available
+    return isNonPhysical
       ? t("availabilityAvailableText")
-      : t("availabilityUnavailableText"));
+      : t("availabilityAvailablePhysicalText");
+  };
+
+  const computedAvailabilityText =
+    availabilityText ||
+    (isAvailable ? getAvailableText() : t("availabilityUnavailableText"));
 
   return (
     <div
@@ -38,7 +46,7 @@ const AvailabilityLabelVisual: React.FunctionComponent<
         selected={selected}
         isAvailable={isAvailable}
         manifestText={manifestText}
-        availabilityText={getAvailabilityText}
+        availabilityText={computedAvailabilityText}
         quantity={quantity}
         isLoading={false}
       />

--- a/src/components/availability-label/availability-label.tsx
+++ b/src/components/availability-label/availability-label.tsx
@@ -5,7 +5,10 @@ import { useText } from "../../core/utils/text";
 import LinkNoStyle from "../atoms/links/LinkNoStyle";
 import { useCollectPageStatistics } from "../../core/statistics/useStatistics";
 import { statistics } from "../../core/statistics/statistics";
-import { getParentAvailabilityLabelClass } from "./helper";
+import {
+  getParentAvailabilityLabelClass,
+  isNonPhysicalForAvailabilityLabel
+} from "./helper";
 import AvailabilityLabelInside from "./availability-label-inside";
 import { FaustId } from "../../core/utils/types/ids";
 import useAvailabilityData from "./useAvailabilityData";
@@ -50,9 +53,17 @@ export const AvailabilityLabel: React.FC<AvailabilityLabelProps> = ({
     manifestText
   });
 
-  const availabilityText = isAvailable
-    ? t("availabilityAvailableText")
-    : t("availabilityUnavailableText");
+  const getAvailabilityText = () => {
+    if (!isAvailable) {
+      return t("availabilityUnavailableText");
+    }
+    // Use different text for physical vs non-physical materials when available
+    return isNonPhysicalForAvailabilityLabel(accessTypes, access)
+      ? t("availabilityAvailableText")
+      : t("availabilityAvailablePhysicalText");
+  };
+
+  const availabilityText = getAvailabilityText();
 
   useDeepCompareEffect(() => {
     // Track material availability (status) if the button is active - also meaning

--- a/src/components/availability-label/helper.ts
+++ b/src/components/availability-label/helper.ts
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { AccessTypeCodeEnum } from "../../core/dbc-gateway/generated/graphql";
 import articleTypes from "../../core/utils/types/article-types";
+import { AccessTypes } from "../../core/utils/types/entities";
 
 type GetParrentAvailabilityLabelClassProps = {
   selected?: boolean;
@@ -9,6 +10,30 @@ type GetParrentAvailabilityLabelClassProps = {
 
 export const isOnline = (accessTypes: AccessTypeCodeEnum[]): boolean =>
   accessTypes?.includes(AccessTypeCodeEnum.Online) ?? false;
+
+/**
+ * Determines if a material should be treated as non-physical for the availability label.
+ *
+ * Non-physical materials are:
+ * - Materials with ONLINE access type
+ * - Materials delivered via Digital Article Service
+ */
+export const isNonPhysicalForAvailabilityLabel = (
+  accessTypes: AccessTypeCodeEnum[],
+  access: AccessTypes[]
+): boolean => {
+  // Online materials are always non-physical
+  if (isOnline(accessTypes)) {
+    return true;
+  }
+
+  // Digital Article Service materials are treated as non-physical
+  if (access?.includes("DigitalArticleService")) {
+    return true;
+  }
+
+  return false;
+};
 
 export const isArticleByLabelText = (manifestText: string): boolean =>
   articleTypes.some((type) => manifestText.toLowerCase() === type);

--- a/src/core/storybook/globalTextArgs.ts
+++ b/src/core/storybook/globalTextArgs.ts
@@ -27,9 +27,17 @@ export const argTypes = {
     control: { type: "text" }
   },
   availabilityAvailableText: {
-    description: "Availability: available text",
+    description:
+      "Availability: available text (for non-physical/digital materials)",
     table: {
       defaultValue: { summary: "Available" }
+    },
+    control: { type: "text" }
+  },
+  availabilityAvailablePhysicalText: {
+    description: "Availability: available text (for physical materials)",
+    table: {
+      defaultValue: { summary: "At home" }
     },
     control: { type: "text" }
   },
@@ -313,6 +321,7 @@ export default {
   multiselectAllOptionText: "All",
   groupModalGoToMaterialAriaLabelText: "Go to @label material details",
   availabilityAvailableText: "Available",
+  availabilityAvailablePhysicalText: "At home",
   availabilityUnavailableText: "Unavailable",
   loansNotOverdueText: "Longer return time",
   patronContactInfoBodyText: "Patron contact info body text",
@@ -369,6 +378,7 @@ export interface GlobalEntryTextProps {
   multiselectAllOptionText: string;
   groupModalGoToMaterialAriaLabelText: string;
   availabilityAvailableText: string;
+  availabilityAvailablePhysicalText: string;
   availabilityUnavailableText: string;
   loansNotOverdueText: string;
   patronContactInfoBodyText: string;


### PR DESCRIPTION
Physical materials now show "Hjemme" (At home) when available, while
non-physical/digital materials show "Tilgængelig" (Available).

Materials are classified as non-physical if:
- accessTypes includes ONLINE, or
- access includes DigitalArticleService (even with PHYSICAL accessType)

#### Link to issue
https://reload.atlassian.net/browse/DDFSAL-488

#### Description

Please include a short description of the suggested change and the reasoning behind the approach you have chosen.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
