### PR TITLE
Add null-safety check for materialTypeGeneral in getWorkTitle

### DIFF
--- a/src/apps/material/helper.ts
+++ b/src/apps/material/helper.ts
@@ -652,6 +652,7 @@ export const getWorkTitle = (work: Work): string => {
   // and matches what the grid/card views display.
   const isMovieOrTvSeries = work.materialTypes?.some(
     ({ materialTypeGeneral }) =>
+      materialTypeGeneral &&
       [
         GeneralMaterialTypeCodeEnum.Films,
         GeneralMaterialTypeCodeEnum.TvSeries


### PR DESCRIPTION
materialTypeGeneral can be undefined at runtime even though TypeScript types mark it as required. This causes a crash on work pages ("Cannot read properties of undefined (reading 'code')"), breaking Pa11y accessibility tests and Cypress functional tests.