### PR TITLE
Move Cypress project to GH secret.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
           parallel: true
           record: true
         env:
+          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload screenshots

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,6 @@ import { defineConfig } from "cypress";
 import plugins from "./cypress/plugins";
 
 export default defineConfig({
-  projectId: "4trcdv",
   defaultCommandTimeout: 10000,
   pageLoadTimeout: 10000,
   requestTimeout: 30000,


### PR DESCRIPTION
This is useful after we move to the mono repo.